### PR TITLE
Introduce NiceGUI frontend prototype

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,6 @@
 
 ## Notes
 - Default secret key is set for dev; change FLASK_SECRET in production.
-- The Flask secret is also used for NiceGUI's session storage; set `FLASK_SECRET` to persist user logins.
+- NiceGUI keeps user sessions in a cookie-based in-memory store; `FLASK_SECRET` secures only the Flask backend.
 - Passwords are stored encrypted with AES-256 using a seed specified via `PASSWORD_SEED`.
 - This is an MVP. You can extend forms, validation, and UI as needed.

--- a/README.md
+++ b/README.md
@@ -42,5 +42,6 @@
 
 ## Notes
 - Default secret key is set for dev; change FLASK_SECRET in production.
+- The Flask secret is also used for NiceGUI's session storage; set `FLASK_SECRET` to persist user logins.
 - Passwords are stored encrypted with AES-256 using a seed specified via `PASSWORD_SEED`.
 - This is an MVP. You can extend forms, validation, and UI as needed.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@
 4) Run:
    flask --app app.app run --debug
 
+5) NiceGUI frontend:
+   # bootstrap on Windows with PowerShell
+   .\start-nicegui.ps1
+   # or run directly
+   python -m app.nicegui_ui
+
 ## Features
 - Player & Admin login
 - Tournaments: Commander, Draft, Constructed

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -14,7 +14,7 @@ import os
 import secrets
 from typing import Dict
 
-from nicegui import ui
+from nicegui import context, ui
 
 from .app import create_app, db
 from .models import Message, Role, Tournament, TournamentPlayer, User
@@ -38,7 +38,7 @@ _SESSION_COOKIE = "walter_session"
 
 
 def _get_session() -> Dict[str, str]:
-    client = ui.get_client()
+    client = context.client
     token = client.cookies.get(_SESSION_COOKIE)
     if token and token in _SESSIONS:
         return _SESSIONS[token]
@@ -52,7 +52,7 @@ def _set_session(data: Dict[str, str]) -> None:
 
 
 def _clear_session() -> None:
-    client = ui.get_client()
+    client = context.client
     token = client.cookies.get(_SESSION_COOKIE)
     if token:
         _SESSIONS.pop(token, None)

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -102,11 +102,11 @@ def _header() -> None:
         with ui.row().classes("items-center gap-2"):
             if "user_id" in session:
                 ui.label(f"Hi, {session['name']}")
-                ui.button("Messages", on_click=lambda: _goto("/messages"))
-                ui.button("Logout", on_click=lambda: _goto("/logout"))
+                ui.link("Messages", "/messages")
+                ui.link("Logout", "/logout")
             else:
-                ui.button("Login", on_click=lambda: _goto("/login"))
-                ui.button("Register", on_click=lambda: _goto("/register"))
+                ui.link("Login", "/login")
+                ui.link("Register", "/register")
 
 
 def _login_required() -> bool:

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -328,7 +328,7 @@ def run() -> None:
     """Run the NiceGUI frontend application."""
     host = os.environ.get("FLASK_RUN_HOST", "127.0.0.1")
     port = int(os.environ.get("FLASK_RUN_PORT", "8080"))
-    ui.run(host=host, port=port)
+    ui.run(host=host, port=port, reload=False)
 
 
 if __name__ == "__main__":

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -326,7 +326,9 @@ def send_message_page() -> None:
 
 def run() -> None:
     """Run the NiceGUI frontend application."""
-    ui.run()
+    host = os.environ.get("FLASK_RUN_HOST", "127.0.0.1")
+    port = int(os.environ.get("FLASK_RUN_PORT", "8080"))
+    ui.run(host=host, port=port)
 
 
 if __name__ == "__main__":

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -170,7 +170,7 @@ def login_page() -> None:
             _set_session(data)
         _goto("/")
 
-    ui.button("Login", on_click=do_login)
+    ui.button("Login", on_click=lambda: do_login())
 
 
 @ui.page("/logout")
@@ -197,7 +197,7 @@ def register_page() -> None:
     select_items = {"": "-- None --"}
     select_items.update({str(t.id): t.name for t in tournaments})
     tournament_id = ui.select(select_items, label="Join Tournament", value="")
