### PR TITLE
Fix tournament deletion cascade

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -359,7 +359,9 @@ def create_app():
                 m.player2.dropped = True
             # Auto-drop losers in elimination rounds
             t = m.round.tournament
-            active = t.players.filter_by(dropped=False).count()
+            active = db.session.query(TournamentPlayer).filter_by(
+                tournament_id=t.id, dropped=False
+            ).count()
             round_limit = t.rounds_override or recommended_rounds(active)
             if m.round.number > round_limit and m.player2_id:
                 if p1_wins > p2_wins:

--- a/app/models.py
+++ b/app/models.py
@@ -41,7 +41,10 @@ class TournamentPlayer(db.Model):
     game_draws = db.Column(db.Integer, default=0)
     dropped = db.Column(db.Boolean, default=False)
 
-    tournament = db.relationship('Tournament', backref=db.backref('players', lazy='dynamic'))
+    tournament = db.relationship(
+        'Tournament',
+        backref=db.backref('players', cascade='all, delete-orphan')
+    )
     user = db.relationship('User', backref='tournament_entries')
 
     __table_args__ = (UniqueConstraint('tournament_id', 'user_id', name='_tournament_user_uc'),)
@@ -51,7 +54,10 @@ class Round(db.Model):
     tournament_id = db.Column(db.Integer, db.ForeignKey('tournament.id'), nullable=False)
     number = db.Column(db.Integer, nullable=False)
 
-    tournament = db.relationship('Tournament', backref=db.backref('rounds', lazy='dynamic'))
+    tournament = db.relationship(
+        'Tournament',
+        backref=db.backref('rounds', cascade='all, delete-orphan')
+    )
 
 class MatchResult(db.Model):
     id = db.Column(db.Integer, primary_key=True)
@@ -68,9 +74,16 @@ class Match(db.Model):
     completed = db.Column(db.Boolean, default=False)
     result_id = db.Column(db.Integer, db.ForeignKey('match_result.id'), nullable=True)
 
-    round = db.relationship('Round', backref=db.backref('matches', lazy='dynamic'))
+    round = db.relationship(
+        'Round',
+        backref=db.backref('matches', cascade='all, delete-orphan')
+    )
     player1 = db.relationship('TournamentPlayer', foreign_keys=[player1_id])
     player2 = db.relationship('TournamentPlayer', foreign_keys=[player2_id])
-    result = db.relationship('MatchResult', backref='match', uselist=False)
+    result = db.relationship(
+        'MatchResult',
+        backref=db.backref('match', cascade='all, delete-orphan'),
+        uselist=False
+    )
 
     __table_args__ = (UniqueConstraint('round_id', 'table_number', name='_round_table_uc'),)


### PR DESCRIPTION
## Summary
- Cascade deletes for players, rounds, matches, and results when removing a tournament
- Replace dynamic players query with explicit count to support new cascades

## Testing
- `python - <<'PY'
from app.app import create_app, db
from app.models import User, Tournament, TournamentPlayer, Round, Match, MatchResult

app = create_app()
app.app_context().push()

db.drop_all()
db.create_all()

T = Tournament(name='Test', format='Draft')
db.session.add(T)
db.session.commit()

u1 = User(name='Alice', email='a@example.com')
db.session.add(u1)
db.session.commit()

tp = TournamentPlayer(tournament_id=T.id, user_id=u1.id)
db.session.add(tp)

r = Round(tournament_id=T.id, number=1)
db.session.add(r)
db.session.commit()

m = Match(round_id=r.id, player1_id=tp.id, player2_id=None, table_number=1)
db.session.add(m)
db.session.commit()

print('Deleting tournament')
db.session.delete(T)
db.session.commit()
print('Remaining tournaments', Tournament.query.all())
print('Remaining players', TournamentPlayer.query.all())
print('Remaining rounds', Round.query.all())
print('Remaining matches', Match.query.all())
print('Remaining results', MatchResult.query.all())
PY`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bbba0ea9c8320baea097363e967a0

## Summary by Sourcery

Enforce cascade deletion of tournament-related entities and update active players count query to support cascades

Bug Fixes:
- Add cascade delete-orphan to players, rounds, matches, and match results relationships to remove dependent records when deleting a tournament

Enhancements:
- Replace dynamic players relationship count with an explicit database query in match reporting logic