### PR TITLE
Add password seed parameter to start-server script

### DIFF
--- a/start-server.ps1
+++ b/start-server.ps1
@@ -2,6 +2,10 @@
 # Installs dependencies, initializes the database, creates an admin user,
 # and starts the Flask development server.
 
+param(
+    [string]$PasswordSeed = "dev-password-seed-change-me"
+)
+
 #check if Flask is already running and stop it if necessary
 $flaskpid = try{
     Get-NetTCPConnection -LocalPort 5000 -State Listen -ErrorAction Stop | Select-Object -ExpandProperty OwningProcess
@@ -17,6 +21,9 @@ Stop-Process -Name "flask" -Force -ErrorAction SilentlyContinue | Out-Null
 
 # Ensure the script runs from its own directory so relative paths work
 Set-Location -Path $PSScriptRoot
+
+# Configure password seed for AES encryption
+$env:PASSWORD_SEED = $PasswordSeed
 
 Write-Host "Installing dependencies..."
 python -m pip install -r "$PSScriptRoot/requirements.txt" | Out-Null


### PR DESCRIPTION
## Summary
- Allow `start-server.ps1` to accept a `PasswordSeed` parameter and export it to `PASSWORD_SEED` so password encryption uses a consistent key.

## Testing
- `python -m pytest`
- `PASSWORD_SEED=dev-password-seed-change-me python - <<'PY'
from app.app import create_app, db
from app.models import User
app = create_app()
with app.app_context():
    db.drop_all()
    db.create_all()
    u = User(email='test@example.com', name='Test')
    u.set_password('secret')
    db.session.add(u)
    db.session.commit()
    print(u.check_password('secret'))
PY`

------
https://chatgpt.com/codex/tasks/task_e_68a8b9f5e710832095ee6f9f85ab019c

## Summary by Sourcery

Add support for specifying a password seed in the PowerShell start-server script to ensure consistent encryption keys

New Features:
- Allow start-server.ps1 to accept a PasswordSeed parameter

Enhancements:
- Export the provided PasswordSeed value to the PASSWORD_SEED environment variable before installing dependencies and launching the server