-    passcode = ui.input("Tournament Passcode", maxlength=4)
+    passcode = ui.input("Tournament Passcode").props("maxlength=4")
     error = ui.label().classes("text-red-500")
 
     def do_register() -> None:
@@ -264,7 +264,7 @@ def view_tournament_page(tid: int) -> None:
             ui.label(f"- {p.name}")
 
         if "user_id" in session and not is_player:
-            pass_input = ui.input("Passcode", maxlength=4)
+            pass_input = ui.input("Passcode").props("maxlength=4")
 
             def do_join() -> None:
                 if not _login_required():

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -38,7 +38,7 @@ _SESSION_COOKIE = "walter_session"
 
 
 def _get_session() -> Dict[str, str]:
-    client = context.client
+    client = context.get_client()
     token = client.cookies.get(_SESSION_COOKIE)
     if token and token in _SESSIONS:
         return _SESSIONS[token]
@@ -52,7 +52,7 @@ def _set_session(data: Dict[str, str]) -> None:
 
 
 def _clear_session() -> None:
-    client = context.client
+    client = context.get_client()
     token = client.cookies.get(_SESSION_COOKIE)
     if token:
         _SESSIONS.pop(token, None)

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -39,6 +39,8 @@ _SESSION_COOKIE = "walter_session"
 
 def _get_session() -> Dict[str, str]:
     client = context.get_client()
+    if not client:
+        return {}
     token = client.cookies.get(_SESSION_COOKIE)
     if token and token in _SESSIONS:
         return _SESSIONS[token]
@@ -53,7 +55,7 @@ def _set_session(data: Dict[str, str]) -> None:
 
 def _clear_session() -> None:
     client = context.get_client()
-    token = client.cookies.get(_SESSION_COOKIE)
+    token = client.cookies.get(_SESSION_COOKIE) if client else None
     if token:
         _SESSIONS.pop(token, None)
     ui.cookie(_SESSION_COOKIE, "", max_age=0)

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -138,7 +138,7 @@ def index_page() -> None:
                 ui.label(f"Players: {player_counts[t.id]}")
                 ui.button(
                     "View",
-                    on_click=lambda t_id=t.id: _goto(f"/t/{t_id}"),
+                    on_click=lambda _, t_id=t.id: _goto(f"/t/{t_id}"),
                 )
 
 
@@ -170,7 +170,7 @@ def login_page() -> None:
             _set_session(data)
         _goto("/")
 
-    ui.button("Login", on_click=lambda: do_login())
+    ui.button("Login", on_click=lambda _: do_login())
 
 
 @ui.page("/logout")
@@ -232,7 +232,7 @@ def register_page() -> None:
 
         _goto("/login")
 
-    ui.button("Create Account", on_click=do_register)
+    ui.button("Create Account", on_click=lambda _: do_register())
 
 
 @ui.page("/t/{tid}")
@@ -281,7 +281,7 @@ def view_tournament_page(tid: int) -> None:
                     db.session.commit()
                 _goto(f"/t/{tid}")
 
-            ui.button("Join", on_click=do_join)
+            ui.button("Join", on_click=lambda _: do_join())
 
 
 @ui.page("/messages")
@@ -335,7 +335,7 @@ def messages_page() -> None:
                 ui.label(m["title"]).classes("text-h6")
                 ui.label(f"From: {m['sender']} at {m['sent_at']}")
                 ui.label(m["body"]).classes("mt-2")
-        ui.button("Compose", on_click=lambda: _goto("/messages/send"))
+        ui.button("Compose", on_click=lambda _: _goto("/messages/send"))
 
 
 @ui.page("/messages/send")
@@ -388,7 +388,7 @@ def send_message_page() -> None:
             db.session.commit()
         _goto("/messages")
 
