### PR TITLE
Add drop handling and tournament bracket view

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -39,6 +39,7 @@ class TournamentPlayer(db.Model):
     game_wins = db.Column(db.Integer, default=0)
     game_losses = db.Column(db.Integer, default=0)
     game_draws = db.Column(db.Integer, default=0)
+    dropped = db.Column(db.Boolean, default=False)
 
     tournament = db.relationship('Tournament', backref=db.backref('players', lazy='dynamic'))
     user = db.relationship('User', backref='tournament_entries')

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -12,3 +12,6 @@ main { padding: 16px; }
 .flashes li { margin:8px 0; padding:8px; border-radius:8px; }
 .flashes li.success { background:#e8f8ee; border:1px solid #bfe5cb; }
 .flashes li.error { background:#fde8e8; border:1px solid #f3c2c2; }
+.bracket { display:flex; gap:20px; }
+.round { flex:1; }
+.match { margin:8px 0; }

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -13,6 +13,9 @@
   <label>Cut
     <select name="cut">
       <option value="none">None</option>
+      <option value="top64">Top 64</option>
+      <option value="top32">Top 32</option>
+      <option value="top16">Top 16</option>
       <option value="top8">Top 8</option>
       <option value="top4">Top 4</option>
     </select>

--- a/app/templates/match/report.html
+++ b/app/templates/match/report.html
@@ -14,6 +14,8 @@
   <label>{{ m.player1.user.name }} game wins: <input type="number" name="p1_wins" min="0" required></label><br>
   <label>{{ m.player2.user.name }} game wins: <input type="number" name="p2_wins" min="0" required></label><br>
   <label>Draws: <input type="number" name="draws" min="0" value="0"></label><br>
+  <label><input type="checkbox" name="drop_p1"> Drop {{ m.player1.user.name }}</label><br>
+  <label><input type="checkbox" name="drop_p2"> Drop {{ m.player2.user.name }}</label><br>
   <button class="btn" type="submit">Submit Result</button>
 </form>
 {% else %}

--- a/app/templates/tournament/bracket.html
+++ b/app/templates/tournament/bracket.html
@@ -1,0 +1,18 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ t.name }} Bracket</h2>
+<button class="btn" onclick="window.print()">Print</button>
+<div class="bracket">
+  {% for r in rounds %}
+  <div class="round">
+    <h3>Round {{ r.number }}</h3>
+    {% for m in r.matches.order_by('table_number') %}
+    <div class="match">
+      {{ m.player1.user.name }}{% if m.player2_id %} vs {{ m.player2.user.name }}{% endif %}
+      {% if m.completed %}- {{ m.result.player1_wins }}-{{ m.result.player2_wins }}{% endif %}
+    </div>
+    {% endfor %}
+  </div>
+  {% endfor %}
+</div>
+{% endblock %}

--- a/app/templates/tournament/standings.html
+++ b/app/templates/tournament/standings.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>{{ t.name }} — Standings</h2>
+<button class="btn" onclick="window.print()">Print</button>
 <table class="table">
   <thead>
     <tr>
@@ -21,9 +22,9 @@
   </tbody>
 </table>
 
-{% if t.cut in ('top8','top4') %}
+{% if t.cut.startswith('top') %}
   <p>Cut: {{ t.cut|upper }}</p>
-  {% set cutn = 8 if t.cut=='top8' else 4 %}
+  {% set cutn = t.cut[3:]|int %}
   <h3>Projected Cut</h3>
   <ol>
     {% for row in standings[:cutn] %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -2,6 +2,7 @@
 {% block content %}
 <h2>{{ t.name }}</h2>
 <p>Format: {{ t.format }} | Cut: {{ t.cut|upper }}</p>
+<button class="btn" onclick="window.print()">Print</button>
 <form method="post" action="{{ url_for('join_tournament', tid=t.id) }}">
   {% if current_user.is_authenticated %}
     <button class="btn" type="submit">Join Tournament</button>
@@ -18,7 +19,7 @@
 </ul>
 
 <h3>Rounds</h3>
-{% if current_user.is_authenticated and current_user.is_admin %}
+  {% if current_user.is_authenticated and current_user.is_admin %}
   <form method="post" action="{{ url_for('set_rounds', tid=t.id) }}">
     <label>Rounds (recommended {{ rec_rounds }}): <input type="number" name="rounds" min="1" value="{{ t.rounds_override or rec_rounds }}"></label>
     <button class="btn" type="submit">Set</button>
@@ -32,17 +33,22 @@
   {% else %}
     <p>Round limit reached.</p>
   {% endif %}
-  {% if t.cut in ('top8','top4') %}
+  {% if t.cut.startswith('top') %}
     <form method="post" action="{{ url_for('cut_to_top', tid=t.id) }}">
-      <button class="btn" type="submit">Cut to Top {{ 8 if t.cut=='top8' else 4 }}</button>
+      <button class="btn" type="submit">Cut to Top {{ t.cut[3:] }}</button>
     </form>
   {% endif %}
-{% endif %}
+  {% endif %}
 
 <ol>
   {% for r in rounds %}
     <li>
       Round {{ r.number }}
+      {% if current_user.is_authenticated and current_user.is_admin %}
+      <form method="post" action="{{ url_for('repair_round', tid=t.id, rid=r.id) }}" style="display:inline;">
+        <button class="btn" type="submit">Re-pair</button>
+      </form>
+      {% endif %}
       <ul>
         {% for m in r.matches.order_by('table_number') %}
           <li>
@@ -73,5 +79,8 @@
 
 <h3>Standings</h3>
 <p><a class="btn" href="{{ url_for('standings', tid=t.id) }}">Open Standings</a></p>
+{% if t.cut.startswith('top') %}
+<p><a class="btn" href="{{ url_for('bracket', tid=t.id) }}">View Bracket</a></p>
+{% endif %}
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- Add ability to drop players when reporting results
- Support random first round pairings and expanded top cut options
- Provide re-pairing controls and bracket/print views

## Testing
- `python -m py_compile app/app.py app/models.py app/pairing.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bab26ff608320bcb21c6a13260fe9