### PR TITLE
Fix NameError in draft seating by importing random

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -9,6 +9,7 @@ from flask_login import (
 )
 from datetime import datetime, timedelta
 import os
+import random
 import click
 
 


### PR DESCRIPTION
## Summary
- import `random` in `app/app.py` so draft seating shuffles players without NameError

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8b72dd9988320846333a32c7ad136