-    ui.button("Send", on_click=do_send)
+    ui.button("Send", on_click=lambda _: do_send())
 
 
 def run() -> None:

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -1,0 +1,50 @@
+from nicegui import ui
+import requests
+
+API_URL = 'http://localhost:5000'
+
+@ui.page('/')
+def index_page() -> None:
+    """Landing page showing basic navigation using NiceGUI components."""
+    with ui.header().classes('items-center justify-between'):
+        ui.label('MTG Tournament App').classes('text-h5')
+    with ui.column().classes('p-4 gap-2'):
+        ui.button('Login', on_click=lambda: ui.open('/login'))
+        ui.button('Register', on_click=lambda: ui.open('/register'))
+
+@ui.page('/login')
+def login_page() -> None:
+    """Simple login form backed by the existing Flask endpoint."""
+    email = ui.input('Email')
+    password = ui.input('Password', password=True, password_toggle_button=True)
+
+    def do_login() -> None:
+        requests.post(f'{API_URL}/login', data={'email': email.value, 'password': password.value})
+        ui.open('/')
+
+    ui.button('Login', on_click=do_login)
+
+@ui.page('/register')
+def register_page() -> None:
+    """Registration form that posts to the backend without using HTML templates."""
+    email = ui.input('Email')
+    name = ui.input('Name')
+    password = ui.input('Password', password=True, password_toggle_button=True)
+
+    def do_register() -> None:
+        requests.post(
+            f'{API_URL}/register',
+            data={'email': email.value, 'name': name.value, 'password': password.value},
+        )
+        ui.open('/login')
+
+    ui.button('Register', on_click=do_register)
+
+
+def run() -> None:
+    """Run the NiceGUI frontend application."""
+    ui.run()
+
+
+if __name__ == '__main__':
+    run()

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -89,6 +89,11 @@ def _clear_session() -> None:
     ui.cookie(_SESSION_COOKIE, "", max_age=0)
 
 
+def _goto(path: str) -> None:
+    """Navigate to ``path`` in the same browser tab."""
+    ui.open(path, new_tab=False)
+
+
 def _header() -> None:
     """Common navigation header used on all pages."""
     session = _get_session()
@@ -97,17 +102,17 @@ def _header() -> None:
         with ui.row().classes("items-center gap-2"):
             if "user_id" in session:
                 ui.label(f"Hi, {session['name']}")
-                ui.button("Messages", on_click=lambda: ui.open("/messages"))
-                ui.button("Logout", on_click=lambda: ui.open("/logout"))
+                ui.button("Messages", on_click=lambda: _goto("/messages"))
+                ui.button("Logout", on_click=lambda: _goto("/logout"))
             else:
-                ui.button("Login", on_click=lambda: ui.open("/login"))
-                ui.button("Register", on_click=lambda: ui.open("/register"))
+                ui.button("Login", on_click=lambda: _goto("/login"))
+                ui.button("Register", on_click=lambda: _goto("/register"))
 
 
 def _login_required() -> bool:
     """Redirect to the login page if no user session exists."""
     if "user_id" not in _get_session():
-        ui.open("/login")
+        _goto("/login")
         return False
     return True
 
@@ -133,7 +138,7 @@ def index_page() -> None:
                 ui.label(f"Players: {player_counts[t.id]}")
                 ui.button(
                     "View",
-                    on_click=lambda t_id=t.id: ui.open(f"/t/{t_id}"),
+                    on_click=lambda t_id=t.id: _goto(f"/t/{t_id}"),
                 )
 
 
@@ -163,7 +168,7 @@ def login_page() -> None:
             except Exception:
                 pass
             _set_session(data)
-        ui.open("/")
+        _goto("/")
 
     ui.button("Login", on_click=do_login)
 
@@ -171,7 +176,7 @@ def login_page() -> None:
 @ui.page("/logout")
 def logout_page() -> None:
     _clear_session()
-    ui.open("/")
+    _goto("/")
 
 
 @ui.page("/register")
@@ -225,7 +230,7 @@ def register_page() -> None:
                 db.session.add(tp)
                 db.session.commit()
 
-        ui.open("/login")
+        _goto("/login")
 
     ui.button("Create Account", on_click=do_register)
 
@@ -274,7 +279,7 @@ def view_tournament_page(tid: int) -> None:
                     )
                     db.session.add(tp)
                     db.session.commit()
-                ui.open(f"/t/{tid}")
+                _goto(f"/t/{tid}")
 
             ui.button("Join", on_click=do_join)
 
