### PR TITLE
Create default admin during DB initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,10 @@
    set FLASK_APP=app.app:app     (Windows)
    export FLASK_APP=app.app:app  (macOS/Linux)
 
-3) Initialize the DB and create an admin:
+3) Initialize the DB (creates a default admin user `admin@example.com` / `admin123`):
    flask --app app.app db-init
-   flask --app app.app create-admin --email admin@example.com --password admin123
+   # Optionally create additional admins
+   flask --app app.app create-admin --email admin2@example.com --password secret
 
 4) Run:
    flask --app app.app run --debug

--- a/app/app.py
+++ b/app/app.py
@@ -37,6 +37,15 @@ def create_app():
     @app.cli.command('db-init')
     def db_init():
         db.create_all()
+        # Ensure a default admin account exists for first-time login
+        if not db.session.query(User).filter_by(
+            email="admin@example.com"
+        ).first():
+            u = User(email="admin@example.com", name="Admin", is_admin=True)
+            u.set_password("admin123")
+            db.session.add(u)
+            db.session.commit()
+            print("Created default admin: admin@example.com / admin123")
         print("Database initialized.")
 
     @app.cli.command('create-admin')


### PR DESCRIPTION
## Summary
- Ensure `flask db-init` seeds an `admin@example.com`/`admin123` account
- Document default admin creation in README

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8b51e36a0832091a665aad101a075