### PR TITLE
Prevent pairing after round limit and add cut button

### DIFF
--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -23,9 +23,19 @@
     <label>Rounds (recommended {{ rec_rounds }}): <input type="number" name="rounds" min="1" value="{{ t.rounds_override or rec_rounds }}"></label>
     <button class="btn" type="submit">Set</button>
   </form>
-  <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
-    <button class="btn" type="submit">Pair Next Round</button>
-  </form>
+  {% set round_limit = t.rounds_override or rec_rounds %}
+  {% set current_rounds = rounds|length %}
+  {% if current_rounds < round_limit %}
+    <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
+      <button class="btn" type="submit">Pair Next Round</button>
+    </form>
+  {% elif t.cut in ('top8','top4') %}
+    <form method="post" action="{{ url_for('cut_to_top', tid=t.id) }}">
+      <button class="btn" type="submit">Cut to Top {{ 8 if t.cut=='top8' else 4 }}</button>
+    </form>
+  {% else %}
+    <p>Round limit reached.</p>
+  {% endif %}
 {% endif %}
 
 <ol>


### PR DESCRIPTION
## Summary
- Block pairing new rounds once the configured round limit is reached
- Allow cutting to top players with new `cut-to-top` endpoint and button
- Show cut button or limit notice in tournament view when appropriate

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a319a81748320bf0595f3b815778e

## Summary by Sourcery

Prevent creating new rounds once the round limit is reached, introduce a cut-to-top feature to pair only the top players in a new round, and update the UI to show the correct button or notice based on tournament state.

New Features:
- Block pairing of new rounds beyond the configured round limit
- Add cut-to-top endpoint and button for pairing top 8 or top 4 players

Enhancements:
- Display the appropriate action (pair, cut, or limit reached message) in the tournament view based on current rounds and cut configuration