@@ -330,7 +335,7 @@ def messages_page() -> None:
                 ui.label(m["title"]).classes("text-h6")
                 ui.label(f"From: {m['sender']} at {m['sent_at']}")
                 ui.label(m["body"]).classes("mt-2")
-        ui.button("Compose", on_click=lambda: ui.open("/messages/send"))
+        ui.button("Compose", on_click=lambda: _goto("/messages/send"))
 
 
 @ui.page("/messages/send")
@@ -381,7 +386,7 @@ def send_message_page() -> None:
             )
             db.session.add(msg)
             db.session.commit()
-        ui.open("/messages")
+        _goto("/messages")
 
     ui.button("Send", on_click=do_send)
 

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -1,44 +1,327 @@
+"""NiceGUI front end for the WaLTER tournament manager.
+
+This module recreates the minimal set of HTML templates using NiceGUI
+components so that the application can be browsed without the
+original CSS or Jinja templates.  It interacts directly with the
+existing Flask/SQLAlchemy backend and therefore does not modify
+backend behaviour; only the user interface layer is replaced.
+"""
+
+from __future__ import annotations
+
+import base64
+import os
+from typing import Dict
+
 from nicegui import ui
-import requests
 
-API_URL = 'http://localhost:5000'
+from .app import create_app, db
+from .models import Message, Role, Tournament, TournamentPlayer, User
 
-@ui.page('/')
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.hazmat.primitives.serialization import (
+    load_pem_private_key,
+    load_pem_public_key,
+)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+
+# Create the Flask app so we can access the database and models.
+flask_app = create_app()
+
+
+def _header() -> None:
+    """Common navigation header used on all pages."""
+    with ui.header().classes("justify-between items-center"):
+        ui.link("WaLTER", "/").classes("text-h5")
+        with ui.row().classes("items-center gap-2"):
+            if "user_id" in ui.storage.user:
+                ui.label(f"Hi, {ui.storage.user['name']}")
+                ui.button("Messages", on_click=lambda: ui.open("/messages"))
+                ui.button("Logout", on_click=lambda: ui.open("/logout"))
+            else:
+                ui.button("Login", on_click=lambda: ui.open("/login"))
+                ui.button("Register", on_click=lambda: ui.open("/register"))
+
+
+def _login_required() -> bool:
+    """Redirect to the login page if no user session exists."""
+    if "user_id" not in ui.storage.user:
+        ui.open("/login")
+        return False
+    return True
+
+
+@ui.page("/")
 def index_page() -> None:
-    """Landing page showing basic navigation using NiceGUI components."""
-    with ui.header().classes('items-center justify-between'):
-        ui.label('MTG Tournament App').classes('text-h5')
-    with ui.column().classes('p-4 gap-2'):
-        ui.button('Login', on_click=lambda: ui.open('/login'))
-        ui.button('Register', on_click=lambda: ui.open('/register'))
+    """Display a list of tournaments."""
+    _header()
+    with flask_app.app_context():
+        tournaments = (
+            db.session.query(Tournament)
+            .order_by(Tournament.created_at.desc())
+            .all()
+        )
+        player_counts: Dict[int, int] = {t.id: len(t.players) for t in tournaments}
 
-@ui.page('/login')
+    with ui.column().classes("p-4 gap-4"):
+        for t in tournaments:
+            with ui.card().classes("p-4 w-full"):
+                ui.label(t.name).classes("text-h6")
+                ui.label(f"Format: {t.format}")
+                ui.label(f"Cut: {t.cut.upper()}")
+                ui.label(f"Players: {player_counts[t.id]}")
+                ui.button(
+                    "View",
+                    on_click=lambda t_id=t.id: ui.open(f"/t/{t_id}"),
+                )
+
+
+@ui.page("/login")
 def login_page() -> None:
-    """Simple login form backed by the existing Flask endpoint."""
-    email = ui.input('Email')
-    password = ui.input('Password', password=True, password_toggle_button=True)
+    """Authenticate a user against the existing database."""
+    _header()
+    email = ui.input("Email")
+    password = ui.input("Password", password=True, password_toggle_button=True)
+    error = ui.label().classes("text-red-500")
 
     def do_login() -> None:
