### PR TITLE
Fix standings template enumeration error in Jinja standings view

### DIFF
--- a/app/templates/tournament/standings.html
+++ b/app/templates/tournament/standings.html
@@ -8,9 +8,9 @@
     </tr>
   </thead>
   <tbody>
-  {% for i, row in enumerate(standings, start=1) %}
+  {% for row in standings %}
     <tr>
-      <td>{{ i }}</td>
+      <td>{{ loop.index }}</td>
       <td>{{ row.player }}</td>
       <td>{{ row.points }}</td>
       <td>{{ '%.2f' % (row.omw*100) }}</td>
@@ -26,7 +26,7 @@
   {% set cutn = 8 if t.cut=='top8' else 4 %}
   <h3>Projected Cut</h3>
   <ol>
-    {% for i, row in enumerate(standings[:cutn], start=1) %}
+    {% for row in standings[:cutn] %}
       <li>{{ row.player }} — {{ row.points }} pts</li>
     {% endfor %}
   </ol>


### PR DESCRIPTION
## Summary
- Replace Python enumerate calls in standings template with Jinja2 loop indexes

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a300d73ec8320b6a8f99d3823d1e3