### PR TITLE
Add scheduling and judge management

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -39,6 +39,14 @@ DEFAULT_ROLE_PERMISSIONS = {
         'tournaments.manage': True,
         'users.manage': True,
     },
+    'venue judge': {
+        'tournaments.manage': True,
+    },
+    'event head judge': {
+        'tournaments.manage': True,
+    },
+    'floor judge': {
+    },
     'user': {
         'tournaments.join': True,
     },
@@ -98,6 +106,11 @@ class Tournament(db.Model):
     round_length = db.Column(db.Integer, default=50)
     draft_time = db.Column(db.Integer, nullable=True)
     deck_build_time = db.Column(db.Integer, nullable=True)
+    # Optional scheduled start time for tournament
+    start_time = db.Column(db.DateTime, nullable=True)
+    # Judge assignments
+    head_judge_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    floor_judges = db.Column(db.Text, default='[]')  # store list of user ids as JSON
     round_timer_end = db.Column(db.DateTime, nullable=True)
     draft_timer_end = db.Column(db.DateTime, nullable=True)
     deck_timer_end = db.Column(db.DateTime, nullable=True)
@@ -105,6 +118,15 @@ class Tournament(db.Model):
     draft_timer_remaining = db.Column(db.Integer, nullable=True)
     deck_timer_remaining = db.Column(db.Integer, nullable=True)
     passcode = db.Column(db.String(4), nullable=False, default=lambda: f"{random.randint(0,9999):04d}")
+
+    head_judge = db.relationship('User', foreign_keys=[head_judge_id])
+
+    def floor_judge_ids(self):
+        """Return list of user IDs assigned as floor judges."""
+        try:
+            return json.loads(self.floor_judges or '[]')
+        except Exception:
+            return []
 
 class SiteLog(db.Model):
     __bind_key__ = 'logs'

--- a/app/templates/admin/edit_tournament.html
+++ b/app/templates/admin/edit_tournament.html
@@ -57,6 +57,10 @@
         <td><input type="number" name="deck_build_time" value="{{ t.deck_build_time or '' }}"></td>
       </tr>
       <tr>
+        <td>Start Time</td>
+        <td><input type="datetime-local" name="start_time" value="{{ t.start_time.strftime('%Y-%m-%dT%H:%M') if t.start_time else '' }}"></td>
+      </tr>
+      <tr>
         <td colspan="2"><button class="btn" type="submit">Save</button></td>
       </tr>
     </tbody>

--- a/app/templates/admin/judges.html
+++ b/app/templates/admin/judges.html
@@ -1,0 +1,21 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Assign Judges for {{ t.name }}</h2>
+<form method="post">
+  <div>
+    <label>Head Judge:
+      <select name="head_judge">
+        <option value="">-- None --</option>
+        {% for u in users %}
+        <option value="{{ u.id }}"{% if t.head_judge_id==u.id %} selected{% endif %}>{{ u.name }}</option>
+        {% endfor %}
+      </select>
+    </label>
+  </div>
+  <h3>Floor Judges</h3>
+  {% for u in users %}
+    <label><input type="checkbox" name="floor_judges" value="{{ u.id }}"{% if u.id in floor_set %} checked{% endif %}> {{ u.name }}</label><br>
+  {% endfor %}
+  <button class="btn" type="submit">Save</button>
+</form>
+{% endblock %}

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -57,6 +57,10 @@
         <td><input type="number" name="deck_build_time"></td>
       </tr>
       <tr>
+        <td>Start Time</td>
+        <td><input type="datetime-local" name="start_time"></td>
+      </tr>
+      <tr>
         <td colspan="2"><button class="btn" type="submit">Create</button></td>
       </tr>
     </tbody>

--- a/app/templates/admin/schedule.html
+++ b/app/templates/admin/schedule.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Tournament Schedule</h2>
+<table class="table center-table">
+  <thead><tr><th>Name</th><th>Start</th><th>End (estimated)</th></tr></thead>
+  <tbody>
+  {% for e in entries %}
+    <tr>
+      <td>{{ e.t.name }}</td>
+      <td>{{ e.start if e.start else 'N/A' }}</td>
+      <td>{{ e.end if e.end else 'N/A' }}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endblock %}

