### PR TITLE
feat: modernize UI with vibrant color scheme

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1,17 +1,90 @@
-body { font-family: system-ui, sans-serif; margin: 0; padding: 0; }
-header { display:flex; justify-content:space-between; align-items:center; padding: 12px 16px; background:#222; color:#fff; }
-header a { color: #9ad; text-decoration:none; margin-left: 12px; }
+/* Color palette */
+:root {
+  --burnt-orange: #cc5500;
+  --light-green: #a8e6a1;
+  --dark-grey: #333333;
+  --creamy-yellow: #fff8e1;
+}
+
+body {
+  font-family: system-ui, sans-serif;
+  margin: 0;
+  padding: 0;
+  background: var(--creamy-yellow);
+  color: var(--dark-grey);
+}
+header {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+  padding: 12px 16px;
+  background: var(--dark-grey);
+  color:#fff;
+}
+header nav {
+  display:flex;
+  gap:12px;
+}
+header a {
+  color: var(--light-green);
+  text-decoration:none;
+  padding:4px 8px;
+  border-radius:6px;
+  transition:background 0.3s;
+}
+header a:hover {
+  background: var(--burnt-orange);
+  color:#fff;
+}
 h1 a { color: #fff; text-decoration:none; }
 main { padding: 16px; }
-.btn { display:inline-block; padding:8px 12px; border-radius:8px; border:1px solid #888; text-decoration:none; }
+.btn {
+  display:inline-block;
+  padding:8px 12px;
+  border-radius:8px;
+  border:1px solid var(--dark-grey);
+  text-decoration:none;
+  background: var(--burnt-orange);
+  color:#fff;
+  transition:background 0.3s, transform 0.2s;
+}
+.btn:hover {
+  background:#b24400;
+  transform:translateY(-2px);
+}
+.btn:active {
+  transform:translateY(0);
+}
 .cards { list-style:none; display:grid; gap:12px; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); padding:0; }
-.card { padding:12px; border:1px solid #ddd; border-radius:12px; background:#fafafa; }
+.card {
+  padding:12px;
+  border:1px solid var(--light-green);
+  border-radius:12px;
+  background:#fff;
+  box-shadow:0 2px 4px rgba(0,0,0,0.1);
+}
 .table { width:100%; border-collapse: collapse; }
-.table th, .table td { border:1px solid #ddd; padding:6px 8px; text-align:center; }
+.table th, .table td {
+  border:1px solid var(--light-green);
+  padding:6px 8px;
+  text-align:center;
+}
 .flashes { list-style:none; padding:0; }
-.flashes li { margin:8px 0; padding:8px; border-radius:8px; }
-.flashes li.success { background:#e8f8ee; border:1px solid #bfe5cb; }
-.flashes li.error { background:#fde8e8; border:1px solid #f3c2c2; }
+.flashes li {
+  margin:8px 0;
+  padding:8px;
+  border-radius:8px;
+}
+.flashes li.success {
+  background:var(--light-green);
+  border:1px solid var(--dark-grey);
+  color:var(--dark-grey);
+}
+.flashes li.error {
+  background:var(--burnt-orange);
+  border:1px solid var(--dark-grey);
+  color:#fff;
+}
 .bracket { display:flex; gap:40px; align-items:flex-start; }
 .round { display:flex; flex-direction:column; gap:20px; }
 .match { position:relative; display:flex; flex-direction:column; gap:4px; padding-right:20px; }
@@ -43,5 +116,18 @@ main { padding: 16px; }
 .players-table { width:100%; border-collapse:collapse; }
 .players-table tbody { display:grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
 .players-table tr { display:contents; }
-.players-table td { border:1px solid #ddd; padding:6px 8px; text-align:center; }
-.centered-form { max-width:400px; margin:0 auto; }
+.players-table td { border:1px solid var(--light-green); padding:6px 8px; text-align:center; }
+.centered-form {
+  max-width:400px;
+  margin:0 auto;
+  background:#fff;
+  padding:16px;
+  border-radius:8px;
+  box-shadow:0 2px 6px rgba(0,0,0,0.1);
+}
+
+input, select, textarea {
+  padding:6px 8px;
+  border:1px solid var(--dark-grey);
+  border-radius:4px;
+}

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -1,7 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Login</h2>
-<form method="post">
+<form method="post" class="centered-form">
   <label>Email <input name="email" type="email" required></label><br>
   <label>Password <input name="password" type="password" required></label><br>
   <button class="btn" type="submit">Login</button>


### PR DESCRIPTION
## Summary
- add burnt orange, light green, dark grey, and creamy yellow palette
- style buttons, navigation, cards, and forms for a more modern look
- apply centered-form styling to login page

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68acbd83cf408320aebc237c93ec9e13