### PR TITLE
Add configurable log DB and server settings

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -25,7 +25,7 @@ PASSWORD_SEED = None
 def create_app():
     app = Flask(__name__)
     db_file = os.environ.get('MTG_DB_PATH', 'mtg_tournament.db')
-    log_db_file = os.environ.get('MTG_LOG_DB_PATH', 'mtg_logs.db')
+    log_db_file = os.environ.get('MTG_LOG_DB_PATH', db_file.replace('.db', '_logs.db'))
     app.config['SQLALCHEMY_DATABASE_URI'] = f'sqlite:///{db_file}'
     app.config['SQLALCHEMY_BINDS'] = {'logs': f'sqlite:///{log_db_file}'}
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,8 @@
 db_file: mtg_tournament.db
+log_db_file: mtg_tournament_logs.db
 admin_email: admin@example.com
 admin_pass: admin123
-secret: dev-secret-change-me
+flask_secret: dev-secret-change-me
+password_seed: dev-password-seed-change-me
+flask_ip: 127.0.0.1
+flask_port: 5000

--- a/start-server.sh
+++ b/start-server.sh
@@ -13,13 +13,23 @@ print(cfg.get(sys.argv[2],''))
 PY
 }
 
+DEFAULT_DB_FILE="mtg_tournament.db"
+DEFAULT_LOG_DB_FILE="mtg_tournament_logs.db"
+
 DB_FILE=$(read_yaml "$CONFIG_FILE" db_file)
+LOG_DB_FILE=$(read_yaml "$CONFIG_FILE" log_db_file)
 ADMIN_EMAIL=$(read_yaml "$CONFIG_FILE" admin_email)
 ADMIN_PASS=$(read_yaml "$CONFIG_FILE" admin_pass)
-SECRET=$(read_yaml "$CONFIG_FILE" secret)
+FLASK_SECRET=$(read_yaml "$CONFIG_FILE" flask_secret)
+PASSWORD_SEED=$(read_yaml "$CONFIG_FILE" password_seed)
+FLASK_IP=$(read_yaml "$CONFIG_FILE" flask_ip)
+FLASK_PORT=$(read_yaml "$CONFIG_FILE" flask_port)
 
 if [ -z "$DB_FILE" ]; then
-  DB_FILE="mtg_tournament_$(date +%Y%m%d%H%M%S).db"
+  DB_FILE="$DEFAULT_DB_FILE"
+fi
+if [ -z "$LOG_DB_FILE" ]; then
+  LOG_DB_FILE="$DEFAULT_LOG_DB_FILE"
 fi
 if [ -z "$ADMIN_EMAIL" ]; then
   ADMIN_EMAIL="admin@example.com"
@@ -27,14 +37,35 @@ fi
 if [ -z "$ADMIN_PASS" ]; then
   ADMIN_PASS="admin123"
 fi
-if [ -z "$SECRET" ]; then
-  SECRET="dev-secret-change-me"
+if [ -z "$FLASK_SECRET" ]; then
+  FLASK_SECRET="dev-secret-change-me"
+fi
+if [ -z "$PASSWORD_SEED" ]; then
+  PASSWORD_SEED="dev-password-seed-change-me"
+fi
+if [ -z "$FLASK_IP" ]; then
+  FLASK_IP="127.0.0.1"
+fi
+if [ -z "$FLASK_PORT" ]; then
+  FLASK_PORT="5000"
+fi
+
+if [ "$DB_FILE" = "$DEFAULT_DB_FILE" ]; then
+  TS=$(date +%Y%m%d%H%M%S)
+  DB_FILE="mtg_tournament_${TS}.db"
+  LOG_DB_FILE="mtg_tournament_logs_${TS}.db"
+elif [ "$LOG_DB_FILE" = "$DEFAULT_LOG_DB_FILE" ]; then
+  LOG_DB_FILE="${DB_FILE%.db}_logs.db"
 fi
 
 export MTG_DB_PATH="$DB_FILE"
+export MTG_LOG_DB_PATH="$LOG_DB_FILE"
 export FLASK_APP=app.app:app
-export FLASK_SECRET="$SECRET"
+export FLASK_SECRET="$FLASK_SECRET"
+export PASSWORD_SEED="$PASSWORD_SEED"
+export FLASK_RUN_HOST="$FLASK_IP"
+export FLASK_RUN_PORT="$FLASK_PORT"
 python -m pip install -r requirements.txt >/dev/null
 python -m flask db-init
 python -m flask create-admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASS"
-flask --app app.app run --debug
+flask --app app.app run --debug --host "$FLASK_IP" --port "$FLASK_PORT"


### PR DESCRIPTION
## Summary
- add log DB name, password seed, Flask host and port to config and rename secret to flask_secret
- timestamp log DB to match main database and export new settings in startup scripts
- derive log database path from main DB when not specified

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbad3fd008320b7691907a6f67eda

## Summary by Sourcery

Enable full configurability of the log database file, password seed, and Flask host/port settings, and ensure log DB filenames follow the same timestamping and derivation logic as the main database.

New Features:
- Add configurable `log_db_file` setting with default and timestamped filenames
- Introduce `password_seed`, `flask_ip`, and `flask_port` configuration options and expose them as environment variables
- Rename `secret` config field to `flask_secret`

Enhancements:
- Derive the default log database path from the main database filename when not explicitly provided
- Synchronize timestamping of log database filenames with the main database
- Update PowerShell and Bash startup scripts to support new configuration settings and default fallbacks

Documentation:
- Update `config.yaml` to include new settings for log_db_file, flask_secret, password_seed, flask_ip, and flask_port