### PR TITLE
Improve user admin and tournament pairing flow

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -13,6 +13,7 @@ class User(db.Model, UserMixin):
     password_hash = db.Column(db.String(255), nullable=True)
     is_admin = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    notes = db.Column(db.Text, nullable=True)
 
     def set_password(self, pw):
         self.password_hash = generate_password_hash(pw)
@@ -45,7 +46,10 @@ class TournamentPlayer(db.Model):
         'Tournament',
         backref=db.backref('players', cascade='all, delete-orphan')
     )
-    user = db.relationship('User', backref='tournament_entries')
+    user = db.relationship(
+        'User',
+        backref=db.backref('tournament_entries', cascade='all, delete-orphan')
+    )
 
     __table_args__ = (UniqueConstraint('tournament_id', 'user_id', name='_tournament_user_uc'),)
 

--- a/app/templates/admin/bulk_register_players.html
+++ b/app/templates/admin/bulk_register_players.html
@@ -3,7 +3,8 @@
 <h2>Bulk Register Players</h2>
 <form method="post">
   <label for="tournament_id">Tournament:</label>
-  <select name="tournament_id" required>
+  <select name="tournament_id">
+    <option value="">-- None --</option>
     {% for t in tournaments %}
       <option value="{{ t.id }}">{{ t.name }}</option>
     {% endfor %}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -2,11 +2,17 @@
 {% block content %}
 <h2>Users</h2>
 <table class="table">
-  <tr><th>Name</th><th>Email</th><th>Tournaments</th><th>Add to Tournament</th></tr>
+  <tr><th>Name</th><th>Email & Notes</th><th>Tournaments</th><th>Add to Tournament</th><th>Delete</th></tr>
   {% for u in users %}
   <tr>
     <td>{{ u.name }}</td>
-    <td>{{ u.email or '' }}</td>
+    <td>
+      <form method="post" action="{{ url_for('admin_update_user', uid=u.id) }}">
+        <input type="email" name="email" value="{{ u.email or '' }}"><br>
+        <textarea name="notes" rows="2" cols="20">{{ u.notes or '' }}</textarea><br>
+        <button class="btn" type="submit">Save</button>
+      </form>
+    </td>
     <td>
       <ul>
         {% for tp in u.tournament_entries %}
@@ -26,6 +32,11 @@
           {% endfor %}
         </select>
         <button class="btn" type="submit">Add</button>
+      </form>
+    </td>
+    <td>
+      <form method="post" action="{{ url_for('admin_delete_user', uid=u.id) }}" onsubmit="return confirm('Delete user?');">
+        <button class="btn" type="submit">Delete</button>
       </form>
     </td>
   </tr>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -10,9 +10,9 @@
   <header>
     <h1><a href="{{ url_for('index') }}">WaLTER</a></h1>
     <nav>
-      <a href="{{ url_for('index') }}">All Tournaments</a>
       {% if current_user.is_authenticated %}
         <span>Hi, {{ current_user.name }}</span>
+        <a href="{{ url_for('index') }}">All Tournaments</a>
         {% if current_user.is_admin %}
         <a href="{{ url_for('new_tournament') }}">New Tournament</a>
         <a href="{{ url_for('admin_register_player') }}">Register Player</a>
@@ -21,6 +21,7 @@
         {% endif %}
         <a href="{{ url_for('logout') }}">Logout</a>
       {% else %}
+        <a href="{{ url_for('index') }}">All Tournaments</a>
         <a href="{{ url_for('login') }}">Login</a>
         <a href="{{ url_for('register') }}">Register</a>
       {% endif %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -37,11 +37,6 @@
   {% else %}
     <p>Round limit reached.</p>
   {% endif %}
-  {% if t.cut.startswith('top') %}
-    <form method="post" action="{{ url_for('cut_to_top', tid=t.id) }}">
-      <button class="btn" type="submit">Cut to Top {{ t.cut[3:] }}</button>
-    </form>
-  {% endif %}
   {% endif %}
 
 <ol>


### PR DESCRIPTION
## Summary
- Add user notes, email management, and deletion from admin users page
- Allow bulk player registration without choosing a tournament
- Simplify tournament flow by removing cut button and enhancing pairing logic
- Redirect match reports back to their round and reposition greeting in navigation

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689bc2025fcc8320af111ddff8b1871e

## Summary by Sourcery

Improve admin user management, bulk registration, and tournament pairing flow

Enhancements:
- Allow bulk player registration without choosing a tournament and handle optional tournament assignment
- Merge cut-to-top logic into pair_next_round and remove separate cut endpoint and button
- Redirect match report submissions back to the round view instead of the tournament view
- Enable inline editing of user email and notes in the admin interface and add user deletion
- Reposition navigation links and greeting for better layout