--- a/app/templates/admin/staff.html
+++ b/app/templates/admin/staff.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Staff Management</h2>
+{% for item in data %}
+  <h3>{{ item.t.name }}</h3>
+  <p>Head Judge: {{ item.head.name if item.head else 'None' }}</p>
+  <p>Floor Judges:
+    {% if item.floor %}
+      {% for u in item.floor %}{{ u.name }}{% if not loop.last %}, {% endif %}{% endfor %}
+    {% else %}None{% endif %}
+  </p>
+{% endfor %}
+{% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -18,6 +18,8 @@
         <a href="{{ url_for('new_tournament') }}">New Tournament</a>
         <a href="{{ url_for('admin_register_player') }}">Register Player</a>
         <a href="{{ url_for('admin_bulk_register') }}">Bulk Register Players</a>
+        <a href="{{ url_for('staff_management') }}">Staff</a>
+        <a href="{{ url_for('schedule') }}">Schedule</a>
         {% endif %}
         {% if current_user.has_permission('users.manage') %}
         <a href="{{ url_for('admin_users') }}">Manage Users</a>
@@ -57,29 +59,46 @@
   }
   const typeLabels = {round:'round', draft:'draft', deck:'deck building'};
   document.querySelectorAll('.timer').forEach(function(el){
-    function update(){
-      if(el.dataset.timerEnd){
-        const end = new Date(el.dataset.timerEnd);
-        const diff = end - new Date();
-        if(diff <= 0){
-          el.textContent = '00:00';
-          const key = 'alerted_' + (el.dataset.tournamentId||'') + '_' + (el.dataset.timerType||'') + '_' + el.dataset.timerEnd;
-          if(!localStorage.getItem(key)){
-            const label = typeLabels[el.dataset.timerType] || '';
-            alert('Time has elapsed for ' + (el.dataset.tournamentName||'') + ' ' + label + ' timer');
-            localStorage.setItem(key, '1');
-          }
-        }else{
-          el.textContent = formatTime(Math.floor(diff/1000));
-          setTimeout(update,1000);
-        }
-      }else if(el.dataset.timerRemaining){
-        el.textContent = formatTime(parseInt(el.dataset.timerRemaining));
+    let remaining = null;
+    let countdown = true;
+    if(el.dataset.timerEnd){
+      const end = new Date(el.dataset.timerEnd);
+      if(el.dataset.serverNow){
+        const serverNow = new Date(el.dataset.serverNow);
+        remaining = Math.floor((end - serverNow)/1000);
       }else{
+        remaining = Math.floor((end - new Date())/1000);
+      }
+    }else if(el.dataset.timerRemaining){
+      remaining = parseInt(el.dataset.timerRemaining);
+      countdown = false;
+    }
+    function tick(){
+      if(remaining === null){
         el.textContent = '00:00';
+        return;
+      }
+      if(remaining <= 0){
+        el.textContent = '00:00';
+        const key = 'alerted_' + (el.dataset.tournamentId||'') + '_' + (el.dataset.timerType||'') + '_' + (el.dataset.timerEnd||'');
+        if(!localStorage.getItem(key)){
+          const label = typeLabels[el.dataset.timerType] || '';
+          alert('Time has elapsed for ' + (el.dataset.tournamentName||'') + ' ' + label + ' timer');
+          localStorage.setItem(key, '1');
+        }
+      }else{
+        el.textContent = formatTime(remaining);
+        remaining -= 1;
+        setTimeout(tick,1000);
       }
     }
-    update();
+    if(countdown){
+      tick();
+    }else if(remaining !== null){
+      el.textContent = formatTime(remaining);
+    }else{
+      el.textContent = '00:00';
+    }
   });
   const menuToggle = document.querySelector('.menu-toggle');
   const nav = document.querySelector('header nav');

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,7 +12,7 @@
       {% set end = t.round_timer_end or t.draft_timer_end or t.deck_timer_end %}
       {% if t.round_timer_end %}{% set ttype = 'round' %}{% elif t.draft_timer_end %}{% set ttype = 'draft' %}{% elif t.deck_timer_end %}{% set ttype = 'deck' %}{% endif %}
       {% if end %}
-      <div>Timer: <span class="timer" data-timer-end="{{ end.isoformat() }}Z" data-tournament-id="{{ t.id }}" data-tournament-name="{{ t.name }}"{% if ttype %} data-timer-type="{{ ttype }}"{% endif %}></span></div>
+      <div>Timer: <span class="timer" data-timer-end="{{ end.isoformat() }}Z" data-server-now="{{ server_now.isoformat() }}Z" data-tournament-id="{{ t.id }}" data-tournament-name="{{ t.name }}"{% if ttype %} data-timer-type="{{ ttype }}"{% endif %}></span></div>
       {% endif %}
       {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
         <a class="btn" href="{{ url_for('edit_tournament', tid=t.id) }}">Edit</a>

--- a/app/templates/tournament/_timer_bar.html
+++ b/app/templates/tournament/_timer_bar.html
@@ -1,5 +1,5 @@
 <div class="timer-bar">
-  <span class="timer"{% if timer_end %} data-timer-end="{{ timer_end.isoformat() }}Z"{% endif %}
+  <span class="timer"{% if timer_end %} data-timer-end="{{ timer_end.isoformat() }}Z" data-server-now="{{ server_now.isoformat() }}Z"{% endif %}
         data-tournament-id="{{ t.id }}" data-tournament-name="{{ t.name }}"{% if timer_type %} data-timer-type="{{ timer_type }}"{% endif %}{% if timer_remaining %} data-timer-remaining="{{ timer_remaining }}"{% endif %}></span>
   {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
     <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='round') }}" style="display:inline;">

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -2,6 +2,15 @@
 {% block content %}
 <h2>{{ t.name }}</h2>
 <p>Format: {{ t.format }} | Cut: {{ t.cut|upper }}</p>
+<p>Head Judge: {{ t.head_judge.name if t.head_judge else 'None' }}</p>
+<p>Floor Judges:
+  {% if floor_judges %}
+    {% for u in floor_judges %}{{ u.name }}{% if not loop.last %}, {% endif %}{% endfor %}
+  {% else %}None{% endif %}
+</p>
+{% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+<p><a class="btn" href="{{ url_for('assign_judges', tid=t.id) }}">Assign Judges</a></p>
+{% endif %}
 {% if show_passcode %}
 <p>Tournament Passcode: {{ t.passcode }}</p>
 {% endif %}

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,6 +1,7 @@
 from app.app import db
 from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult
 from app.pairing import swiss_pair_round, compute_standings
+from datetime import datetime
 
 
 def test_tournament_create_pairing_standings(session):
@@ -43,3 +44,12 @@ def test_tournament_create_pairing_standings(session):
     session.delete(t)
     session.commit()
     assert session.query(Tournament).count() == 0
+
+
+def test_tournament_start_time(session):
+    start = datetime(2024, 1, 1, 10, 0)
+    t = Tournament(name='Start Event', format='Constructed', start_time=start)
+    session.add(t)
+    session.commit()
+    fetched = session.get(Tournament, t.id)
+    assert fetched.start_time == start

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -23,3 +23,10 @@ def test_user_crud(session):
     session.delete(fetched)
     session.commit()
     assert session.query(User).count() == 0
+
+
+def test_judge_roles_exist(session):
+    roles = {r.name for r in session.query(Role).all()}
+    assert 'venue judge' in roles
+    assert 'event head judge' in roles
+    assert 'floor judge' in roles


### PR DESCRIPTION
## Summary
- Define new judge roles and track tournament start times and judge assignments
- Add scheduling, staff management, and judge assignment pages with overlap warnings
- Fix timer drift using server-side timestamp and add unit tests

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7799cf8508320ab026524ffc649bc

## Summary by Sourcery

Introduce tournament scheduling and judge assignment functionality, add overlap warnings, improve timer accuracy using server-side timestamps, and include related unit tests

New Features:
- Add optional start_time field on tournaments with end-time estimation and overlap warning
- Define venue judge, event head judge, and floor judge roles with pages to assign and manage judges

Bug Fixes:
- Fix timer drift by calculating remaining time against server_now

Enhancements:
- Add schedule and staff management pages with nav links and display of assigned judges in tournament views
- Refactor client-side timer logic to use server-provided timestamp to prevent drift

Tests:
- Add tests for tournament start_time persistence
- Add tests to verify judge roles exist