### PR TITLE
feat: improve mobile navigation

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -131,3 +131,33 @@ input, select, textarea {
   border:1px solid var(--dark-grey);
   border-radius:4px;
 }
+
+.menu-toggle {
+  display:none;
+}
+
+@media (max-width: 600px) {
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+  header nav {
+    flex-direction: column;
+    width:100%;
+    gap:8px;
+    margin-top:8px;
+    display:none;
+  }
+  header nav.open {
+    display:flex;
+  }
+  .menu-toggle {
+    display:block;
+    background: var(--burnt-orange);
+    color:#fff;
+    border:none;
+    padding:8px 12px;
+    border-radius:6px;
+    margin-top:8px;
+  }
+}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -9,6 +9,7 @@
 <body>
   <header>
     <h1><a href="{{ url_for('index') }}">WaLTER</a></h1>
+    <button class="menu-toggle" aria-label="Toggle navigation">Menu</button>
     <nav>
       {% if current_user.is_authenticated %}
         <span>Hi, {{ current_user.name }}</span>
@@ -80,6 +81,13 @@
     }
     update();
   });
+  const menuToggle = document.querySelector('.menu-toggle');
+  const nav = document.querySelector('header nav');
+  if(menuToggle && nav){
+    menuToggle.addEventListener('click', function(){
+      nav.classList.toggle('open');
+    });
+  }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add mobile menu toggle to base template
- style header for small screens with responsive CSS

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acbf054cd883208a530e916ce387a4