### PR TITLE
Filter judge roles and add break timers

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -41,11 +41,14 @@ DEFAULT_ROLE_PERMISSIONS = {
     },
     'venue judge': {
         'tournaments.manage': True,
+        'users.manage': True,
     },
     'event head judge': {
         'tournaments.manage': True,
+        'users.manage': True,
     },
     'floor judge': {
+        'users.manage': True,
     },
     'user': {
         'tournaments.join': True,
@@ -75,6 +78,7 @@ class User(db.Model, UserMixin):
     notes = db.Column(db.Text, nullable=True)
     role_id = db.Column(db.Integer, db.ForeignKey('role.id'))
     role = db.relationship('Role')
+    break_end = db.Column(db.DateTime, nullable=True)
 
     def set_password(self, pw):
         self.salt = os.urandom(16).hex()

--- a/app/templates/admin/judges.html
+++ b/app/templates/admin/judges.html
@@ -6,14 +6,14 @@
     <label>Head Judge:
       <select name="head_judge">
         <option value="">-- None --</option>
-        {% for u in users %}
+        {% for u in head_judges %}
         <option value="{{ u.id }}"{% if t.head_judge_id==u.id %} selected{% endif %}>{{ u.name }}</option>
         {% endfor %}
       </select>
     </label>
   </div>
   <h3>Floor Judges</h3>
-  {% for u in users %}
+  {% for u in floor_judges %}
     <label><input type="checkbox" name="floor_judges" value="{{ u.id }}"{% if u.id in floor_set %} checked{% endif %}> {{ u.name }}</label><br>
   {% endfor %}
   <button class="btn" type="submit">Save</button>

--- a/app/templates/admin/staff.html
+++ b/app/templates/admin/staff.html
@@ -2,12 +2,30 @@
 {% block content %}
 <h2>Staff Management</h2>
 {% for item in data %}
-  <h3>{{ item.t.name }}</h3>
+  <h3>{{ item.t.name }}{% if item.start %} ({{ item.start.strftime('%H:%M') }} - {% if item.end %}{{ item.end.strftime('%H:%M') }}{% else %}?{% endif %}){% endif %}</h3>
   <p>Head Judge: {{ item.head.name if item.head else 'None' }}</p>
-  <p>Floor Judges:
-    {% if item.floor %}
-      {% for u in item.floor %}{{ u.name }}{% if not loop.last %}, {% endif %}{% endfor %}
-    {% else %}None{% endif %}
-  </p>
+  <p>Floor Judges:</p>
+  <ul>
+  {% if item.floor %}
+    {% for u in item.floor %}
+    <li>
+      {{ u.name }}
+      {% if u.break_end and u.break_end > server_now %}
+        - On break (<span class="timer" data-timer-end="{{ u.break_end.isoformat() }}Z" data-server-now="{{ server_now.isoformat() }}Z" data-tournament-id="{{ u.id }}" data-tournament-name="{{ u.name }}" data-timer-type="break"></span>)
+        <form method="post" action="{{ url_for('judge_break', uid=u.id) }}" style="display:inline;">
+          <button class="btn" type="submit">Clear</button>
+        </form>
+      {% else %}
+        <form method="post" action="{{ url_for('judge_break', uid=u.id) }}" style="display:inline;">
+          <input type="number" name="minutes" value="15" min="1" style="width:4em;">
+          <button class="btn" type="submit">Break</button>
+        </form>
+      {% endif %}
+    </li>
+    {% endfor %}
+  {% else %}
+    <li>None</li>
+  {% endif %}
+  </ul>
 {% endfor %}
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -57,7 +57,7 @@
     const s = seconds%60;
     return m.toString().padStart(2,'0') + ':' + s.toString().padStart(2,'0');
   }
-  const typeLabels = {round:'round', draft:'draft', deck:'deck building'};
+  const typeLabels = {round:'round', draft:'draft', deck:'deck building', break:'break'};
   document.querySelectorAll('.timer').forEach(function(el){
     let remaining = null;
     let countdown = true;

--- a/tests/test_db_upgrade.py
+++ b/tests/test_db_upgrade.py
@@ -28,3 +28,30 @@ def test_start_time_column_added(tmp_path, monkeypatch):
         cols = [c['name'] for c in inspector.get_columns('tournament')]
         assert 'start_time' in cols
         db.session.remove()
+
+
+def test_break_end_column_added(tmp_path, monkeypatch):
+    db_path = tmp_path / "pre.db"
+    log_path = tmp_path / "logs.db"
+    # create an old user table without break_end column
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE user (
+            id INTEGER PRIMARY KEY,
+            email VARCHAR(255),
+            name VARCHAR(120) NOT NULL
+        )
+        """
+    )
+    conn.close()
+
+    monkeypatch.setenv("MTG_DB_PATH", str(db_path))
+    monkeypatch.setenv("MTG_LOG_DB_PATH", str(log_path))
+
+    app = create_app()
+    with app.app_context():
+        inspector = inspect(db.engine)
+        cols = [c['name'] for c in inspector.get_columns('user')]
+        assert 'break_end' in cols
+        db.session.remove()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -30,3 +30,10 @@ def test_judge_roles_exist(session):
     assert 'venue judge' in roles
     assert 'event head judge' in roles
     assert 'floor judge' in roles
+
+
+def test_judge_roles_have_user_manage(session):
+    roles = {r.name: r for r in session.query(Role).all()}
+    for name in ('venue judge', 'event head judge', 'floor judge'):
+        perms = json.loads(roles[name].permissions)
+        assert perms.get('users.manage')


### PR DESCRIPTION
## Summary
- Restrict judge assignment lists to users with appropriate roles
- Show tournament start/end times in staff overview and allow floor judge break timers
- Grant user management permission to all judge roles and add DB upgrade for judge breaks

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7843f8f9083209fa4343c2465cd0a