### PR TITLE
fix: run db init via python in PowerShell

### DIFF
--- a/start-server.ps1
+++ b/start-server.ps1
@@ -96,11 +96,7 @@ Write-Host "Installing dependencies..."
 python -m pip install -r "$PSScriptRoot/requirements.txt" | Out-Null
 
 Write-Host "Initializing database..."
-python - <<'PY'
-from app.app import create_app, db
-create_app()
-db.create_all()
-PY
+python -c "from app.app import create_app, db; create_app(); db.create_all()"
 
 Write-Host "Starting FastAPI server..."
 Start-Process -NoNewWindow -FilePath "python" -ArgumentList "-m", "uvicorn", "app.app:app", "--reload", "--host=$FlaskIP", "--port=$FlaskPort"


### PR DESCRIPTION
## Summary
- run inline database initialization with `python -c` in PowerShell start script

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf02bb7db8832092b97da476ad2477

## Summary by Sourcery

Bug Fixes:
- Replace the multi-line Python heredoc with a single python -c invocation to run create_app and db.create_all() in start-server.ps1