### PR TITLE
Improve Commander bracket and tournament controls

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -34,3 +34,11 @@ main { padding: 16px; }
   bottom:-20px;
   border-left:1px solid #000;
 }
+
+.center-table { margin: 0 auto; width:auto; }
+.toolbar { display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin-bottom:16px; }
+.toolbar form { display:inline-flex; gap:4px; align-items:center; }
+.players-table { width:100%; border-collapse:collapse; }
+.players-table tbody { display:grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
+.players-table tr { display:contents; }
+.players-table td { border:1px solid #ddd; padding:6px 8px; text-align:center; }

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -31,4 +31,19 @@
   </label><br>
   <button class="btn" type="submit">Create</button>
 </form>
+<script>
+const fmtSel = document.querySelector('select[name="format"]');
+const cutSel = document.querySelector('select[name="cut"]');
+function updateCut(){
+  const top8 = cutSel.querySelector('option[value="top8"]');
+  if(fmtSel.value === 'Commander'){
+    top8.style.display = 'none';
+    if(cutSel.value === 'top8'){ cutSel.value = 'top4'; }
+  }else{
+    top8.style.display = '';
+  }
+}
+fmtSel.addEventListener('change', updateCut);
+updateCut();
+</script>
 {% endblock %}

--- a/app/templates/match/report.html
+++ b/app/templates/match/report.html
@@ -12,22 +12,71 @@
 </p>
 {% if t.format == 'Commander' %}
 <form method="post">
-  <label>{{ m.player1.user.name }} place: <input type="number" name="p1_place" min="1" max="4" value="{{ m.result.p1_place if m.result else '' }}"></label><br>
-  {% if m.player2_id %}<label>{{ m.player2.user.name }} place: <input type="number" name="p2_place" min="1" max="4" value="{{ m.result.p2_place if m.result else '' }}"></label><br>{% endif %}
-  {% if m.player3_id %}<label>{{ m.player3.user.name }} place: <input type="number" name="p3_place" min="1" max="4" value="{{ m.result.p3_place if m.result else '' }}"></label><br>{% endif %}
-  {% if m.player4_id %}<label>{{ m.player4.user.name }} place: <input type="number" name="p4_place" min="1" max="4" value="{{ m.result.p4_place if m.result else '' }}"></label><br>{% endif %}
-  <label><input type="checkbox" name="is_draw" {% if m.result and m.result.is_draw %}checked{% endif %}> Draw (all players)</label><br>
-  <button class="btn" type="submit">Submit Result</button>
+  <table class="table center-table">
+    <tbody>
+      <tr>
+        <td>{{ m.player1.user.name }} place</td>
+        <td><input type="number" name="p1_place" min="1" max="4" value="{{ m.result.p1_place if m.result else '' }}"></td>
+        <td><label><input type="checkbox" name="drop_p1"> Drop</label></td>
+      </tr>
+      {% if m.player2_id %}
+      <tr>
+        <td>{{ m.player2.user.name }} place</td>
+        <td><input type="number" name="p2_place" min="1" max="4" value="{{ m.result.p2_place if m.result else '' }}"></td>
+        <td><label><input type="checkbox" name="drop_p2"> Drop</label></td>
+      </tr>
+      {% endif %}
+      {% if m.player3_id %}
+      <tr>
+        <td>{{ m.player3.user.name }} place</td>
+        <td><input type="number" name="p3_place" min="1" max="4" value="{{ m.result.p3_place if m.result else '' }}"></td>
+        <td><label><input type="checkbox" name="drop_p3"> Drop</label></td>
+      </tr>
+      {% endif %}
+      {% if m.player4_id %}
+      <tr>
+        <td>{{ m.player4.user.name }} place</td>
+        <td><input type="number" name="p4_place" min="1" max="4" value="{{ m.result.p4_place if m.result else '' }}"></td>
+        <td><label><input type="checkbox" name="drop_p4"> Drop</label></td>
+      </tr>
+      {% endif %}
+      <tr>
+        <td colspan="3"><label><input type="checkbox" name="is_draw" {% if m.result and m.result.is_draw %}checked{% endif %}> Draw (all players)</label></td>
+      </tr>
+      <tr>
+        <td colspan="3"><button class="btn" type="submit">Submit Result</button></td>
+      </tr>
+    </tbody>
+  </table>
 </form>
 {% else %}
   {% if m.player2_id %}
   <form method="post">
-    <label>{{ m.player1.user.name }} game wins: <input type="number" name="p1_wins" min="0" required value="{{ m.result.player1_wins if m.result else '' }}"></label><br>
-    <label>{{ m.player2.user.name }} game wins: <input type="number" name="p2_wins" min="0" required value="{{ m.result.player2_wins if m.result else '' }}"></label><br>
-    <label>Draws: <input type="number" name="draws" min="0" value="{{ m.result.draws if m.result else 0 }}"></label><br>
-    <label><input type="checkbox" name="drop_p1"> Drop {{ m.player1.user.name }}</label><br>
-    <label><input type="checkbox" name="drop_p2"> Drop {{ m.player2.user.name }}</label><br>
-    <button class="btn" type="submit">Submit Result</button>
+    <table class="table center-table">
+      <tbody>
+        <tr>
+          <td>{{ m.player1.user.name }} game wins</td>
+          <td><input type="number" name="p1_wins" min="0" required value="{{ m.result.player1_wins if m.result else '' }}"></td>
+        </tr>
+        <tr>
+          <td>{{ m.player2.user.name }} game wins</td>
+          <td><input type="number" name="p2_wins" min="0" required value="{{ m.result.player2_wins if m.result else '' }}"></td>
+        </tr>
+        <tr>
+          <td>Draws</td>
+          <td><input type="number" name="draws" min="0" value="{{ m.result.draws if m.result else 0 }}"></td>
+        </tr>
+        <tr>
+          <td colspan="2"><label><input type="checkbox" name="drop_p1"> Drop {{ m.player1.user.name }}</label></td>
+        </tr>
+        <tr>
+          <td colspan="2"><label><input type="checkbox" name="drop_p2"> Drop {{ m.player2.user.name }}</label></td>
+        </tr>
+        <tr>
+          <td colspan="2"><button class="btn" type="submit">Submit Result</button></td>
+        </tr>
+      </tbody>
+    </table>
   </form>
   {% else %}
   <p>BYE — no reporting needed.</p>

--- a/app/templates/tournament/bracket.html
+++ b/app/templates/tournament/bracket.html
@@ -8,18 +8,37 @@
   <div class="round">
     {% for m in r.matches|sort(attribute='table_number') %}
     <div class="match">
+        {% if t.format == 'Commander' %}
+          {% set players = [
+            (m.player1, m.player1_id, m.result.p1_place if m.result else None),
+            (m.player2, m.player2_id, m.result.p2_place if m.result else None),
+            (m.player3, m.player3_id, m.result.p3_place if m.result else None),
+            (m.player4, m.player4_id, m.result.p4_place if m.result else None)
+          ] %}
+          {% for pl, pid, place in players %}
+            {% if pl %}
+            <div class="player">
+              {{ pl.user.name }} ({{ points[pid] }})
+              {% if m.completed %}- {{ place }}{% endif %}
+            </div>
+            {% else %}
+            <div class="player bye">BYE</div>
+            {% endif %}
+          {% endfor %}
+        {% else %}
         <div class="player">
           {{ m.player1.user.name }} ({{ points[m.player1_id] }})
           {% if m.completed %}- {{ m.result.player1_wins }}{% endif %}
         </div>
-      {% if m.player2_id %}
+        {% if m.player2_id %}
         <div class="player">
           {{ m.player2.user.name }} ({{ points[m.player2_id] }})
           {% if m.completed %}- {{ m.result.player2_wins }}{% endif %}
         </div>
-      {% else %}
-      <div class="player bye">BYE</div>
-      {% endif %}
+        {% else %}
+        <div class="player bye">BYE</div>
+        {% endif %}
+        {% endif %}
     </div>
     {% endfor %}
   </div>

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -2,53 +2,47 @@
 {% block content %}
 <h2>{{ t.name }}</h2>
 <p>Format: {{ t.format }} | Cut: {{ t.cut|upper }}</p>
-<button class="btn" onclick="window.print()">Print</button>
-<form method="post" action="{{ url_for('join_tournament', tid=t.id) }}">
-  {% if current_user.is_authenticated %}
-    <button class="btn" type="submit">Join Tournament</button>
-  {% else %}
-    <a class="btn" href="{{ url_for('login') }}">Login to Join</a>
+{% set round_limit = t.rounds_override or rec_rounds %}
+{% set current_rounds = rounds|length %}
+<div class="toolbar">
+  <button class="btn" onclick="window.print()">Print</button>
+  <form method="post" action="{{ url_for('join_tournament', tid=t.id) }}">
+    {% if current_user.is_authenticated %}
+      <button class="btn" type="submit">Join</button>
+    {% else %}
+      <a class="btn" href="{{ url_for('login') }}">Login to Join</a>
+    {% endif %}
+  </form>
+  <a class="btn" href="{{ url_for('standings', tid=t.id) }}">Standings</a>
+  {% if t.cut.startswith('top') %}
+  <a class="btn" href="{{ url_for('bracket', tid=t.id) }}">Bracket</a>
   {% endif %}
-</form>
+  {% if current_user.is_authenticated and current_user.is_admin %}
+    {% if current_rounds < round_limit or t.cut.startswith('top') %}
+    <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
+      <button class="btn" type="submit">Pair</button>
+    </form>
+    {% endif %}
+    <form method="post" action="{{ url_for('set_rounds', tid=t.id) }}">
+      <input type="number" name="rounds" min="1" value="{{ t.rounds_override or rec_rounds }}">
+      <button class="btn" type="submit">Set Rounds</button>
+    </form>
+  {% endif %}
+</div>
 
 <h3>Players ({{ players|length }})</h3>
-<ul>
+<table class="players-table">
+  <tbody>
   {% for p in players %}
-    <li>{{ p.user.name }}</li>
+    <tr><td>{{ p.user.name }}</td></tr>
   {% endfor %}
-</ul>
+  </tbody>
+</table>
 
 <h3>Rounds</h3>
-  {% if current_user.is_authenticated and current_user.is_admin %}
-  <form method="post" action="{{ url_for('set_rounds', tid=t.id) }}">
-    <label>Rounds (recommended {{ rec_rounds }}): <input type="number" name="rounds" min="1" value="{{ t.rounds_override or rec_rounds }}"></label>
-    <button class="btn" type="submit">Set</button>
-  </form>
-  {% set round_limit = t.rounds_override or rec_rounds %}
-  {% set current_rounds = rounds|length %}
-  {% if current_rounds < round_limit %}
-    <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
-      <button class="btn" type="submit">Pair Next Round</button>
-    </form>
-  {% elif t.cut.startswith('top') %}
-    <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
-      <button class="btn" type="submit">Pair Next Round</button>
-    </form>
-  {% else %}
-    <p>Round limit reached.</p>
-  {% endif %}
-  {% endif %}
-
 <ol>
   {% for r in rounds %}
     <li><a href="{{ url_for('view_round', tid=t.id, rid=r.id) }}">Round {{ r.number }}</a></li>
   {% endfor %}
 </ol>
-
-<h3>Standings</h3>
-<p><a class="btn" href="{{ url_for('standings', tid=t.id) }}">Open Standings</a></p>
-{% if t.cut.startswith('top') %}
-<p><a class="btn" href="{{ url_for('bracket', tid=t.id) }}">View Bracket</a></p>
-{% endif %}
-
 {% endblock %}


### PR DESCRIPTION
## Summary
- Show Commander elimination brackets as 4-player pods and restrict cuts to powers of four
- Add drop options and centered tables for match reporting
- Introduce toolbar with print, join, standings, bracket, pair, and set rounds buttons and responsive player list

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a89b8185d0832084a7d83719f677c6