### PR TITLE
Add encrypted user messaging system

### DIFF
--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,6 +14,7 @@
       {% if current_user.is_authenticated %}
         <span>Hi, {{ current_user.name }}</span>
         <a href="{{ url_for('index') }}">All Tournaments</a>
+        <a href="{{ url_for('messages_inbox') }}">Messages</a>
         {% if current_user.has_permission('tournaments.manage') %}
         <a href="{{ url_for('new_tournament') }}">New Tournament</a>
         <a href="{{ url_for('admin_register_player') }}">Register Player</a>

--- a/app/templates/messages.html
+++ b/app/templates/messages.html
@@ -1,0 +1,20 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Inbox</h2>
+<table>
+  <tr><th>From</th><th>Title</th><th>Date</th></tr>
+  {% for m in messages %}
+  <tr>
+    <td>{{ m.sender.name }}</td>
+    <td>{{ m.title }}</td>
+    <td>{{ m.sent_at }}</td>
+  </tr>
+  <tr>
+    <td colspan="3">{{ m.body }}</td>
+  </tr>
+  {% else %}
+  <tr><td colspan="3">No messages</td></tr>
+  {% endfor %}
+</table>
+<p><a href="{{ url_for('send_message') }}">Compose Message</a></p>
+{% endblock %}

--- a/app/templates/send_message.html
+++ b/app/templates/send_message.html
@@ -1,0 +1,13 @@
+{% extends "base.html" %}
+{% block content %}
+<h2>Send Message</h2>
+<form method="post">
+  <label for="to">To (email):</label>
+  <input type="email" name="to" id="to" required><br>
+  <label for="title">Title:</label>
+  <input type="text" name="title" id="title" required><br>
+  <label for="body">Body:</label><br>
+  <textarea name="body" id="body" rows="6" cols="40" required></textarea><br>
+  <button type="submit">Send</button>
+</form>
+{% endblock %}


### PR DESCRIPTION
## Summary
- generate RSA key pairs for users and encrypt private keys with AES-256 derived from their password
- add Message model with AES/RSA encrypted content and basic inbox and compose pages
- expose navigation link for messages

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b79b8f32048320b6df2c90566a3232