### PR TITLE
Add initial test suite for user and tournament features

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,28 @@
+import os
+import json
+import pytest
+from app.app import create_app, db
+from app.models import Role, DEFAULT_ROLE_PERMISSIONS
+
+
+@pytest.fixture
+def app(tmp_path, monkeypatch):
+    # use temporary SQLite databases for testing
+    monkeypatch.setenv("MTG_DB_PATH", str(tmp_path / "test.db"))
+    monkeypatch.setenv("MTG_LOG_DB_PATH", str(tmp_path / "test_logs.db"))
+    application = create_app()
+    application.config['TESTING'] = True
+    with application.app_context():
+        db.create_all()
+        # set up default roles
+        for name, perms in DEFAULT_ROLE_PERMISSIONS.items():
+            role = Role(name=name, permissions=json.dumps(perms))
+            db.session.add(role)
+        db.session.commit()
+        yield application
+        db.session.remove()
+
+
+@pytest.fixture
+def session(app):
+    return db.session

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,0 +1,45 @@
+from app.app import db
+from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult
+from app.pairing import swiss_pair_round, compute_standings
+
+
+def test_tournament_create_pairing_standings(session):
+    role_user = session.query(Role).filter_by(name='user').first()
+    # create tournament
+    t = Tournament(name='Test Event', format='Constructed')
+    session.add(t)
+    session.commit()
+
+    # add players
+    players = []
+    for i in range(2):
+        u = User(email=f'p{i}@ex.com', name=f'P{i}', role=role_user)
+        session.add(u)
+        session.commit()
+        tp = TournamentPlayer(tournament_id=t.id, user_id=u.id)
+        session.add(tp)
+        session.commit()
+        players.append(tp)
+
+    # round 1 pairing
+    r1 = Round(tournament_id=t.id, number=1)
+    session.add(r1)
+    session.commit()
+    matches = swiss_pair_round(t, r1, session)
+    assert len(matches) == 1
+
+    # record a result
+    m = matches[0]
+    res = MatchResult(player1_wins=2, player2_wins=0)
+    m.result = res
+    m.completed = True
+    session.commit()
+
+    standings = compute_standings(t, session)
+    points = [row['points'] for row in standings]
+    assert sorted(points) == [0, 3]
+
+    # delete tournament
+    session.delete(t)
+    session.commit()
+    assert session.query(Tournament).count() == 0

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,0 +1,25 @@
+import json
+from app.app import db
+from app.models import User, Role
+
+
+def test_user_crud(session):
+    role_user = session.query(Role).filter_by(name='user').first()
+    # create
+    u = User(email='test@example.com', name='Test', role=role_user)
+    u.set_password('secret')
+    session.add(u)
+    session.commit()
+
+    fetched = session.query(User).filter_by(email='test@example.com').one()
+    assert fetched.check_password('secret')
+
+    # modify
+    fetched.name = 'Updated'
+    session.commit()
+    assert session.get(User, fetched.id).name == 'Updated'
+
+    # delete
+    session.delete(fetched)
+    session.commit()
+    assert session.query(User).count() == 0


### PR DESCRIPTION
## Summary
- set up pytest fixtures with temporary SQLite databases
- add tests covering user create/modify/delete workflow
- add basic tournament test with player pairing, result recording, and standings computation

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b773d52d1c83209e0a974780b67469

## Summary by Sourcery

Add initial pytest-based test suite for user and tournament functionality, including fixture setup, user CRUD tests, and tournament pairing and standings scenarios

Tests:
- Set up pytest fixtures with temporary SQLite databases and default role seeding
- Add user CRUD tests covering creation, password validation, update, and deletion
- Add tournament tests covering creation, Swiss pairing, result recording, standings computation, and cleanup