### PR TITLE
Handle bye results and add stop script

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -901,8 +901,8 @@ def create_app():
                     m.player4.dropped = True
                     dropped_ids.append(m.player4.user_id)
             else:
-                p1_wins = int(request.form['p1_wins'])
-                p2_wins = int(request.form['p2_wins'])
+                p1_wins = int(request.form.get('p1_wins', 2 if m.player2_id is None else 0))
+                p2_wins = int(request.form.get('p2_wins', 0))
                 draws   = int(request.form.get('draws', 0))
                 m.result = MatchResult(player1_wins=p1_wins, player2_wins=p2_wins, draws=draws)
                 m.completed = True

--- a/app/templates/match/report.html
+++ b/app/templates/match/report.html
@@ -16,7 +16,7 @@
     <tbody>
       <tr>
         <td>{{ m.player1.user.name }} place</td>
-        <td><input type="number" name="p1_place" min="1" max="4" value="{{ m.result.p1_place if m.result else '' }}"></td>
+        <td><input type="number" name="p1_place" min="1" max="4" value="{{ m.result.p1_place if m.result else (1 if not m.player2_id else '') }}"></td>
         <td><label><input type="checkbox" name="drop_p1"> Drop</label></td>
       </tr>
       {% if m.player2_id %}
@@ -79,7 +79,14 @@
     </table>
   </form>
   {% else %}
-  <p>BYE — no reporting needed.</p>
+  <form method="post">
+    <p>BYE for {{ m.player1.user.name }}</p>
+    <input type="hidden" name="p1_wins" value="{{ m.result.player1_wins if m.result else 2 }}">
+    <input type="hidden" name="p2_wins" value="{{ m.result.player2_wins if m.result else 0 }}">
+    <input type="hidden" name="draws" value="{{ m.result.draws if m.result else 0 }}">
+    <p><label><input type="checkbox" name="drop_p1"> Drop {{ m.player1.user.name }}</label></p>
+    <button class="btn" type="submit">Submit Result</button>
+  </form>
   {% endif %}
 {% endif %}
 {% endblock %}

--- a/stop-server.ps1
+++ b/stop-server.ps1
@@ -1,0 +1,59 @@
+# PowerShell script to stop the MTG Tournament Swiss App.
+# Terminates the Flask server process and any python process holding
+# an open handle to the SQLite database.
+# Requires the Sysinternals 'handle' utility to check open file handles.
+
+# Load settings from YAML config
+$configPath = Join-Path $PSScriptRoot 'config.yaml'
+if(!(Test-Path $configPath)){
+    Write-Error 'Missing config.yaml'
+    exit 1
+}
+
+try {
+    $pythonScript = @"
+import sys, json
+import yaml
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    data = yaml.safe_load(f)
+print(json.dumps(data))
+"@
+    $cfgJson = & python -c $pythonScript $configPath
+    $cfg = $cfgJson | ConvertFrom-Json
+} catch {
+    Write-Error 'Failed to parse config.yaml'
+    exit 1
+}
+
+$flaskPort = $cfg.flask_port
+$dbPath = Join-Path $PSScriptRoot $cfg.db_file
+
+Write-Host "Stopping server on port $flaskPort"
+
+# Kill flask process listening on the configured port
+$flaskConn = Get-NetTCPConnection -LocalPort $flaskPort -ErrorAction SilentlyContinue | Select-Object -First 1
+if($flaskConn){
+    $proc = Get-Process -Id $flaskConn.OwningProcess -ErrorAction SilentlyContinue
+    if($proc){
+        Write-Host "Terminating Flask process $($proc.Id)"
+        $proc | Stop-Process -Force
+    }
+}
+
+# Kill any python process with handle on the database file
+$pyProcs = Get-Process python -ErrorAction SilentlyContinue
+foreach($p in $pyProcs){
+    $handles = & handle.exe -p $p.Id $dbPath 2>$null
+    if($handles){
+        Write-Host "Terminating Python process $($p.Id) using $dbPath"
+        $p | Stop-Process -Force
+    }
+}
+
+Start-Sleep -Seconds 1
+$remaining = & handle.exe $dbPath 2>$null
+if($remaining){
+    Write-Warning "Database $dbPath is still in use."
+} else {
+    Write-Host "Database $dbPath is quiesced."
+}


### PR DESCRIPTION
## Summary
- Allow bye matches to be reported with default results
- Pre-fill commander bye placements and 1v1 bye game wins
- Provide a PowerShell script to shut down the server and kill processes holding the DB

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b1cef53d388320b85e1920cc032bd7