### PR TITLE
Add PowerShell script to run Flask app

### DIFF
--- a/start-server.ps1
+++ b/start-server.ps1
@@ -1,0 +1,18 @@
+# PowerShell script to set up and run the MTG Tournament Swiss App.
+# Installs dependencies, initializes the database, creates an admin user,
+# and starts the Flask development server.
+
+Write-Host "Installing dependencies..."
+python -m pip install -r requirements.txt
+
+Write-Host "Setting Flask environment..."
+$env:FLASK_APP = "app.app:app"
+
+Write-Host "Initializing database..."
+flask --app app.app db-init
+
+Write-Host "Creating default admin user..."
+flask --app app.app create-admin --email admin@example.com --password admin123
+
+Write-Host "Starting Flask development server..."
+flask --app app.app run --debug


### PR DESCRIPTION
## Summary
- Add `start-server.ps1` to install dependencies, initialize the database, create a default admin user, and launch the Flask dev server without using a virtual environment.

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689a0778bf5c8320ad172d46dec91d84

## Summary by Sourcery

New Features:
- Add start-server.ps1 to install dependencies, set Flask environment variables, initialize the database, create a default admin user, and start the Flask development server.