### PR TITLE
Introduce role-based permissions and configurable admin credentials

### DIFF
--- a/app/templates/admin/permissions.html
+++ b/app/templates/admin/permissions.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Permissions</h2>
+<table class="table">
+  <tr><th>Role</th><th>Granted Permissions</th></tr>
+  {% for role in roles %}
+  <tr>
+    <td>{{ role.name }}</td>
+    <td>
+      {% for key, val in role.permissions_dict().items() %}
+        {% if val %}<div>{{ key }}</div>{% endif %}
+      {% endfor %}
+    </td>
+  </tr>
+  {% endfor %}
+</table>
+<h3>Create Role</h3>
+<form method="post">
+  <input type="text" name="name" placeholder="Role name" required><br>
+  {% for cat, perms in permission_groups.items() %}
+  <fieldset>
+    <legend>{{ cat|capitalize }}</legend>
+    {% for perm, desc in perms.items() %}
+    <label><input type="checkbox" name="{{ cat }}.{{ perm }}"> {{ desc }}</label><br>
+    {% endfor %}
+  </fieldset>
+  {% endfor %}
+  <button class="btn" type="submit">Create</button>
+</form>
+{% endblock %}

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -10,6 +10,11 @@
       <form method="post" action="{{ url_for('admin_update_user', uid=u.id) }}">
         <input type="email" name="email" value="{{ u.email or '' }}"><br>
         <textarea name="notes" rows="2" cols="20">{{ u.notes or '' }}</textarea><br>
+        <select name="role_id">
+          {% for r in roles %}
+          <option value="{{ r.id }}" {% if u.role_id == r.id %}selected{% endif %}>{{ r.name }}</option>
+          {% endfor %}
+        </select><br>
         <button class="btn" type="submit">Save</button>
       </form>
     </td>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -13,12 +13,19 @@
       {% if current_user.is_authenticated %}
         <span>Hi, {{ current_user.name }}</span>
         <a href="{{ url_for('index') }}">All Tournaments</a>
-        {% if current_user.is_admin %}
+        {% if current_user.has_permission('tournaments.manage') %}
         <a href="{{ url_for('new_tournament') }}">New Tournament</a>
         <a href="{{ url_for('admin_register_player') }}">Register Player</a>
         <a href="{{ url_for('admin_bulk_register') }}">Bulk Register Players</a>
+        {% endif %}
+        {% if current_user.has_permission('users.manage') %}
         <a href="{{ url_for('admin_users') }}">Manage Users</a>
+        {% endif %}
+        {% if current_user.has_permission('admin.panel') %}
         <a href="{{ url_for('admin_panel') }}">Admin Panel</a>
+        {% endif %}
+        {% if current_user.has_permission('admin.permissions') %}
+        <a href="{{ url_for('permissions') }}">Permissions</a>
         {% endif %}
         <a href="{{ url_for('logout') }}">Logout</a>
       {% else %}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Tournaments</h2>
-<p><a class="btn" href="{{ url_for('new_tournament') }}" {% if not current_user.is_authenticated or not current_user.is_admin %}style="display:none"{% endif %}>Create Tournament</a></p>
+<p><a class="btn" href="{{ url_for('new_tournament') }}" {% if not current_user.is_authenticated or not current_user.has_permission('tournaments.manage') %}style="display:none"{% endif %}>Create Tournament</a></p>
 <ul class="cards">
   {% for t in tournaments %}
     <li class="card">
@@ -14,11 +14,11 @@
       {% if end %}
       <div>Timer: <span class="timer" data-timer-end="{{ end.isoformat() }}Z" data-tournament-id="{{ t.id }}" data-tournament-name="{{ t.name }}"{% if ttype %} data-timer-type="{{ ttype }}"{% endif %}></span></div>
       {% endif %}