-        requests.post(f'{API_URL}/login', data={'email': email.value, 'password': password.value})
-        ui.open('/')
+        with flask_app.app_context():
+            user = (
+                db.session.query(User)
+                .filter_by(email=email.value.strip().lower())
+                .first()
+            )
+            if not user or not user.check_password(password.value):
+                error.text = "Invalid credentials"
+                return
+            ui.storage.user["user_id"] = user.id
+            ui.storage.user["name"] = user.name
+            try:
+                priv_pem = user.decrypt_private_key(password.value)
+                if priv_pem:
+                    ui.storage.user["private_key"] = base64.b64encode(priv_pem).decode()
+            except Exception:
+                ui.storage.user["private_key"] = None
+        ui.open("/")
 
-    ui.button('Login', on_click=do_login)
+    ui.button("Login", on_click=do_login)
 
-@ui.page('/register')
+
+@ui.page("/logout")
+def logout_page() -> None:
+    ui.storage.user.clear()
+    ui.open("/")
+
+
+@ui.page("/register")
 def register_page() -> None:
-    """Registration form that posts to the backend without using HTML templates."""
-    email = ui.input('Email')
-    name = ui.input('Name')
-    password = ui.input('Password', password=True, password_toggle_button=True)
+    """Create a new user account and optionally join a tournament."""
+    _header()
+    name = ui.input("Name")
+    email = ui.input("Email")
+    password = ui.input("Password", password=True, password_toggle_button=True)
+
+    with flask_app.app_context():
+        tournaments = (
+            db.session.query(Tournament)
+            .order_by(Tournament.created_at.desc())
+            .all()
+        )
+
+    select_items = {"": "-- None --"}
+    select_items.update({str(t.id): t.name for t in tournaments})
+    tournament_id = ui.select(select_items, label="Join Tournament", value="")
+    passcode = ui.input("Tournament Passcode", maxlength=4)
+    error = ui.label().classes("text-red-500")
 
     def do_register() -> None:
-        requests.post(
-            f'{API_URL}/register',
-            data={'email': email.value, 'name': name.value, 'password': password.value},
-        )
-        ui.open('/login')
+        with flask_app.app_context():
+            if (
+                db.session.query(User)
+                .filter_by(email=email.value.strip().lower())
+                .first()
+            ):
+                error.text = "Email already registered"
+                return
+            role_user = db.session.query(Role).filter_by(name="user").first()
+            u = User(
+                email=email.value.strip().lower(),
+                name=name.value.strip(),
+                role=role_user,
+            )
+            u.set_password(password.value)
+            u.generate_keys(password.value)
+            db.session.add(u)
+            db.session.commit()
 
