### PR TITLE
Add tournament passcodes and salted passwords

### DIFF
--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -13,6 +13,7 @@
       {% endfor %}
     </select>
   </label><br>
+  <label>Tournament Passcode <input name="passcode" maxlength="4"></label><br>
   <button class="btn" type="submit">Create Account</button>
 </form>
 {% endblock %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -2,18 +2,24 @@
 {% block content %}
 <h2>{{ t.name }}</h2>
 <p>Format: {{ t.format }} | Cut: {{ t.cut|upper }}</p>
+{% if show_passcode %}
+<p>Tournament Passcode: {{ t.passcode }}</p>
+{% endif %}
 {% include 'tournament/_timer_bar.html' %}
 {% set round_limit = t.rounds_override or rec_rounds %}
 {% set current_rounds = rounds|length %}
 <div class="toolbar">
   <button class="btn" onclick="window.print()">Print</button>
+  {% if not is_player %}
   <form method="post" action="{{ url_for('join_tournament', tid=t.id) }}">
     {% if current_user.is_authenticated %}
+      <input type="text" name="passcode" maxlength="4" pattern="\d{4}" placeholder="Passcode" required>
       <button class="btn" type="submit">Join</button>
     {% else %}
       <a class="btn" href="{{ url_for('login') }}">Login to Join</a>
     {% endif %}
   </form>
+  {% endif %}
   <a class="btn" href="{{ url_for('standings', tid=t.id) }}">Standings</a>
   {% if t.cut.startswith('top') %}
   <a class="btn" href="{{ url_for('bracket', tid=t.id) }}">Bracket</a>

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -2,8 +2,9 @@
 # Installs dependencies, initializes the database, creates an admin user,
 # and starts the Flask development server.
 param(
+        [string]$DatabasePath,
         [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]    
+        [System.Management.Automation.Credential()]
         $PasswordSeed
 )
 
@@ -30,6 +31,13 @@ if($null -eq $PasswordSeed){
 
 # Configure password seed for AES encryption
 $env:PASSWORD_SEED = $PasswordSeed.UserName
+
+# Determine database path
+if([string]::IsNullOrEmpty($DatabasePath)){
+    $timestamp = Get-Date -Format "yyyyMMddHHmmss"
+    $DatabasePath = "mtg_tournament_$timestamp.db"
+}
+$env:MTG_DB_PATH = $DatabasePath
 
 Write-Host "Installing dependencies..."
 python -m pip install -r "$PSScriptRoot/requirements.txt" | Out-Null

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+DB_FILE="$1"
+if [ -z "$DB_FILE" ]; then
+  DB_FILE="mtg_tournament_$(date +%Y%m%d%H%M%S).db"
+fi
+export MTG_DB_PATH="$DB_FILE"
+export FLASK_APP=app.app:app
+python -m pip install -r requirements.txt >/dev/null
+python -m flask db-init
+python -m flask create-admin --email admin@example.com --password admin123
+flask --app app.app run --debug


### PR DESCRIPTION
## Summary
- hash passwords with per-user salt
- require a 4-digit tournament passcode to join and show it to participants and admins
- refuse pairing rounds when a tournament has no players
- fix admin panel CPU and database size metrics
- create new timestamped database unless a path is provided to the start script

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8c385d5fc832097d0a6ffc0fd3c6f