### PR TITLE
Show total points on bracket

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -21,7 +21,7 @@ def create_app():
     login_manager.login_view = 'login'
 
     from .models import User, Tournament, TournamentPlayer, Round, Match, MatchResult
-    from .pairing import swiss_pair_round, recommended_rounds, compute_standings
+    from .pairing import swiss_pair_round, recommended_rounds, compute_standings, player_points
 
     @login_manager.user_loader
     def load_user(user_id):
@@ -430,7 +430,8 @@ def create_app():
         if t.structure == 'single_elim':
             round_limit = 0
         elim_rounds = [r for r in rounds if r.number > round_limit]
-        return render_template('tournament/bracket.html', t=t, rounds=elim_rounds)
+        points = {tp.id: player_points(tp, db.session) for tp in players}
+        return render_template('tournament/bracket.html', t=t, rounds=elim_rounds, points=points)
 
     @app.route('/admin/users')
     def admin_users():

--- a/app/templates/tournament/bracket.html
+++ b/app/templates/tournament/bracket.html
@@ -8,15 +8,15 @@
   <div class="round">
     {% for m in r.matches|sort(attribute='table_number') %}
     <div class="match">
-      <div class="player">
-        {{ m.player1.user.name }} ({{ m.player1.points }})
-        {% if m.completed %}- {{ m.result.player1_wins }}{% endif %}
-      </div>
+        <div class="player">
+          {{ m.player1.user.name }} ({{ points[m.player1_id] }})
+          {% if m.completed %}- {{ m.result.player1_wins }}{% endif %}
+        </div>
       {% if m.player2_id %}
-      <div class="player">
-        {{ m.player2.user.name }} ({{ m.player2.points }})
-        {% if m.completed %}- {{ m.result.player2_wins }}{% endif %}
-      </div>
+        <div class="player">
+          {{ m.player2.user.name }} ({{ points[m.player2_id] }})
+          {% if m.completed %}- {{ m.result.player2_wins }}{% endif %}
+        </div>
       {% else %}
       <div class="player bye">BYE</div>
       {% endif %}


### PR DESCRIPTION
## Summary
- display each player's total match points on the bracket page
- compute and pass cumulative point totals when rendering brackets

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689bc901cef083209a4ad085228ef90e

## Summary by Sourcery

Compute and pass cumulative player points in the bracket endpoint and update the bracket template to display each player's total points next to their name.

New Features:
- Show total cumulative match points beside each player's name on the bracket page.

Enhancements:
- Compute each player’s total points in the bracket view using player_points and pass them to the template.