### PR TITLE
Encrypt passwords with AES-256

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,5 @@
-from .app import db
+from .app import db, encrypt_password, verify_password
 from flask_login import UserMixin
-from werkzeug.security import generate_password_hash, check_password_hash
 from datetime import datetime
 from sqlalchemy import UniqueConstraint
 import uuid
@@ -17,12 +16,12 @@ class User(db.Model, UserMixin):
     notes = db.Column(db.Text, nullable=True)
 
     def set_password(self, pw):
-        self.password_hash = generate_password_hash(pw)
+        self.password_hash = encrypt_password(pw)
 
     def check_password(self, pw):
         if not self.password_hash:
             return False
-        return check_password_hash(self.password_hash, pw)
+        return verify_password(pw, self.password_hash)
 
 class Tournament(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Flask==3.0.3
 Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
+cryptography==42.0.4


### PR DESCRIPTION
## Summary
- Encrypt user passwords using AES-256 with a random salt initialized at startup
- Update user model to store and verify encrypted passwords
- Add cryptography dependency for AES support

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8b1cb70a48320b88d9811e6d8f35c