-      {% if current_user.is_authenticated and current_user.is_admin %}
-      <a class="btn" href="{{ url_for('edit_tournament', tid=t.id) }}">Edit</a>
-      <form method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');">
-        <button class="btn" type="submit">Delete</button>
-      </form>
+      {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+        <a class="btn" href="{{ url_for('edit_tournament', tid=t.id) }}">Edit</a>
+        <form method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');">
+          <button class="btn" type="submit">Delete</button>
+        </form>
       {% endif %}
     </li>
   {% else %}

--- a/app/templates/tournament/_timer_bar.html
+++ b/app/templates/tournament/_timer_bar.html
@@ -1,7 +1,7 @@
 <div class="timer-bar">
   <span class="timer"{% if timer_end %} data-timer-end="{{ timer_end.isoformat() }}Z"{% endif %}
         data-tournament-id="{{ t.id }}" data-tournament-name="{{ t.name }}"{% if timer_type %} data-timer-type="{{ timer_type }}"{% endif %}{% if timer_remaining %} data-timer-remaining="{{ timer_remaining }}"{% endif %}></span>
-  {% if current_user.is_authenticated and current_user.is_admin %}
+  {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
     <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='round') }}" style="display:inline;">
       <button class="btn" type="submit">Start Round</button>
     </form>

--- a/app/templates/tournament/round.html
+++ b/app/templates/tournament/round.html
@@ -3,7 +3,7 @@
 <p><a href="{{ url_for('view_tournament', tid=t.id) }}">Back to Tournament</a></p>
 <h2>{{ t.name }} — Round {{ r.number }}</h2>
 {% include 'tournament/_timer_bar.html' %}
