### PR TITLE
Separate log database and expand logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@
    # Optional: set a seed for AES password encryption
    set PASSWORD_SEED=some-random-string     (Windows)
    export PASSWORD_SEED=some-random-string  (macOS/Linux)
+   # Optional: specify a separate SQLite database file for logs
+   set MTG_LOG_DB_PATH=mtg_logs.db          (Windows)
+   export MTG_LOG_DB_PATH=mtg_logs.db       (macOS/Linux)
 
 3) Initialize the DB (creates a default admin user `admin@example.com` / `admin123`):
    flask --app app.app db-init

--- a/app/models.py
+++ b/app/models.py
@@ -107,24 +107,25 @@ class Tournament(db.Model):
     passcode = db.Column(db.String(4), nullable=False, default=lambda: f"{random.randint(0,9999):04d}")
 
 class SiteLog(db.Model):
+    __bind_key__ = 'logs'
     id = db.Column(db.Integer, primary_key=True)
     action = db.Column(db.String(200), nullable=False)
     result = db.Column(db.String(200), nullable=False)
     error = db.Column(db.Text, nullable=True)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
-    user = db.relationship('User')
+    user_id = db.Column(db.Integer, nullable=True)
+    # relationship loaded manually to avoid cross-db foreign key
 
 class TournamentLog(db.Model):
+    __bind_key__ = 'logs'
     id = db.Column(db.Integer, primary_key=True)
-    tournament_id = db.Column(db.Integer, db.ForeignKey('tournament.id'), nullable=False)
+    tournament_id = db.Column(db.Integer, nullable=False)
     action = db.Column(db.String(200), nullable=False)
     result = db.Column(db.String(200), nullable=False)
     error = db.Column(db.Text, nullable=True)
     timestamp = db.Column(db.DateTime, default=datetime.utcnow)
-    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
-    user = db.relationship('User')
-    tournament = db.relationship('Tournament', backref=db.backref('logs', cascade='all, delete-orphan'))
+    user_id = db.Column(db.Integer, nullable=True)
+    # relationship loaded manually to avoid cross-db foreign key
 
 class TournamentPlayer(db.Model):
     id = db.Column(db.Integer, primary_key=True)


### PR DESCRIPTION
## Summary
- Store site and tournament logs in their own SQLite database
- Track admin panel access, role creation, tournament edits, timer actions, pairing, drops, and match reports
- Document log database configuration via `MTG_LOG_DB_PATH`

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8d5ebdb408320b6f964b08c7e3b1a