### PR TITLE
Enable admin bulk player registration without credentials

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -6,9 +6,11 @@ from sqlalchemy import UniqueConstraint
 
 class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
-    email = db.Column(db.String(255), unique=True, nullable=False)
+    # Email and password are optional to allow admin bulk registration without
+    # requiring login credentials.
+    email = db.Column(db.String(255), unique=True, nullable=True)
     name = db.Column(db.String(120), nullable=False)
-    password_hash = db.Column(db.String(255), nullable=False)
+    password_hash = db.Column(db.String(255), nullable=True)
     is_admin = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
 
@@ -16,6 +18,8 @@ class User(db.Model, UserMixin):
         self.password_hash = generate_password_hash(pw)
 
     def check_password(self, pw):
+        if not self.password_hash:
+            return False
         return check_password_hash(self.password_hash, pw)
 
 class Tournament(db.Model):

--- a/app/templates/admin/bulk_register_players.html
+++ b/app/templates/admin/bulk_register_players.html
@@ -1,0 +1,17 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Bulk Register Players</h2>
+<form method="post">
+  <label for="tournament_id">Tournament:</label>
+  <select name="tournament_id" required>
+    {% for t in tournaments %}
+      <option value="{{ t.id }}">{{ t.name }}</option>
+    {% endfor %}
+  </select>
+  <div>
+    <label for="names">Player Names (one per line):</label><br>
+    <textarea name="names" rows="10" cols="30"></textarea>
+  </div>
+  <button type="submit">Register Players</button>
+</form>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -15,6 +15,7 @@
         {% if current_user.is_admin %}
         <a href="{{ url_for('new_tournament') }}">New Tournament</a>
         <a href="{{ url_for('admin_register_player') }}">Register Player</a>
+        <a href="{{ url_for('admin_bulk_register') }}">Bulk Register Players</a>
         {% endif %}
         <a href="{{ url_for('logout') }}">Logout</a>
       {% else %}


### PR DESCRIPTION
## Summary
- Allow `User` records without emails/passwords for admin-only players
- Add admin bulk registration page to create multiple players for a tournament
- Link bulk register page in admin navigation

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689a34ba47d08320b93884b958b2282b

## Summary by Sourcery

Enable admin users to bulk register players without requiring email or password by updating User model to support credential-less accounts and adding a dedicated bulk registration interface.

New Features:
- Add an admin bulk registration page and endpoint to create multiple tournament players from a list of names

Bug Fixes:
- Return False in check_password when password_hash is missing to prevent authentication errors

Enhancements:
- Make email and password fields optional on User records to support admin-created accounts without credentials
- Add a link to the bulk registration page in the admin navigation