-{% if current_user.is_authenticated and current_user.is_admin %}
+{% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
 <form method="post" action="{{ url_for('repair_round', tid=t.id, rid=r.id) }}" style="display:inline;">
   <button class="btn" type="submit">Re-pair</button>
 </form>
@@ -42,14 +42,14 @@
             {% if m.result.is_draw %}Draw{% else %}Placings: {{ m.result.p1_place }}{% if m.player2_id %}, {{ m.result.p2_place }}{% endif %}{% if m.player3_id %}, {{ m.result.p3_place }}{% endif %}{% if m.player4_id %}, {{ m.result.p4_place }}{% endif %}{% endif %}
             {% if not locked %}
               {% set ids = [m.player1.user_id, m.player2.user_id if m.player2_id else None, m.player3.user_id if m.player3_id else None, m.player4.user_id if m.player4_id else None] %}
-              {% if current_user.is_authenticated and (current_user.is_admin or current_user.id in ids) %}
+              {% if current_user.is_authenticated and (current_user.has_permission('tournaments.manage') or current_user.id in ids) %}
                 <a href="{{ url_for('report_match', mid=m.id) }}">Edit</a>
               {% endif %}
             {% endif %}
           {% else %}
             {% if not locked %}
               {% set ids = [m.player1.user_id, m.player2.user_id if m.player2_id else None, m.player3.user_id if m.player3_id else None, m.player4.user_id if m.player4_id else None] %}
-              {% if current_user.is_authenticated and (current_user.is_admin or current_user.id in ids) %}
+              {% if current_user.is_authenticated and (current_user.has_permission('tournaments.manage') or current_user.id in ids) %}
                 <a href="{{ url_for('report_match', mid=m.id) }}">Report</a>
               {% endif %}
             {% endif %}
@@ -62,12 +62,12 @@
               Win by BYE
             {% endif %}
             {% if not locked %}
-              {% if current_user.is_authenticated and (current_user.is_admin or current_user.id in (m.player1.user_id, m.player2.user_id or -1)) %}
+              {% if current_user.is_authenticated and (current_user.has_permission('tournaments.manage') or current_user.id in (m.player1.user_id, m.player2.user_id or -1)) %}
                 <a href="{{ url_for('report_match', mid=m.id) }}">Edit</a>
               {% endif %}
             {% endif %}
           {% else %}
-            {% if not locked and current_user.is_authenticated and (current_user.is_admin or current_user.id in (m.player1.user_id, m.player2.user_id or -1)) %}
+            {% if not locked and current_user.is_authenticated and (current_user.has_permission('tournaments.manage') or current_user.id in (m.player1.user_id, m.player2.user_id or -1)) %}
               <a href="{{ url_for('report_match', mid=m.id) }}">Report</a>
             {% endif %}
           {% endif %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -24,7 +24,7 @@
   {% if t.cut.startswith('top') %}
   <a class="btn" href="{{ url_for('bracket', tid=t.id) }}">Bracket</a>
   {% endif %}
-  {% if current_user.is_authenticated and current_user.is_admin %}
+  {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
     {% if current_rounds < round_limit or t.cut.startswith('top') %}
     <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}">
       <button class="btn" type="submit">Pair</button>

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -3,6 +3,9 @@
 # and starts the Flask development server.
 param(
         [string]$DatabasePath,
+        [string]$AdminEmail = "admin@example.com",
+        [string]$AdminPassword = "admin123",
+        [string]$FlaskSecret = "dev-secret-change-me",
         [System.Management.Automation.PSCredential]
         [System.Management.Automation.Credential()]
         $PasswordSeed
@@ -32,6 +35,9 @@ if($null -eq $PasswordSeed){
 # Configure password seed for AES encryption
 $env:PASSWORD_SEED = $PasswordSeed.UserName
 
+# Configure Flask secret
+$env:FLASK_SECRET = $FlaskSecret
+
 # Determine database path
 if([string]::IsNullOrEmpty($DatabasePath)){
     $timestamp = Get-Date -Format "yyyyMMddHHmmss"
@@ -49,7 +55,7 @@ Write-Host "Initializing database..."
 python -m flask --app app.app db-init
 
 Write-Host "Creating default admin user..."
-python -m flask --app app.app create-admin --email admin@example.com --password admin123
+python -m flask --app app.app create-admin --email $AdminEmail --password $AdminPassword
 
 Write-Host "Starting Flask development server..."
 #python -m flask --app app.app run --debug

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,11 +1,26 @@
 #!/bin/bash
 DB_FILE="$1"
+ADMIN_EMAIL="$2"
+ADMIN_PASS="$3"
+SECRET="$4"
+
 if [ -z "$DB_FILE" ]; then
   DB_FILE="mtg_tournament_$(date +%Y%m%d%H%M%S).db"
 fi
+if [ -z "$ADMIN_EMAIL" ]; then
+  ADMIN_EMAIL="admin@example.com"
+fi
+if [ -z "$ADMIN_PASS" ]; then
+  ADMIN_PASS="admin123"
+fi
+if [ -z "$SECRET" ]; then
+  SECRET="dev-secret-change-me"
+fi
+
 export MTG_DB_PATH="$DB_FILE"
 export FLASK_APP=app.app:app
+export FLASK_SECRET="$SECRET"
 python -m pip install -r requirements.txt >/dev/null
 python -m flask db-init
-python -m flask create-admin --email admin@example.com --password admin123
+python -m flask create-admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASS"
 flask --app app.app run --debug


### PR DESCRIPTION
## Summary
- allow specifying admin credentials and Flask secret in server scripts
- add Role model with grouped permissions and default admin/manager/user roles
- let admins manage roles and user access via new permissions page and updated user management

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8c7d0517c8320b049e421bec271d5

## Summary by Sourcery

Introduce a role-based permission system and make admin credentials and Flask secret configurable, replacing hardcoded is_admin checks with granular permission enforcement and adding UI for managing roles and user access

New Features:
- Introduce a Role model with permission groups and default roles (admin, manager, user)
- Add a permissions management page to view and create roles with configurable permissions
- Allow specifying admin email, admin password, and Flask secret via start-server scripts
- Seed default roles and create an initial admin user during database initialization

Enhancements:
- Replace is_admin checks with granular has_permission checks on routes and templates
- Add a role assignment dropdown to the user management UI for assigning roles to users