### PR TITLE
Add round management and global user administration

### DIFF
--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -1,0 +1,34 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Users</h2>
+<table class="table">
+  <tr><th>Name</th><th>Email</th><th>Tournaments</th><th>Add to Tournament</th></tr>
+  {% for u in users %}
+  <tr>
+    <td>{{ u.name }}</td>
+    <td>{{ u.email or '' }}</td>
+    <td>
+      <ul>
+        {% for tp in u.tournament_entries %}
+        <li>{{ tp.tournament.name }}
+          <form method="post" action="{{ url_for('admin_remove_user_from_tournament', uid=u.id, tid=tp.tournament_id) }}" style="display:inline;">
+            <button class="btn" type="submit">Remove</button>
+          </form>
+        </li>
+        {% endfor %}
+      </ul>
+    </td>
+    <td>
+      <form method="post" action="{{ url_for('admin_add_user_to_tournament', uid=u.id) }}">
+        <select name="tournament_id">
+          {% for t in tournaments %}
+          <option value="{{ t.id }}">{{ t.name }}</option>
+          {% endfor %}
+        </select>
+        <button class="btn" type="submit">Add</button>
+      </form>
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -3,19 +3,21 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <title>{{ title or 'MTG Tournament' }}</title>
+  <title>{{ title or 'WaLTER' }}</title>
   <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
 </head>
 <body>
   <header>
-    <h1><a href="{{ url_for('index') }}">MTG Tournament</a></h1>
+    <h1><a href="{{ url_for('index') }}">WaLTER</a></h1>
     <nav>
+      <a href="{{ url_for('index') }}">All Tournaments</a>
       {% if current_user.is_authenticated %}
         <span>Hi, {{ current_user.name }}</span>
         {% if current_user.is_admin %}
         <a href="{{ url_for('new_tournament') }}">New Tournament</a>
         <a href="{{ url_for('admin_register_player') }}">Register Player</a>
         <a href="{{ url_for('admin_bulk_register') }}">Bulk Register Players</a>
+        <a href="{{ url_for('admin_users') }}">Manage Users</a>
         {% endif %}
         <a href="{{ url_for('logout') }}">Logout</a>
       {% else %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,6 +8,11 @@
       <h3><a href="{{ url_for('view_tournament', tid=t.id) }}">{{ t.name }}</a></h3>
       <div>Format: {{ t.format }}</div>
       <div>Cut: {{ t.cut|upper }}</div>
+      {% if current_user.is_authenticated and current_user.is_admin %}
+      <form method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');">
+        <button class="btn" type="submit">Delete</button>
+      </form>
+      {% endif %}
     </li>
   {% else %}
     <li>No tournaments yet.</li>

--- a/app/templates/match/report.html
+++ b/app/templates/match/report.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
+<p><a href="{{ url_for('view_tournament', tid=m.round.tournament_id) }}">Back to Tournament</a></p>
 <h2>Report Match</h2>
 <p>Round {{ m.round.number }} — Table {{ m.table_number }}</p>
 <p>

--- a/app/templates/tournament/bracket.html
+++ b/app/templates/tournament/bracket.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
+<p><a href="{{ url_for('view_tournament', tid=t.id) }}">Back to Tournament</a></p>
 <h2>{{ t.name }} Bracket</h2>
 <button class="btn" onclick="window.print()">Print</button>
 <div class="bracket">

--- a/app/templates/tournament/round.html
+++ b/app/templates/tournament/round.html
@@ -1,0 +1,39 @@
+{% extends 'base.html' %}
+{% block content %}
+<p><a href="{{ url_for('view_tournament', tid=t.id) }}">Back to Tournament</a></p>
+<h2>{{ t.name }} — Round {{ r.number }}</h2>
+{% if current_user.is_authenticated and current_user.is_admin %}
+<form method="post" action="{{ url_for('repair_round', tid=t.id, rid=r.id) }}" style="display:inline;">
+  <button class="btn" type="submit">Re-pair</button>
+</form>
+{% if not has_results %}
+<form method="post" action="{{ url_for('delete_round', tid=t.id, rid=r.id) }}" style="display:inline;" onsubmit="return confirm('Delete this round?');">
+  <button class="btn" type="submit">Delete Round</button>
+</form>
+{% endif %}
+{% endif %}
+<ul>
+{% for m in r.matches.order_by('table_number') %}
+  <li>
+    Table {{ m.table_number }}:
+    {% if m.player2_id %}
+      {{ m.player1.user.name }} vs {{ m.player2.user.name }}
+    {% else %}
+      {{ m.player1.user.name }} has a BYE
+    {% endif %}
+    {% if m.completed %}
+      - Result:
+      {% if m.player2_id %}
+        {{ m.result.player1_wins }}-{{ m.result.player2_wins }} (Draws {{ m.result.draws }})
+      {% else %}
+        Win by BYE
+      {% endif %}
+    {% else %}
+      {% if current_user.is_authenticated and (current_user.is_admin or current_user.id in (m.player1.user_id, m.player2.user_id or -1)) %}
+        <a href="{{ url_for('report_match', mid=m.id) }}">Report</a>
+      {% endif %}
+    {% endif %}
+  </li>
+{% endfor %}
+</ul>
+{% endblock %}

--- a/app/templates/tournament/standings.html
+++ b/app/templates/tournament/standings.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
+<p><a href="{{ url_for('view_tournament', tid=t.id) }}">Back to Tournament</a></p>
 <h2>{{ t.name }} — Standings</h2>
 <button class="btn" onclick="window.print()">Print</button>
 <table class="table">

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -46,38 +46,7 @@
 
 <ol>
   {% for r in rounds %}
-    <li>
-      Round {{ r.number }}
-      {% if current_user.is_authenticated and current_user.is_admin %}
-      <form method="post" action="{{ url_for('repair_round', tid=t.id, rid=r.id) }}" style="display:inline;">
-        <button class="btn" type="submit">Re-pair</button>
-      </form>
-      {% endif %}
-      <ul>
-        {% for m in r.matches.order_by('table_number') %}
-          <li>
-            Table {{ m.table_number }}:
-            {% if m.player2_id %}
-              {{ m.player1.user.name }} vs {{ m.player2.user.name }}
-            {% else %}
-              {{ m.player1.user.name }} has a BYE
-            {% endif %}
-            {% if m.completed %}
-              - Result:
-              {% if m.player2_id %}
-                {{ m.result.player1_wins }}-{{ m.result.player2_wins }} (Draws {{ m.result.draws }})
-              {% else %}
-                Win by BYE
-              {% endif %}
-            {% else %}
-              {% if current_user.is_authenticated and (current_user.is_admin or current_user.id in (m.player1.user_id, m.player2.user_id or -1)) %}
-                <a href="{{ url_for('report_match', mid=m.id) }}">Report</a>
-              {% endif %}
-            {% endif %}
-          </li>
-        {% endfor %}
-      </ul>
-    </li>
+    <li><a href="{{ url_for('view_round', tid=t.id, rid=r.id) }}">Round {{ r.number }}</a></li>
   {% endfor %}
 </ol>
 


### PR DESCRIPTION
## Summary
- Prevent pairing new rounds or cutting to top when prior matches are incomplete
- Introduce per-round pages with delete functionality for unreported rounds
- Add global user management page and navigation updates including back-links and tournament deletion

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689bb8295f088320af77353f837d4173