### PR TITLE
Handle invalid padding during password verification

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -5,6 +5,7 @@ from sqlalchemy import UniqueConstraint
 import uuid
 import os
 import base64
+import binascii
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from cryptography.hazmat.primitives import padding
 from cryptography.hazmat.backends import default_backend
@@ -44,7 +45,10 @@ class User(db.Model, UserMixin):
     def check_password(self, pw):
         if not self.password_hash:
             return False
-        return self._decrypt(self.password_hash) == pw
+        try:
+            return self._decrypt(self.password_hash) == pw
+        except (ValueError, binascii.Error):
+            return False
 
 class Tournament(db.Model):
     id = db.Column(db.Integer, primary_key=True)


### PR DESCRIPTION
## Summary
- Guard decryption in `User.check_password` against invalid padding or base64 errors so the admin panel doesn't crash when revealing the password seed.

## Testing
- `python -m py_compile app/models.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a8c04ff6fc8320a2081f5027c2d5fe

## Summary by Sourcery

Bug Fixes:
- Handle invalid padding and base64 decoding errors in User.check_password by catching ValueError and binascii.Error and returning False