### PR TITLE
Add YAML config and logging with tournament join permission

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -12,6 +12,7 @@ import json
 PERMISSION_GROUPS = {
     'tournaments': {
         'manage': 'Create and manage tournaments',
+        'join': 'Join tournaments',
     },
     'users': {
         'manage': 'Manage users',
@@ -38,7 +39,9 @@ DEFAULT_ROLE_PERMISSIONS = {
         'tournaments.manage': True,
         'users.manage': True,
     },
-    'user': {},
+    'user': {
+        'tournaments.join': True,
+    },
 }
 
 
@@ -102,6 +105,26 @@ class Tournament(db.Model):
     draft_timer_remaining = db.Column(db.Integer, nullable=True)
     deck_timer_remaining = db.Column(db.Integer, nullable=True)
     passcode = db.Column(db.String(4), nullable=False, default=lambda: f"{random.randint(0,9999):04d}")
+
+class SiteLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    action = db.Column(db.String(200), nullable=False)
+    result = db.Column(db.String(200), nullable=False)
+    error = db.Column(db.Text, nullable=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    user = db.relationship('User')
+
+class TournamentLog(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    tournament_id = db.Column(db.Integer, db.ForeignKey('tournament.id'), nullable=False)
+    action = db.Column(db.String(200), nullable=False)
+    result = db.Column(db.String(200), nullable=False)
+    error = db.Column(db.Text, nullable=True)
+    timestamp = db.Column(db.DateTime, default=datetime.utcnow)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    user = db.relationship('User')
+    tournament = db.relationship('Tournament', backref=db.backref('logs', cascade='all, delete-orphan'))
 
 class TournamentPlayer(db.Model):
     id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/admin/site_logs.html
+++ b/app/templates/admin/site_logs.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Site Logs</h2>
+<table>
+  <tr><th>Time</th><th>User</th><th>Action</th><th>Result</th><th>Error</th></tr>
+  {% for l in logs %}
+  <tr>
+    <td>{{ l.timestamp }}</td>
+    <td>{{ l.user.name if l.user else '' }}</td>
+    <td>{{ l.action }}</td>
+    <td>{{ l.result }}</td>
+    <td>{{ l.error or '' }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,6 +23,7 @@
         {% endif %}
         {% if current_user.has_permission('admin.panel') %}
         <a href="{{ url_for('admin_panel') }}">Admin Panel</a>
+        <a href="{{ url_for('site_logs') }}">Site Logs</a>
         {% endif %}
         {% if current_user.has_permission('admin.permissions') %}
         <a href="{{ url_for('permissions') }}">Permissions</a>

--- a/app/templates/tournament/logs.html
+++ b/app/templates/tournament/logs.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>{{ t.name }} Logs</h2>
+<table>
+  <tr><th>Time</th><th>User</th><th>Action</th><th>Result</th><th>Error</th></tr>
+  {% for l in logs %}
+  <tr>
+    <td>{{ l.timestamp }}</td>
+    <td>{{ l.user.name if l.user else '' }}</td>
+    <td>{{ l.action }}</td>
+    <td>{{ l.result }}</td>
+    <td>{{ l.error or '' }}</td>
+  </tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -37,6 +37,7 @@
     {% if t.format == 'Draft' %}
     <a class="btn" href="{{ url_for('draft_seating', tid=t.id) }}">Draft Seating</a>
     {% endif %}
+    <a class="btn" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
   {% endif %}
 </div>
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+db_file: mtg_tournament.db
+admin_email: admin@example.com
+admin_pass: admin123
+secret: dev-secret-change-me

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
 cryptography==42.0.7
 psutil==5.9.8
+PyYAML==6.0.1

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -1,16 +1,24 @@
 # PowerShell script to set up and run the MTG Tournament Swiss App.
 # Installs dependencies, initializes the database, creates an admin user,
 # and starts the Flask development server.
-param(
-        [string]$DatabasePath,
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        [string]$newadmin,
-        [string]$FlaskSecret = "dev-secret-change-me",
-        [System.Management.Automation.PSCredential]
-        [System.Management.Automation.Credential()]
-        $PasswordSeed
-)
+# Load settings from YAML config
+$configPath = Join-Path $PSScriptRoot "config.yaml"
+if(!(Test-Path $configPath)){
+    Write-Error "Missing config.yaml"
+    exit 1
+}
+
+try{
+    $cfg = Get-Content $configPath | ConvertFrom-Yaml
+}catch{
+    Write-Error "Failed to parse config.yaml"
+    exit 1
+}
+
+$DatabasePath = $cfg.db_file
+$FlaskSecret = $cfg.secret
+$PasswordSeed = New-Object System.Management.Automation.PSCredential("dev-password-seed-change-me", (ConvertTo-SecureString "dev-password-seed-change-me" -AsPlainText -Force))
+$newadmin = New-Object System.Management.Automation.PSCredential($cfg.admin_email, (ConvertTo-SecureString $cfg.admin_pass -AsPlainText -Force))
 
 #check if Flask is already running and stop it if necessary
 $flaskpid = try{

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,8 +1,22 @@
 #!/bin/bash
-DB_FILE="$1"
-ADMIN_EMAIL="$2"
-ADMIN_PASS="$3"
-SECRET="$4"
+CONFIG_FILE="config.yaml"
+if [ ! -f "$CONFIG_FILE" ]; then
+  echo "Missing $CONFIG_FILE"
+  exit 1
+fi
+
+read_yaml() {
+  python - <<PY
+import yaml,sys
+cfg=yaml.safe_load(open(sys.argv[1]))
+print(cfg.get(sys.argv[2],''))
+PY
+}
+
+DB_FILE=$(read_yaml "$CONFIG_FILE" db_file)
+ADMIN_EMAIL=$(read_yaml "$CONFIG_FILE" admin_email)
+ADMIN_PASS=$(read_yaml "$CONFIG_FILE" admin_pass)
+SECRET=$(read_yaml "$CONFIG_FILE" secret)
 
 if [ -z "$DB_FILE" ]; then
   DB_FILE="mtg_tournament_$(date +%Y%m%d%H%M%S).db"


### PR DESCRIPTION
## Summary
- Load server settings from new `config.yaml`
- Track site and tournament actions with log pages
- Require `tournaments.join` permission and prevent admin self-demotion

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a8cd8b537c8320ae56bb740edaee51

## Summary by Sourcery

Add YAML configuration for the server and startup scripts, introduce site and tournament action logging with admin log viewer pages, enforce a new tournaments.join permission, and prevent administrators from demoting themselves.

New Features:
- Load application and startup settings from config.yaml
- Add SiteLog and TournamentLog models with corresponding logging calls and admin log viewer pages
- Enforce a new tournaments.join permission for joining tournaments

Bug Fixes:
- Prevent administrators from demoting their own admin role

Build:
- Add PyYAML dependency and update PowerShell and shell startup scripts to parse config.yaml