### PR TITLE
Add tournament timers and draft utilities

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,7 @@ from flask_login import UserMixin
 from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime
 from sqlalchemy import UniqueConstraint
+import uuid
 
 class User(db.Model, UserMixin):
     id = db.Column(db.Integer, primary_key=True)
@@ -33,6 +34,13 @@ class Tournament(db.Model):
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     # Comma separated points for Commander: first, second, third, fourth, draw
     commander_points = db.Column(db.String(50), default='3,2,1,0,1')
+    guid = db.Column(db.String(36), unique=True, default=lambda: str(uuid.uuid4()))
+    round_length = db.Column(db.Integer, default=50)
+    draft_time = db.Column(db.Integer, nullable=True)
+    deck_build_time = db.Column(db.Integer, nullable=True)
+    round_timer_end = db.Column(db.DateTime, nullable=True)
+    draft_timer_end = db.Column(db.DateTime, nullable=True)
+    deck_timer_end = db.Column(db.DateTime, nullable=True)
 
 class TournamentPlayer(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -44,3 +44,4 @@ main { padding: 16px; }
 .players-table tbody { display:grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
 .players-table tr { display:contents; }
 .players-table td { border:1px solid #ddd; padding:6px 8px; text-align:center; }
+.centered-form { max-width:400px; margin:0 auto; }

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -45,6 +45,18 @@
         <td><input name="commander_points" value="3,2,1,0,1"></td>
       </tr>
       <tr>
+        <td>Round Length (minutes)</td>
+        <td><input type="number" name="round_length" value="50"></td>
+      </tr>
+      <tr>
+        <td>Draft Time (minutes)</td>
+        <td><input type="number" name="draft_time"></td>
+      </tr>
+      <tr>
+        <td>Deck Build Time (minutes)</td>
+        <td><input type="number" name="deck_build_time"></td>
+      </tr>
+      <tr>
         <td colspan="2"><button class="btn" type="submit">Create</button></td>
       </tr>
     </tbody>

--- a/app/templates/admin/register_player.html
+++ b/app/templates/admin/register_player.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Register Player</h2>
-<form method="post">
+<form method="post" class="centered-form">
   <label>Name <input name="name" required></label><br>
   <label>Email <input name="email" type="email" required></label><br>
   <label>Password <input name="password" type="password" required></label><br>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -25,6 +25,7 @@
         <a href="{{ url_for('login') }}">Login</a>
         <a href="{{ url_for('register') }}">Register</a>
       {% endif %}
+      {% if timer_end %}<span id="header-timer" data-timer-end="{{ timer_end.isoformat() }}Z"></span>{% endif %}
     </nav>
   </header>
   {% with messages = get_flashed_messages(with_categories=true) %}
@@ -39,5 +40,26 @@
   <main>
     {% block content %}{% endblock %}
   </main>
+  <script>
+  document.querySelectorAll('[data-timer-end]').forEach(function(el){
+    const end = new Date(el.dataset.timerEnd);
+    function update(){
+      const diff = end - new Date();
+      if (diff <= 0){
+        el.textContent = '00:00';
+        if(!el.dataset.alerted){
+          alert('Time has elapsed');
+          el.dataset.alerted = '1';
+        }
+      }else{
+        const m = Math.floor(diff/60000);
+        const s = Math.floor((diff%60000)/1000);
+        el.textContent = m.toString().padStart(2,'0') + ':' + s.toString().padStart(2,'0');
+        setTimeout(update,1000);
+      }
+    }
+    update();
+  });
+  </script>
 </body>
 </html>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -9,6 +9,10 @@
       <div>Format: {{ t.format }}</div>
       <div>Cut: {{ t.cut|upper }}</div>
       <div>Players: {{ player_counts[t.id] }}</div>
+      {% set end = t.round_timer_end or t.draft_timer_end or t.deck_timer_end %}
+      {% if end %}
+      <div>Timer: <span class="timer" data-timer-end="{{ end.isoformat() }}Z"></span></div>
+      {% endif %}
       {% if current_user.is_authenticated and current_user.is_admin %}
       <form method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');">
         <button class="btn" type="submit">Delete</button>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Register</h2>
-<form method="post">
+<form method="post" class="centered-form">
   <label>Name <input name="name" required></label><br>
   <label>Email <input name="email" type="email" required></label><br>
   <label>Password <input name="password" type="password" required></label><br>

--- a/app/templates/tournament/bracket.html
+++ b/app/templates/tournament/bracket.html
@@ -43,6 +43,13 @@
     {% endfor %}
   </div>
   {% endfor %}
+  {% if champion %}
+  <div class="round">
+    <div class="match">
+      <div class="player">{{ champion.user.name }}</div>
+    </div>
+  </div>
+  {% endif %}
 </div>
 {% endblock %}
 

--- a/app/templates/tournament/draft_seating.html
+++ b/app/templates/tournament/draft_seating.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<p><a href="{{ url_for('view_tournament', tid=t.id) }}">Back to Tournament</a></p>
+<h2>{{ t.name }} Draft Seating</h2>
+{% for table in tables %}
+<h3>Table {{ loop.index }}</h3>
+<ol>
+{% for p in table %}
+<li>{{ p.user.name }}</li>
+{% endfor %}
+</ol>
+{% endfor %}
+{% endblock %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -27,6 +27,18 @@
       <input type="number" name="rounds" min="1" value="{{ t.rounds_override or rec_rounds }}">
       <button class="btn" type="submit">Set Rounds</button>
     </form>
+    <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='round') }}">
+      <button class="btn" type="submit">Start Round Timer</button>
+    </form>
+    {% if t.format == 'Draft' %}
+    <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='draft') }}">
+      <button class="btn" type="submit">Start Draft Timer</button>
+    </form>
+    <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='deck') }}">
+      <button class="btn" type="submit">Start Deck Timer</button>
+    </form>
+    <a class="btn" href="{{ url_for('draft_seating', tid=t.id) }}">Draft Seating</a>
+    {% endif %}
   {% endif %}
 </div>
 


### PR DESCRIPTION
## Summary
- add GUID and timer fields to tournaments
- allow configuring round, draft, and deck build times and start timers with alerts
- support draft seating generation and champion column in brackets

## Testing
- `python -m py_compile app/*.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8a7626c68832092798bcf1d009f95