-    ui.button('Register', on_click=do_register)
+            if tournament_id.value:
+                t = db.session.get(Tournament, int(tournament_id.value))
+                code = passcode.value or ""
+                if not t or (t.passcode and code != t.passcode):
+                    error.text = "Invalid tournament passcode"
+                    return
+                tp = TournamentPlayer(tournament_id=t.id, user_id=u.id)
+                db.session.add(tp)
+                db.session.commit()
+
+        ui.open("/login")
+
+    ui.button("Create Account", on_click=do_register)
+
+
+@ui.page("/t/{tid}")
+def view_tournament_page(tid: int) -> None:
+    """Display details for a tournament and allow players to join."""
+    _header()
+    with flask_app.app_context():
+        t = db.session.get(Tournament, tid)
+        if not t:
+            ui.label("Tournament not found").classes("p-4")
+            return
+        players = [tp.user for tp in t.players]
+        is_player = False
+        if "user_id" in ui.storage.user:
+            is_player = (
+                db.session.query(TournamentPlayer)
+                .filter_by(tournament_id=tid, user_id=ui.storage.user["user_id"])
+                .first()
+                is not None
+            )
+
+    with ui.column().classes("p-4 gap-2"):
+        ui.label(t.name).classes("text-h5")
+        ui.label(f"Format: {t.format}")
+        ui.label(f"Cut: {t.cut.upper()}")
+        ui.label("Players:")
+        for p in players:
+            ui.label(f"- {p.name}")
+
+        if "user_id" in ui.storage.user and not is_player:
+            pass_input = ui.input("Passcode", maxlength=4)
+
+            def do_join() -> None:
+                if not _login_required():
+                    return
+                with flask_app.app_context():
+                    t2 = db.session.get(Tournament, tid)
+                    if t2.passcode and pass_input.value != t2.passcode:
+                        ui.notify("Invalid passcode", type="negative")
+                        return
+                    tp = TournamentPlayer(
+                        tournament_id=tid, user_id=ui.storage.user["user_id"]
+                    )
+                    db.session.add(tp)
+                    db.session.commit()
+                ui.open(f"/t/{tid}")
+
+            ui.button("Join", on_click=do_join)
+
+
+@ui.page("/messages")
+def messages_page() -> None:
+    """Inbox for the logged in user."""
+    if not _login_required():
+        return
+    _header()
+    priv_b64 = ui.storage.user.get("private_key")
+    with flask_app.app_context():
+        msgs = []
+        if priv_b64:
+            priv = load_pem_private_key(base64.b64decode(priv_b64), password=None)
+            msgs_db = (
+                db.session.query(Message)
+                .filter_by(recipient_id=ui.storage.user["user_id"])
+                .order_by(Message.sent_at.desc())
+                .all()
+            )
+            for m in msgs_db:
+                try:
+                    aes_key = priv.decrypt(
+                        m.key_encrypted,
+                        padding.OAEP(
+                            mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                            algorithm=hashes.SHA256(),
+                            label=None,
+                        ),
+                    )
+                    aesgcm = AESGCM(aes_key)
+                    title = aesgcm.decrypt(m.title_nonce, m.title_encrypted, None).decode()
+                    body = aesgcm.decrypt(m.body_nonce, m.body_encrypted, None).decode()
+                    msgs.append({
+                        "title": title,
+                        "body": body,
+                        "sender": m.sender.name,
+                        "sent_at": m.sent_at,
+                    })
+                    if not m.is_read:
+                        m.is_read = True
+                except Exception:
+                    continue
+            db.session.commit()
+
+    with ui.column().classes("p-4 gap-4"):
+        if not msgs:
+            ui.label("No messages")
+        for m in msgs:
+            with ui.card().classes("p-4 w-full"):
+                ui.label(m["title"]).classes("text-h6")
+                ui.label(f"From: {m['sender']} at {m['sent_at']}")
+                ui.label(m["body"]).classes("mt-2")
+        ui.button("Compose", on_click=lambda: ui.open("/messages/send"))
+
+
+@ui.page("/messages/send")
+def send_message_page() -> None:
+    """Compose a new message."""
+    if not _login_required():
+        return
+    _header()
+    to_input = ui.input("To (email)")
+    title_input = ui.input("Title")
+    body_input = ui.textarea("Body")
+    error = ui.label().classes("text-red-500")
+
+    def do_send() -> None:
+        with flask_app.app_context():
+            recipient = (
+                db.session.query(User)
+                .filter_by(email=to_input.value.strip().lower())
+                .first()
+            )
+            if not recipient or not recipient.public_key:
+                error.text = "Recipient not found or cannot receive messages"
+                return
+            public_key = load_pem_public_key(recipient.public_key)
+            aes_key = os.urandom(32)
+            aesgcm = AESGCM(aes_key)
+            nonce_title = os.urandom(12)
+            nonce_body = os.urandom(12)
+            title_enc = aesgcm.encrypt(nonce_title, title_input.value.encode(), None)
+            body_enc = aesgcm.encrypt(nonce_body, body_input.value.encode(), None)
+            key_enc = public_key.encrypt(
+                aes_key,
+                padding.OAEP(
+                    mgf=padding.MGF1(algorithm=hashes.SHA256()),
+                    algorithm=hashes.SHA256(),
+                    label=None,
+                ),
+            )
+            msg = Message(
+                sender_id=ui.storage.user["user_id"],
+                recipient_id=recipient.id,
+                key_encrypted=key_enc,
+                title_encrypted=title_enc,
+                title_nonce=nonce_title,
+                body_encrypted=body_enc,
+                body_nonce=nonce_body,
+            )
+            db.session.add(msg)
+            db.session.commit()
+        ui.open("/messages")
+
+    ui.button("Send", on_click=do_send)
 
 
 def run() -> None:
