### PR TITLE
fix: update requirements for fastapi

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 cryptography==42.0.7
 psutil==5.9.8
 PyYAML==6.0.1
-fastapi==0.111.0
-nicegui==1.4.17
+fastapi==0.116.1
+nicegui==2.24.0
 SQLAlchemy==2.0.29
-uvicorn==0.29.0
+uvicorn==0.35.0


### PR DESCRIPTION
## Summary
- update dependencies to FastAPI 0.116.1, NiceGUI 2.24.0 and Uvicorn 0.35.0

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf071206dc83209b0f15f8230bad7c