### PR TITLE
Add admin debug panel for system metrics

### DIFF
--- a/app/templates/admin/panel.html
+++ b/app/templates/admin/panel.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Admin Debug Panel</h2>
+<ul>
+  <li>Encryption type: {{ encryption_type }}</li>
+  <li>Database size: {{ db_size }}</li>
+  <li>RAM usage: {{ ram_usage }}</li>
+  <li>CPU usage: {{ cpu_usage }}%</li>
+  <li>Current connections: {{ connections }}</li>
+  <li>System uptime: {{ uptime }} seconds</li>
+</ul>
+{% if password_seed %}
+<p>Password seed: {{ password_seed }}</p>
+{% else %}
+<form method="post">
+  <label>Confirm password to reveal seed:</label>
+  <input type="password" name="password">
+  <button class="btn" type="submit">Reveal</button>
+</form>
+{% endif %}
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,6 +18,7 @@
         <a href="{{ url_for('admin_register_player') }}">Register Player</a>
         <a href="{{ url_for('admin_bulk_register') }}">Bulk Register Players</a>
         <a href="{{ url_for('admin_users') }}">Manage Users</a>
+        <a href="{{ url_for('admin_panel') }}">Admin Panel</a>
         {% endif %}
         <a href="{{ url_for('logout') }}">Logout</a>
       {% else %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ Flask==3.0.3
 Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
 cryptography==42.0.7
+psutil==5.9.8


### PR DESCRIPTION
## Summary
- Store password seed for optional display in admin debug panel
- Add admin panel with encryption info, database size, resource usage, and connection stats
- Expose debug panel link in navigation and include psutil dependency

## Testing
- `python -m py_compile app/app.py app/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8bbede0fc8320a94647b198333a53

## Summary by Sourcery

Introduce an admin debug panel that surfaces key system metrics and encryption information, persist the password seed for secure reveal, and integrate the panel into the application navigation

New Features:
- Add /admin/panel route displaying encryption type, database size, CPU and RAM usage, connection count, uptime, and optional password seed reveal
- Expose admin debug panel link in the main navigation

Enhancements:
- Store and surface the password seed (from environment or random generation) for optional display after password confirmation

Build:
- Add psutil dependency to requirements.txt for system metrics