@@ -46,5 +329,6 @@ def run() -> None:
     ui.run()
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     run()
+

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -328,7 +328,8 @@ def run() -> None:
     """Run the NiceGUI frontend application."""
     host = os.environ.get("FLASK_RUN_HOST", "127.0.0.1")
     port = int(os.environ.get("FLASK_RUN_PORT", "8080"))
-    ui.run(host=host, port=port, reload=False)
+    secret = os.environ.get("STORAGE_SECRET", flask_app.config.get("SECRET_KEY", "dev-secret-change-me"))
+    ui.run(host=host, port=port, reload=False, storage_secret=secret)
 
 
 if __name__ == "__main__":

--- a/app/nicegui_ui.py
+++ b/app/nicegui_ui.py
@@ -30,6 +30,12 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 # Create the Flask app so we can access the database and models.
 flask_app = create_app()
 
+# Derive and apply a secret so NiceGUI's per-user storage works.
+_NG_SECRET = os.environ.get(
+    "STORAGE_SECRET", flask_app.config.get("SECRET_KEY", "dev-secret-change-me")
+)
+ng_app.storage.secret_key = _NG_SECRET
+
 
 def _header() -> None:
     """Common navigation header used on all pages."""
@@ -328,8 +334,7 @@ def run() -> None:
     """Run the NiceGUI frontend application."""
     host = os.environ.get("FLASK_RUN_HOST", "127.0.0.1")
     port = int(os.environ.get("FLASK_RUN_PORT", "8080"))
-    secret = os.environ.get("STORAGE_SECRET", flask_app.config.get("SECRET_KEY", "dev-secret-change-me"))
-    ui.run(host=host, port=port, reload=False, storage_secret=secret)
+    ui.run(host=host, port=port, reload=False, storage_secret=_NG_SECRET)
 
 
 if __name__ == "__main__":

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-SQLAlchemy==3.1.1
 cryptography==42.0.7
 psutil==5.9.8
 PyYAML==6.0.1
+nicegui==1.4.0

