### PR TITLE
Show cut button on tournament view at all times

### DIFF
--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -29,12 +29,13 @@
     <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
       <button class="btn" type="submit">Pair Next Round</button>
     </form>
-  {% elif t.cut in ('top8','top4') %}
+  {% else %}
+    <p>Round limit reached.</p>
+  {% endif %}
+  {% if t.cut in ('top8','top4') %}
     <form method="post" action="{{ url_for('cut_to_top', tid=t.id) }}">
       <button class="btn" type="submit">Cut to Top {{ 8 if t.cut=='top8' else 4 }}</button>
     </form>
-  {% else %}
-    <p>Round limit reached.</p>
   {% endif %}
 {% endif %}
 


### PR DESCRIPTION
## Summary
- Always display the cut-to-top 4/8 button in the tournament page

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689a3666b2d88320b0dd35e65d6ebf12