### PR TITLE
Enhance messaging and add lost and found tracking

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -157,6 +157,7 @@ class Message(db.Model):
     sender_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     recipient_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
     key_encrypted = db.Column(db.LargeBinary, nullable=False)
+    sender_key_encrypted = db.Column(db.LargeBinary, nullable=True)
     title_encrypted = db.Column(db.LargeBinary, nullable=False)
     title_nonce = db.Column(db.LargeBinary, nullable=False)
     body_encrypted = db.Column(db.LargeBinary, nullable=False)
@@ -187,6 +188,8 @@ class Tournament(db.Model):
     format = db.Column(db.String(50), nullable=False)  # Commander, Draft, Constructed
     structure = db.Column(db.String(20), default='swiss')  # swiss or single_elim
     cut = db.Column(db.String(10), default='none')     # none, top8, top4
+    rules_enforcement_level = db.Column(db.String(20), default='None')
+    is_cube = db.Column(db.Boolean, default=False)
     rounds_override = db.Column(db.Integer, nullable=True)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     # Comma separated points for Commander: first, second, third, fourth, draw
@@ -309,3 +312,17 @@ class Match(db.Model):
     )
 
     __table_args__ = (UniqueConstraint('round_id', 'table_number', name='_round_table_uc'),)
+
+
+class LostFoundItem(db.Model):
+    __bind_key__ = 'media'
+    id = db.Column(db.Integer, primary_key=True)
+    title = db.Column(db.String(200), nullable=False)
+    description = db.Column(db.Text, nullable=True)
+    status = db.Column(db.String(20), default='unclaimed')
+    location = db.Column(db.String(200), nullable=True)
+    image_path = db.Column(db.String(500), nullable=True)
+    reporter_name = db.Column(db.String(120), nullable=True)
+    reporter_contact = db.Column(db.String(200), nullable=True)
+    created_at = db.Column(db.DateTime, default=datetime.utcnow)
+    updated_at = db.Column(db.DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -150,6 +150,172 @@ main { padding: 16px; }
   width:100%;
 }
 