--- a/start-nicegui.ps1
+++ b/start-nicegui.ps1
@@ -1,0 +1,117 @@
+# PowerShell script to set up and run the WaLTER app with NiceGUI.
+# Loads configuration, installs dependencies, initializes the database,
+# creates an admin user, and then launches the NiceGUI frontend.
+
+# Load settings from YAML config
+$configPath = Join-Path $PSScriptRoot "config.yaml"
+if(!(Test-Path $configPath)){
+    Write-Error "Missing config.yaml"
+    exit 1
+}
+
+function ConvertTo-Hashtable {
+    param([Parameter(ValueFromPipeline = $true)][object]$InputObject)
+    if ($null -eq $InputObject) { return $null }
+    if ($InputObject -is [System.Collections.IDictionary]) {
+        $hash = @{}
+        foreach ($key in $InputObject.Keys) {
+            $hash[$key] = ConvertTo-Hashtable $InputObject[$key]
+        }
+        return $hash
+    }
+    if ($InputObject -is [System.Collections.IEnumerable] -and $InputObject.GetType().Name -ne "String") {
+        return @($InputObject | ForEach-Object { ConvertTo-Hashtable $_ })
+    }
+    return $InputObject
+}
+
+try {
+    $pythonScript = @"
+import sys, json
+try:
+    import yaml
+except ModuleNotFoundError:
+    import subprocess
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', '--quiet', 'PyYAML'])
+    import yaml
+with open(sys.argv[1], 'r', encoding='utf-8') as f:
+    data = yaml.safe_load(f)
+print(json.dumps(data))
+"@
+    $cfgJson = & python -c $pythonScript $configPath
+    $cfg = $cfgJson | ConvertFrom-Json | ConvertTo-Hashtable
+} catch {
+    Write-Error "Failed to parse config.yaml"
+    exit 1
+}
+
+$DefaultDb = "mtg_tournament.db"
+$DefaultLogDb = "mtg_tournament_logs.db"
+
+$DatabasePath = $cfg.db_file
+$LogDatabasePath = $cfg.log_db_file
+$FlaskSecret = $cfg.flask_secret
+$PasswordSeed = $cfg.password_seed
+$FlaskIP = $cfg.flask_ip
+$FlaskPort = $cfg.flask_port
+$newadmin = New-Object System.Management.Automation.PSCredential($cfg.admin_email, (ConvertTo-SecureString $cfg.admin_pass -AsPlainText -Force))
+
+if([string]::IsNullOrEmpty($DatabasePath)){ $DatabasePath = $DefaultDb }
+if([string]::IsNullOrEmpty($LogDatabasePath)){ $LogDatabasePath = $DefaultLogDb }
+if([string]::IsNullOrEmpty($FlaskSecret)){ $FlaskSecret = "dev-secret-change-me" }
+if([string]::IsNullOrEmpty($PasswordSeed)){ $PasswordSeed = "dev-password-seed-change-me" }
+if([string]::IsNullOrEmpty($FlaskIP)){ $FlaskIP = "127.0.0.1" }
+if([string]::IsNullOrEmpty($FlaskPort)){ $FlaskPort = 5000 }
+
+$flaskpid = try{
+    Get-NetTCPConnection -LocalPort $FlaskPort -State Listen -ErrorAction Stop | Select-Object -ExpandProperty OwningProcess
+}catch{
+    $null
+}
+
+if($flaskpid){
+    Get-Process -Id $flaskpid | Stop-Process -Force -Confirm:$false
+}
+
+Stop-Process -Name "python" -ErrorAction SilentlyContinue | Out-Null
+
+Set-Location -Path $PSScriptRoot
+
+$env:PASSWORD_SEED = $PasswordSeed
+$env:FLASK_SECRET = $FlaskSecret
+$env:FLASK_RUN_HOST = $FlaskIP
+$env:FLASK_RUN_PORT = $FlaskPort
+
+$timestamp = Get-Date -Format "yyyyMMddHHmmss"
+
+if($DatabasePath -eq $DefaultDb){
+    $DatabasePath = "mtg_tournament_$timestamp.db"
+    $LogDatabasePath = "mtg_tournament_logs_$timestamp.db"
+} elseif($LogDatabasePath -eq $DefaultLogDb) {
+    $base = [System.IO.Path]::GetFileNameWithoutExtension($DatabasePath)
+    $dir = [System.IO.Path]::GetDirectoryName($DatabasePath)
+    if([string]::IsNullOrEmpty($dir)){ $dir = "." }
+    $LogDatabasePath = Join-Path $dir "$base`_logs.db"
+}
+
+$env:MTG_DB_PATH = $DatabasePath
+$env:MTG_LOG_DB_PATH = $LogDatabasePath
+
+Write-Host "Installing dependencies..."
+python -m pip install -r "$PSScriptRoot/requirements.txt" | Out-Null
+
+Write-Host "Setting Flask environment..."
+$env:FLASK_APP = "app.app:app"
+
+Write-Host "Initializing database..."
+python -m flask --app app.app db-init
+
+Write-Host "Creating default admin user..."
+python -m flask --app app.app create-admin --email $newadmin.UserName --password $newadmin.GetNetworkCredential().Password
+
+Write-Host "Starting NiceGUI server..."
+Start-Process -NoNewWindow -FilePath "python" -ArgumentList "-m app.nicegui_ui"
+
+Start-Sleep -Seconds 3
+
+Start-Process "http://$($FlaskIP):$($FlaskPort)/"


### PR DESCRIPTION
## Summary
- add NiceGUI dependency
- prototype NiceGUI UI with login and registration pages

## Testing
- `PYTHONPATH=. pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bf286cb59c83208bdf8e39593d90b3

## Summary by Sourcery

Set up an initial NiceGUI UI with navigation, login, and registration pages integrated with the backend

New Features:
- Introduce a NiceGUI-based prototype frontend with a landing page and login/registration flows that POST to the existing Flask API

Build:
- Add nicegui==1.4.0 to requirements.txt