### PR TITLE
Implement elimination bracket progression

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -12,6 +12,25 @@ main { padding: 16px; }
 .flashes li { margin:8px 0; padding:8px; border-radius:8px; }
 .flashes li.success { background:#e8f8ee; border:1px solid #bfe5cb; }
 .flashes li.error { background:#fde8e8; border:1px solid #f3c2c2; }
-.bracket { display:flex; gap:20px; }
-.round { flex:1; }
-.match { margin:8px 0; }
+.bracket { display:flex; gap:40px; align-items:flex-start; }
+.round { display:flex; flex-direction:column; gap:20px; }
+.match { position:relative; display:flex; flex-direction:column; gap:4px; padding-right:20px; }
+.player { padding:4px 8px; border:1px solid #ddd; width:180px; background:#fff; }
+.player.bye { font-style:italic; }
+.round:not(:last-child) .match::after {
+  content:'';
+  position:absolute;
+  right:0;
+  top:50%;
+  width:20px;
+  border-top:1px solid #000;
+}
+.round + .round .match { margin-top:40px; }
+.round + .round .match::before {
+  content:'';
+  position:absolute;
+  left:-20px;
+  top:-20px;
+  bottom:-20px;
+  border-left:1px solid #000;
+}

--- a/app/templates/tournament/bracket.html
+++ b/app/templates/tournament/bracket.html
@@ -5,14 +5,24 @@
 <div class="bracket">
   {% for r in rounds %}
   <div class="round">
-    <h3>Round {{ r.number }}</h3>
     {% for m in r.matches.order_by('table_number') %}
     <div class="match">
-      {{ m.player1.user.name }}{% if m.player2_id %} vs {{ m.player2.user.name }}{% endif %}
-      {% if m.completed %}- {{ m.result.player1_wins }}-{{ m.result.player2_wins }}{% endif %}
+      <div class="player">
+        {{ m.player1.user.name }} ({{ m.player1.points }})
+        {% if m.completed %}- {{ m.result.player1_wins }}{% endif %}
+      </div>
+      {% if m.player2_id %}
+      <div class="player">
+        {{ m.player2.user.name }} ({{ m.player2.points }})
+        {% if m.completed %}- {{ m.result.player2_wins }}{% endif %}
+      </div>
+      {% else %}
+      <div class="player bye">BYE</div>
+      {% endif %}
     </div>
     {% endfor %}
   </div>
   {% endfor %}
 </div>
 {% endblock %}
+

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -30,6 +30,10 @@
     <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
       <button class="btn" type="submit">Pair Next Round</button>
     </form>
+  {% elif t.cut.startswith('top') %}
+    <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
+      <button class="btn" type="submit">Pair Next Round</button>
+    </form>
   {% else %}
     <p>Round limit reached.</p>
   {% endif %}


### PR DESCRIPTION
## Summary
- Support single-elimination progression after Swiss rounds with automatic winner pairing
- Drop losing players when elimination match results are reported
- Add bracket view showing player points and bracket connectors

## Testing
- `python -m py_compile app/app.py app/models.py app/pairing.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bb16b50fc83208670742f17c9b926

## Summary by Sourcery

Implement single-elimination bracket progression after Swiss rounds, including pairing logic, automatic loser elimination, bracket visualization, and related UI and style updates

New Features:
- Add single-elimination progression after Swiss rounds with automatic pairing of winners
- Auto-drop losing players in elimination matches when results are reported
- Introduce bracket view displaying player names, points, match results, and BYE handling

Enhancements:
- Update tournament view to enable pairing elimination rounds when a cut is configured
- Style bracket layout in CSS with connectors, player panels, and responsive spacing