### PR TITLE
feat: fail fast when dependency installation fails

### DIFF
--- a/start-server.ps1
+++ b/start-server.ps1
@@ -95,7 +95,11 @@ $env:MTG_DB_PATH = $DatabasePath
 $env:MTG_LOG_DB_PATH = $LogDatabasePath
 
 Write-Host "Installing dependencies..."
-python -m pip install -r "$PSScriptRoot/requirements.txt" | Out-Null
+python -m pip install -r "$PSScriptRoot/requirements.txt"
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to install dependencies"
+    exit $LASTEXITCODE
+}
 
 Write-Host "Initializing database..."
 python -c "from app.app import create_app, db; create_app(); db.create_all()"

--- a/start-server.sh
+++ b/start-server.sh
@@ -57,7 +57,13 @@ fi
 export MTG_DB_PATH="$DB_FILE"
 export MTG_LOG_DB_PATH="$LOG_DB_FILE"
 export PASSWORD_SEED="$PASSWORD_SEED"
-python -m pip install -r requirements.txt >/dev/null
+
+# install python dependencies and fail fast if it doesn't work
+if ! python -m pip install -r requirements.txt; then
+  echo "Failed to install dependencies"
+  exit 1
+fi
+
 python - <<'PY'
 from app.app import create_app, db
 create_app()


### PR DESCRIPTION
## Summary
- stop startup scripts when dependency installation fails
- surface pip output during install for easier debugging

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf0a4fa7f48320b759c03e5a93bcc1