### PR TITLE
Allow admins to register players

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -111,6 +111,24 @@ def create_app():
             return redirect(url_for('view_tournament', tid=t.id))
         return render_template('admin/new_tournament.html')
 
+    @app.route('/admin/register-player', methods=['GET', 'POST'])
+    def admin_register_player():
+        require_admin()
+        if request.method == 'POST':
+            email = request.form['email'].strip().lower()
+            name = request.form['name'].strip()
+            password = request.form['password']
+            if db.session.query(User).filter_by(email=email).first():
+                flash("Email already registered", "error")
+            else:
+                u = User(email=email, name=name)
+                u.set_password(password)
+                db.session.add(u)
+                db.session.commit()
+                flash("Player registered.", "success")
+                return redirect(url_for('admin_register_player'))
+        return render_template('admin/register_player.html')
+
     @app.route('/admin/tournaments/<int:tid>/delete', methods=['POST'])
     def delete_tournament(tid):
         require_admin()

--- a/app/templates/admin/register_player.html
+++ b/app/templates/admin/register_player.html
@@ -1,0 +1,10 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Register Player</h2>
+<form method="post">
+  <label>Name <input name="name" required></label><br>
+  <label>Email <input name="email" type="email" required></label><br>
+  <label>Password <input name="password" type="password" required></label><br>
+  <button class="btn" type="submit">Register</button>
+</form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -12,7 +12,10 @@
     <nav>
       {% if current_user.is_authenticated %}
         <span>Hi, {{ current_user.name }}</span>
-        {% if current_user.is_admin %}<a href="{{ url_for('new_tournament') }}">New Tournament</a>{% endif %}
+        {% if current_user.is_admin %}
+        <a href="{{ url_for('new_tournament') }}">New Tournament</a>
+        <a href="{{ url_for('admin_register_player') }}">Register Player</a>
+        {% endif %}
         <a href="{{ url_for('logout') }}">Logout</a>
       {% else %}
         <a href="{{ url_for('login') }}">Login</a>


### PR DESCRIPTION
## Summary
- Add admin-only route to create player accounts
- Link registration page in navigation
- Provide admin template for registering players

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log || tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_689a2504b2d88320a8d3713dca678ce5