+.message-actions {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  margin-bottom:16px;
+}
+
+.message-table th,
+.message-table td {
+  text-align:left;
+}
+
+.message-row.unread {
+  font-weight:600;
+}
+
+.message-table .preview-row td {
+  text-align:left;
+  background:#fff;
+  font-size:0.9rem;
+  border-top:none;
+}
+
+.encrypted-note {
+  display:block;
+  margin-top:4px;
+  font-style:italic;
+  color:#555;
+}
+
+.message-detail,
+.message-reply {
+  background:#fff;
+  padding:16px;
+  border-radius:10px;
+  box-shadow:0 2px 6px rgba(0,0,0,0.1);
+  margin-bottom:24px;
+}
+
+.message-meta {
+  display:grid;
+  grid-template-columns: auto 1fr;
+  gap:4px 12px;
+  margin:0 0 12px;
+}
+
+.message-meta dt {
+  font-weight:600;
+}
+
+.message-body {
+  background:#fdf5e6;
+  border:1px solid var(--light-green);
+  border-radius:8px;
+  padding:12px;
+  line-height:1.4;
+}
+
+.nav-badge {
+  display:inline-flex;
+  align-items:center;
+  justify-content:center;
+  min-width:24px;
+  padding:0 8px;
+  border-radius:12px;
+  background:var(--burnt-orange);
+  color:#fff;
+  font-size:0.85rem;
+  margin-left:4px;
+}
+
+.hidden {
+  display:none !important;
+}
+
+.lost-form,
+.lost-list {
+  margin-bottom:24px;
+}
+
+.lost-grid {
+  display:grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap:16px;
+}
+
+.lost-card {
+  background:#fff;
+  padding:16px;
+  border-radius:12px;
+  box-shadow:0 2px 8px rgba(0,0,0,0.08);
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+}
+
+.lost-card-header {
+  display:flex;
+  justify-content:space-between;
+  align-items:center;
+}
+
+.lost-status {
+  padding:4px 8px;
+  border-radius:12px;
+  font-size:0.85rem;
+}
+
+.lost-status-unclaimed {
+  background:var(--light-green);
+  color:var(--dark-grey);
+}
+
+.lost-status-claimed {
+  background:#ffe082;
+  color:#5d4037;
+}
+
+.lost-status-returned {
+  background:#c5cae9;
+  color:#1a237e;
+}
+
+.lost-image img {
+  width:100%;
+  height:auto;
+  border-radius:10px;
+}
+
+.lost-meta {
+  font-size:0.85rem;
+  color:#555;
+}
+
+.lost-update summary {
+  cursor:pointer;
+  font-weight:600;
+  margin-bottom:8px;
+}
+
+.inline-add-player {
+  background:#fff;
+  padding:16px;
+  border-radius:10px;
+  box-shadow:0 2px 6px rgba(0,0,0,0.1);
+  margin-bottom:24px;
+}
+
+.inline-form-divider {
+  text-align:center;
+  margin:12px 0;
+  font-weight:600;
+  color:#555;
+}
+
+.add-player-form label {
+  display:block;
+  margin-bottom:8px;
+}
+
+.add-player-form input[type="text"],
+.add-player-form input[type="email"] {
+  width:100%;
+  max-width:320px;
+}
+
 .report-section {
   background:#fff;
   padding:16px;

--- a/app/templates/admin/edit_tournament.html
+++ b/app/templates/admin/edit_tournament.html
@@ -11,11 +11,17 @@
       <tr>
         <td>Format</td>
         <td>
-          <select name="format" required>
+          <select name="format" id="tournament-format" required>
             <option{% if t.format=='Commander' %} selected{% endif %}>Commander</option>
             <option{% if t.format=='Draft' %} selected{% endif %}>Draft</option>
             <option{% if t.format=='Constructed' %} selected{% endif %}>Constructed</option>
           </select>
+        </td>
+      </tr>
+      <tr class="cube-row">
+        <td>Cube Draft</td>
+        <td>
+          <label><input type="checkbox" name="is_cube" value="1"{% if t.is_cube %} checked{% endif %}> Mark this draft as a cube event</label>
         </td>
       </tr>
       <tr>
@@ -24,6 +30,16 @@
           <select name="structure">
             <option value="swiss"{% if t.structure=='swiss' %} selected{% endif %}>Swiss / Cut</option>
             <option value="single_elim"{% if t.structure=='single_elim' %} selected{% endif %}>Single Elimination</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>Rules Enforcement Level</td>
+        <td>
+          <select name="rules_enforcement_level">
+            {% for option in ['None','Casual','Competitive','Professional'] %}
+            <option value="{{ option }}"{% if t.rules_enforcement_level == option %} selected{% endif %}>{{ option }}</option>
+            {% endfor %}
           </select>
         </td>
       </tr>
@@ -67,8 +83,9 @@
   </table>
 </form>
 <script>
-const fmtSel = document.querySelector('select[name="format"]');
+const fmtSel = document.querySelector('#tournament-format');
 const cutSel = document.querySelector('select[name="cut"]');
+const cubeRow = document.querySelector('.cube-row');
 function updateCut(){
   const top8 = cutSel.querySelector('option[value="top8"]');
   if(fmtSel.value === 'Commander'){
@@ -76,6 +93,9 @@ function updateCut(){
     if(cutSel.value === 'top8'){ cutSel.value = 'top4'; }
   }else{
     top8.style.display = '';
+  }
+  if(cubeRow){
+    cubeRow.style.display = fmtSel.value === 'Draft' ? '' : 'none';
   }
 }
 fmtSel.addEventListener('change', updateCut);

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -11,11 +11,17 @@
       <tr>
         <td>Format</td>
         <td>
-          <select name="format" required>
+          <select name="format" id="tournament-format" required>
             <option>Commander</option>
             <option>Draft</option>
             <option>Constructed</option>
           </select>
+        </td>
+      </tr>
+      <tr class="cube-row">
+        <td>Cube Draft</td>
+        <td>
+          <label><input type="checkbox" name="is_cube" value="1"> Mark this draft as a cube event</label>
         </td>
       </tr>
       <tr>
@@ -24,6 +30,17 @@
           <select name="structure">
             <option value="swiss">Swiss / Cut</option>
             <option value="single_elim">Single Elimination</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
+        <td>Rules Enforcement Level</td>
+        <td>
+          <select name="rules_enforcement_level">
+            <option value="None">None</option>
+            <option value="Casual">Casual</option>
+            <option value="Competitive">Competitive</option>
+            <option value="Professional">Professional</option>
           </select>
         </td>
       </tr>
@@ -67,8 +84,9 @@
   </table>
 </form>
 <script>
-const fmtSel = document.querySelector('select[name="format"]');
+const fmtSel = document.querySelector('#tournament-format');
 const cutSel = document.querySelector('select[name="cut"]');
+const cubeRow = document.querySelector('.cube-row');
 function updateCut(){
   const top8 = cutSel.querySelector('option[value="top8"]');
   if(fmtSel.value === 'Commander'){
@@ -76,6 +94,9 @@ function updateCut(){
     if(cutSel.value === 'top8'){ cutSel.value = 'top4'; }
   }else{
     top8.style.display = '';
+  }
+  if(cubeRow){
+    cubeRow.style.display = fmtSel.value === 'Draft' ? '' : 'none';
   }
 }
 fmtSel.addEventListener('change', updateCut);

--- a/app/templates/admin/reports.html
+++ b/app/templates/admin/reports.html
@@ -1,6 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Submitted Reports</h2>
+<div class="toolbar">
+  <a class="btn" href="{{ url_for('export_reports_csv') }}">Export CSV</a>
+  <button class="btn" type="button" onclick="window.print()">Print</button>
+</div>
 {% if not reports %}
 <p>No reports have been submitted.</p>
 {% else %}

--- a/app/templates/admin/schedule.html
+++ b/app/templates/admin/schedule.html
@@ -1,6 +1,10 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>Tournament Schedule</h2>
+<div class="toolbar">
+  <a class="btn" href="{{ url_for('export_schedule_csv') }}">Export CSV</a>
+  <button class="btn" type="button" onclick="window.print()">Print</button>
+</div>
 <table class="table center-table">
   <thead><tr><th>Name</th><th>Start</th><th>End (estimated)</th></tr></thead>
   <tbody>

--- a/app/templates/admin/users.html
+++ b/app/templates/admin/users.html
@@ -2,7 +2,8 @@
 {% block content %}
 <h2>Users</h2>
 <form method="get" class="user-search">
-  <input type="text" name="q" value="{{ search_query }}" placeholder="Search by name or email">
+  <input type="text" name="q" id="admin-user-search" value="{{ search_query }}" placeholder="Search by name or email" autocomplete="off">
+  <div id="admin-user-results" class="user-lookup-results" aria-live="polite"></div>
   <button class="btn" type="submit">Search</button>
   {% if search_query %}
   <a class="btn" href="{{ url_for('admin_users') }}">Clear</a>
@@ -96,4 +97,11 @@
   {% endfor %}
 </table>
 {% endif %}
+<script>
+  document.addEventListener('DOMContentLoaded', function(){
+    if(window.attachUserLookup){
+      window.attachUserLookup('admin-user-search', 'admin-user-results');
+    }
+  });
+</script>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -14,7 +14,8 @@
       {% if current_user.is_authenticated %}
         <span>Hi, {{ current_user.name }}</span>
         <a href="{{ url_for('index') }}">All Tournaments</a>
-        <a href="{{ url_for('messages_home') }}">Messages</a>
+        <a href="{{ url_for('messages_home') }}">Messages <span id="nav-messages-count" class="nav-badge{% if not nav_unread_messages %} hidden{% endif %}">{{ nav_unread_messages }}</span></a>
+        <a href="{{ url_for('lost_and_found') }}">Lost &amp; Found</a>
         <a href="{{ url_for('submit_report') }}">Report Issue</a>
         {% if current_user.has_permission('tournaments.manage') %}
         <a href="{{ url_for('new_tournament') }}">New Tournament</a>
@@ -29,7 +30,7 @@
         {% if current_user.has_permission('admin.panel') %}
         <a href="{{ url_for('admin_panel') }}">Admin Panel</a>
         <a href="{{ url_for('site_logs') }}">Site Logs</a>
-        <a href="{{ url_for('admin_reports') }}">Reports</a>
+        <a href="{{ url_for('admin_reports') }}">Reports <span id="nav-reports-count" class="nav-badge{% if not nav_open_reports %} hidden{% endif %}">{{ nav_open_reports }}</span></a>
         {% endif %}
         {% if current_user.has_permission('admin.permissions') %}
         <a href="{{ url_for('permissions') }}">Permissions</a>
@@ -189,6 +190,16 @@
       .then(function(data){
         if(!data || typeof data.count !== 'number'){
           return;
+        }
+        const navBadge = document.getElementById('nav-messages-count');
+        if(navBadge){
+          if(data.count > 0){
+            navBadge.textContent = data.count;
+            navBadge.classList.remove('hidden');
+          }else{
+            navBadge.textContent = '';
+            navBadge.classList.add('hidden');
+          }
         }
         const key = 'walter_unread_count';
         if(data.count > 0){

--- a/app/templates/lost_found/index.html
+++ b/app/templates/lost_found/index.html
@@ -1,0 +1,95 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Lost &amp; Found</h2>
+{% if manage_access %}
+<section class="lost-form">
+  <h3>Add an Item</h3>
+  <form method="post" enctype="multipart/form-data" class="message-form">
+    <label>Item Name
+      <input type="text" name="title" required>
+    </label><br>
+    <label>Description
+      <textarea name="description" rows="3" placeholder="Describe the item or how it can be identified."></textarea>
+    </label><br>
+    <label>Location
+      <input type="text" name="location" placeholder="Where the item is stored or was found.">
+    </label><br>
+    <label>Reporter Name
+      <input type="text" name="reporter_name" placeholder="Optional name of the person who reported it.">
+    </label><br>
+    <label>Contact Details
+      <input type="text" name="reporter_contact" placeholder="How to reach the reporter (optional).">
+    </label><br>
+    <label>Status
+      <select name="status">
+        {% for value, label in status_options %}
+        <option value="{{ value }}">{{ label }}</option>
+        {% endfor %}
+      </select>
+    </label><br>
+    <label>Photo
+      <input type="file" name="photo" accept="image/*">
+    </label><br>
+    <button class="btn" type="submit">Save Item</button>
+  </form>
+</section>
+{% endif %}
+<section class="lost-list">
+  {% if not items %}
+  <p>No lost or found items have been recorded yet.</p>
+  {% else %}
+  <div class="lost-grid">
+    {% for item in items %}
+    <article class="lost-card">
+      <header class="lost-card-header">
+        <h3>{{ item.title }}</h3>
+        <span class="lost-status lost-status-{{ item.status }}">{{ item.status|capitalize }}</span>
+      </header>
+      {% if item.image_path %}
+      <div class="lost-image">
+        <img src="{{ url_for('media_file', filename=item.image_path) }}" alt="Photo of {{ item.title }}">
+      </div>
+      {% endif %}
+      <p class="lost-meta">Logged {{ item.created_at.strftime('%Y-%m-%d %H:%M') if item.created_at else '' }}</p>
+      {% if item.location %}
+      <p><strong>Location:</strong> {{ item.location }}</p>
+      {% endif %}
+      {% if item.description %}
+      <p>{{ item.description }}</p>
+      {% endif %}
+      {% if item.reporter_name or item.reporter_contact %}
+      <p class="lost-reporter">
+        {% if item.reporter_name %}<strong>Reporter:</strong> {{ item.reporter_name }}{% endif %}
+        {% if item.reporter_contact %}<br><strong>Contact:</strong> {{ item.reporter_contact }}{% endif %}
+      </p>
+      {% endif %}
+      {% if manage_access %}
+      <details class="lost-update">
+        <summary>Update Item</summary>
+        <form method="post" action="{{ url_for('update_lost_and_found', item_id=item.id) }}" enctype="multipart/form-data" class="message-form">
+          <label>Status
+            <select name="status">
+              {% for value, label in status_options %}
+              <option value="{{ value }}"{% if item.status == value %} selected{% endif %}>{{ label }}</option>
+              {% endfor %}
+            </select>
+          </label><br>
+          <label>Location
+            <input type="text" name="location" value="{{ item.location or '' }}">
+          </label><br>
+          <label>Contact Details
+            <input type="text" name="reporter_contact" value="{{ item.reporter_contact or '' }}">
+          </label><br>
+          <label>Replace Photo
+            <input type="file" name="photo" accept="image/*">
+          </label><br>
+          <button class="btn" type="submit">Update</button>
+        </form>
+      </details>
+      {% endif %}
+    </article>
+    {% endfor %}
+  </div>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/messages/index.html
+++ b/app/templates/messages/index.html
@@ -4,6 +4,7 @@
 <p>Select the messaging option that matches what you need to do.</p>
 <ul class="message-nav">
   <li><a href="{{ url_for('messages_inbox') }}">Player Inbox</a> – read your encrypted messages and compose direct replies.</li>
+  <li><a href="{{ url_for('messages_sent') }}">Sent Messages</a> – review anything you have sent.</li>
   {% if judge_access %}
   <li><a href="{{ url_for('messages_judge') }}">Judge Broadcast</a> – send announcements to all players in a tournament.</li>
   {% endif %}

--- a/app/templates/messages/player.html
+++ b/app/templates/messages/player.html
@@ -1,21 +1,30 @@
 {% extends "base.html" %}
 {% block content %}
-<h2>Direct Messages</h2>
-<p class="message-nav"><a href="{{ url_for('messages_home') }}">Back to Messages</a></p>
-<p><a class="btn" href="{{ url_for('send_message') }}">Compose Message</a></p>
-<table class="table">
-  <tr><th>From</th><th>Title</th><th>Date</th></tr>
+<h2>Inbox</h2>
+<div class="message-actions">
+  <a class="btn" href="{{ url_for('send_message') }}">Compose</a>
+  <a class="btn" href="{{ url_for('messages_sent') }}">Sent</a>
+  <a class="btn" href="{{ url_for('messages_home') }}">Message Options</a>
+</div>
+{% if not messages %}
+<p>No messages yet.</p>
+{% else %}
+<table class="table message-table">
+  <thead>
+    <tr><th>From</th><th>Subject</th><th>Received</th></tr>
+  </thead>
+  <tbody>
   {% for m in messages %}
-  <tr>
-    <td>{{ m.sender.name }}</td>
-    <td>{{ m.title }}</td>
-    <td>{{ m.sent_at }}</td>
-  </tr>
-  <tr>
-    <td colspan="3">{{ m.body }}</td>
-  </tr>
-  {% else %}
-  <tr><td colspan="3">No messages</td></tr>
+    <tr class="message-row{% if m.was_unread %} unread{% endif %}">
+      <td data-label="From">{{ m.sender.name if m.sender else 'Unknown' }}</td>
+      <td data-label="Subject"><a href="{{ url_for('view_message', mid=m.id) }}">{{ m.title }}</a></td>
+      <td data-label="Received">{{ m.sent_at.strftime('%Y-%m-%d %H:%M') if m.sent_at else '' }}</td>
+    </tr>
+    <tr class="preview-row">
+      <td colspan="3">{{ m.body|truncate(200) }}</td>
+    </tr>
   {% endfor %}
+  </tbody>
 </table>
+{% endif %}
 {% endblock %}

--- a/app/templates/messages/sent.html
+++ b/app/templates/messages/sent.html
@@ -1,0 +1,33 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Sent Messages</h2>
+<div class="message-actions">
+  <a class="btn" href="{{ url_for('send_message') }}">Compose</a>
+  <a class="btn" href="{{ url_for('messages_inbox') }}">Inbox</a>
+  <a class="btn" href="{{ url_for('messages_home') }}">Message Options</a>
+</div>
+{% if not messages %}
+<p>No sent messages yet.</p>
+{% else %}
+<table class="table message-table">
+  <thead>
+    <tr><th>To</th><th>Subject</th><th>Sent</th></tr>
+  </thead>
+  <tbody>
+  {% for m in messages %}
+    <tr class="message-row">
+      <td data-label="To">{{ m.recipient.name if m.recipient else 'Unknown' }}</td>
+      <td data-label="Subject">
+        <a href="{{ url_for('view_message', mid=m.id) }}"{% if not m.can_view %} class="encrypted-link"{% endif %}>{{ m.title }}</a>
+        {% if not m.can_view %}<span class="encrypted-note">Unlock your private key to view the contents.</span>{% endif %}
+      </td>
+      <td data-label="Sent">{{ m.sent_at.strftime('%Y-%m-%d %H:%M') if m.sent_at else '' }}</td>
+    </tr>
+    <tr class="preview-row">
+      <td colspan="3">{% if m.can_view %}{{ m.body|truncate(200) }}{% else %}Message body encrypted.{% endif %}</td>
+    </tr>
+  {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+{% endblock %}

--- a/app/templates/messages/view.html
+++ b/app/templates/messages/view.html
@@ -1,0 +1,38 @@
+{% extends 'base.html' %}
+{% block content %}
+<h2>Message</h2>
+<div class="message-actions">
+  <a class="btn" href="{{ url_for('messages_inbox') }}">Inbox</a>
+  <a class="btn" href="{{ url_for('messages_sent') }}">Sent</a>
+  <a class="btn" href="{{ url_for('messages_home') }}">Message Options</a>
+</div>
+<section class="message-detail">
+  <dl class="message-meta">
+    <dt>From</dt><dd>{{ message.sender.name if message.sender else 'Unknown' }}</dd>
+    <dt>To</dt><dd>{{ message.recipient.name if message.recipient else 'Unknown' }}</dd>
+    <dt>Sent</dt><dd>{{ message.sent_at.strftime('%Y-%m-%d %H:%M') if message.sent_at else '' }}</dd>
+    {% if payload %}<dt>Subject</dt><dd>{{ payload.title }}</dd>{% endif %}
+  </dl>
+  {% if payload %}
+  <div class="message-body">{{ payload.body | e | replace('\n', '<br>') | safe }}</div>
+  {% else %}
+  <p class="encrypted-note">Unable to decrypt this message right now. Try logging out and back in to unlock your key.</p>
+  {% endif %}
+</section>
+{% if can_reply and payload %}
+<section class="message-reply">
+  <h3>Reply</h3>
+  <form method="post" action="{{ url_for('reply_message', mid=message.id) }}" class="message-form">
+    <label>Subject
+      <input type="text" name="title" value="{{ reply_subject }}" required>
+    </label><br>
+    <label>Message
+      <textarea name="body" rows="6" required></textarea>
+    </label><br>
+    <button class="btn" type="submit">Send Reply</button>
+  </form>
+</section>
+{% elif payload and not can_reply %}
+<p class="encrypted-note">Cannot reply because the other participant is unavailable.</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -1,7 +1,8 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>{{ t.name }}</h2>
-<p>Format: {{ t.format }} | Cut: {{ t.cut|upper }}</p>
+<p>Format: {{ t.format }}{% if t.format == 'Draft' and t.is_cube %} (Cube){% endif %} | Cut: {{ t.cut|upper }}</p>
+<p>Rules Enforcement Level: {{ t.rules_enforcement_level }}</p>
 <p>Head Judge: {{ t.head_judge.name if t.head_judge else 'None' }}</p>
 <p>Floor Judges:
   {% if floor_judges %}
@@ -49,6 +50,34 @@
     <a class="btn" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
   {% endif %}
 </div>
+
+{% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+<section class="inline-add-player">
+  <h3>Add Player</h3>
+  <form method="post" action="{{ url_for('add_player_to_tournament', tid=t.id) }}" class="message-form add-player-form">
+    <label>Find Existing Player
+      <input type="text" id="add-player-search" placeholder="Search by name or email" autocomplete="off">
+    </label>
+    <div id="add-player-results" class="user-lookup-results" aria-live="polite"></div>
+    <input type="hidden" name="user_id" id="add-player-id">
+    <p class="inline-form-divider">or quick add</p>
+    <label>Player Name
+      <input type="text" name="new_player_name" placeholder="New player name">
+    </label>
+    <label>Email (optional)
+      <input type="email" name="new_player_email" placeholder="email@example.com">
+    </label>
+    <button class="btn" type="submit">Add Player</button>
+  </form>
+</section>
+<script>
+  document.addEventListener('DOMContentLoaded', function(){
+    if(window.attachUserLookup){
+      window.attachUserLookup('add-player-search', 'add-player-results', 'add-player-id');
+    }
+  });
+</script>
+{% endif %}
 
 <h3>Players ({{ players|length }})</h3>
 <table class="players-table">

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ Flask-SQLAlchemy==3.1.1
 cryptography==42.0.7
 psutil==5.9.8
 PyYAML==6.0.1
+Pillow==10.3.0


### PR DESCRIPTION
## Summary
- refresh the messaging experience with inbox detail views, replying, a sent mailbox, and toolbar unread indicators
- add a lost and found workflow with sanitized photo uploads backed by a dedicated media database
- extend tournament management with REL and cube settings, inline player additions, improved user lookups, and CSV/print utilities for reports and schedules

## Testing
- pip install -r requirements.txt
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d02737dcfc8320a3875fcdbc2c39d4

## Summary by Sourcery

Enhance the application with richer messaging features, a new lost-and-found workflow, and expanded tournament management options.

New Features:
- Introduce Lost & Found module with photo upload, status tracking, and dedicated media storage
- Add Sent Messages view, message detail pages, and inline reply functionality
- Extend tournament setup with rules enforcement levels and optional cube draft mode
- Enable inline player addition via lookup or quick-create in tournament view
- Provide CSV export and print controls for admin reports and schedules

Enhancements:
- Display unread message counts in the navigation and messaging toolbar
- Sanitize and thumbnail uploaded images before storage in a separate media database
- Support flexible datetime parsing for tournament start times
- Add live user lookup autocomplete in admin and tournament forms
- Serve uploaded media files securely via a dedicated endpoint

Build:
- Add Pillow dependency for image processing