### PR TITLE
Improve tournament pages and match display

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -54,7 +54,8 @@ def create_app():
     @app.route('/')
     def index():
         tournaments = db.session.query(Tournament).order_by(Tournament.created_at.desc()).all()
-        return render_template('index.html', tournaments=tournaments)
+        player_counts = {t.id: len(t.players) for t in tournaments}
+        return render_template('index.html', tournaments=tournaments, player_counts=player_counts)
 
     @app.route('/register', methods=['GET','POST'])
     def register():

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -35,6 +35,8 @@ main { padding: 16px; }
   border-left:1px solid #000;
 }
 
+.round + .round { align-self: center; }
+
 .center-table { margin: 0 auto; width:auto; }
 .toolbar { display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin-bottom:16px; }
 .toolbar form { display:inline-flex; gap:4px; align-items:center; }

--- a/app/templates/admin/bulk_register_players.html
+++ b/app/templates/admin/bulk_register_players.html
@@ -2,17 +2,27 @@
 {% block content %}
 <h2>Bulk Register Players</h2>
 <form method="post">
-  <label for="tournament_id">Tournament:</label>
-  <select name="tournament_id">
-    <option value="">-- None --</option>
-    {% for t in tournaments %}
-      <option value="{{ t.id }}">{{ t.name }}</option>
-    {% endfor %}
-  </select>
-  <div>
-    <label for="names">Player Names (one per line):</label><br>
-    <textarea name="names" rows="10" cols="30"></textarea>
-  </div>
-  <button type="submit">Register Players</button>
+  <table class="center-table">
+    <tbody>
+      <tr>
+        <td>Tournament:</td>
+        <td>
+          <select name="tournament_id">
+            <option value="">-- None --</option>
+            {% for t in tournaments %}
+              <option value="{{ t.id }}">{{ t.name }}</option>
+            {% endfor %}
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>Player Names (one per line):</td>
+        <td><textarea name="names" rows="10" cols="30"></textarea></td>
+      </tr>
+      <tr>
+        <td colspan="2"><button class="btn" type="submit">Register Players</button></td>
+      </tr>
+    </tbody>
+  </table>
 </form>
 {% endblock %}

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -2,34 +2,53 @@
 {% block content %}
 <h2>New Tournament</h2>
 <form method="post">
-  <label>Name <input name="name" required></label><br>
-  <label>Format
-    <select name="format" required>
-      <option>Commander</option>
-      <option>Draft</option>
-      <option>Constructed</option>
-    </select>
-  </label><br>
-  <label>Structure
-    <select name="structure">
-      <option value="swiss">Swiss / Cut</option>
-      <option value="single_elim">Single Elimination</option>
-    </select>
-  </label><br>
-  <label>Cut
-    <select name="cut">
-      <option value="none">None</option>
-      <option value="top64">Top 64</option>
-      <option value="top32">Top 32</option>
-      <option value="top16">Top 16</option>
-      <option value="top8">Top 8</option>
-      <option value="top4">Top 4</option>
-    </select>
-  </label><br>
-  <label>Commander Points (1st,2nd,3rd,4th,draw)
-    <input name="commander_points" value="3,2,1,0,1">
-  </label><br>
-  <button class="btn" type="submit">Create</button>
+  <table class="table center-table">
+    <tbody>
+      <tr>
+        <td>Name</td>
+        <td><input name="name" required></td>
+      </tr>
+      <tr>
+        <td>Format</td>
+        <td>
+          <select name="format" required>
+            <option>Commander</option>
+            <option>Draft</option>
+            <option>Constructed</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>Structure</td>
+        <td>
+          <select name="structure">
+            <option value="swiss">Swiss / Cut</option>
+            <option value="single_elim">Single Elimination</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>Cut</td>
+        <td>
+          <select name="cut">
+            <option value="none">None</option>
+            <option value="top64">Top 64</option>
+            <option value="top32">Top 32</option>
+            <option value="top16">Top 16</option>
+            <option value="top8">Top 8</option>
+            <option value="top4">Top 4</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>Commander Points (1st,2nd,3rd,4th,draw)</td>
+        <td><input name="commander_points" value="3,2,1,0,1"></td>
+      </tr>
+      <tr>
+        <td colspan="2"><button class="btn" type="submit">Create</button></td>
+      </tr>
+    </tbody>
+  </table>
 </form>
 <script>
 const fmtSel = document.querySelector('select[name="format"]');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -8,6 +8,7 @@
       <h3><a href="{{ url_for('view_tournament', tid=t.id) }}">{{ t.name }}</a></h3>
       <div>Format: {{ t.format }}</div>
       <div>Cut: {{ t.cut|upper }}</div>
+      <div>Players: {{ player_counts[t.id] }}</div>
       {% if current_user.is_authenticated and current_user.is_admin %}
       <form method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');">
         <button class="btn" type="submit">Delete</button>

--- a/app/templates/match/report.html
+++ b/app/templates/match/report.html
@@ -5,7 +5,7 @@
 <p>Round {{ m.round.number }} — Table {{ m.table_number }}</p>
 <p>
   {% if m.player2_id %}
-    {{ m.player1.user.name }} vs {{ m.player2.user.name }}
+    {{ m.player1.user.name }} vs {{ m.player2.user.name }}{% if m.player3_id %} vs {{ m.player3.user.name }}{% endif %}{% if m.player4_id %} vs {{ m.player4.user.name }}{% endif %}
   {% else %}
     {{ m.player1.user.name }} has a BYE
   {% endif %}


### PR DESCRIPTION
## Summary
- Show all players in match headers when reporting results
- Center new tournament and bulk register forms using tables
- Display player counts on tournament cards and center later bracket rounds

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8a1b9159c8320bc7a4f98ae9559d9