### PR TITLE
Add NiceGUI interface for tournament listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,16 @@
 4) Run:
    flask --app app.app run --debug
 
+### Optional NiceGUI interface
+For a modern web UI built with [NiceGUI](https://nicegui.io/), run:
+
+```
+python -m app.nicegui_app
+```
+
+This starts a separate server and mounts a NiceGUI page at `/nice` while reusing the
+existing Flask backend and database.
+
 ## Features
 - Player & Admin login
 - Tournaments: Commander, Draft, Constructed

--- a/app/nicegui_app.py
+++ b/app/nicegui_app.py
@@ -1,0 +1,40 @@
+"""NiceGUI interface for the MTG Tournament app.
+
+This module provides a lightweight user interface built with
+[nicegui](https://nicegui.io/) while reusing the existing Flask backend.
+It does not modify or replace the backend logic; instead it queries the
+same database models to present data to the user.
+"""
+
+from nicegui import ui
+from .app import create_app, db
+from .models import Tournament
+
+# Reuse the existing Flask application and database configuration
+flask_app = create_app()
+
+
+@ui.page('/nice')
+def tournament_page() -> None:
+    """Show a list of tournaments using a simple NiceGUI page."""
+    with flask_app.app_context():
+        tournaments = (
+            db.session.query(Tournament)
+            .order_by(Tournament.created_at.desc())
+            .all()
+        )
+
+    ui.label('Tournaments').classes('text-2xl m-4')
+    for t in tournaments:
+        with ui.card().classes('m-4 p-4'):
+            ui.label(t.name).classes('text-lg')
+            ui.label(f'{len(t.players)} players')
+
+
+def run() -> None:
+    """Start the NiceGUI interface."""
+    ui.run()
+
+
+if __name__ == '__main__':
+    run()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-SQLAlchemy==3.1.1
 cryptography==42.0.7
 psutil==5.9.8
 PyYAML==6.0.1
+nicegui==2.24.0


### PR DESCRIPTION
## Summary
- include nicegui dependency
- document and expose a basic NiceGUI page showing tournaments

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bf1aac3e30832082f536247065f2d2

## Summary by Sourcery

Add an optional NiceGUI-based interface for listing tournaments alongside the existing Flask app

New Features:
- Expose a `/nice` NiceGUI page that queries and displays tournaments from the Flask backend

Build:
- Add `nicegui==2.24.0` to requirements

Documentation:
- Update README with instructions for running the NiceGUI interface