### PR TITLE
Add report workflow tools and tournament join approvals

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -113,6 +113,16 @@ main { padding: 16px; }
 .center-table { margin: 0 auto; width:auto; }
 .toolbar { display:flex; flex-wrap:wrap; gap:8px; align-items:center; margin-bottom:16px; }
 .toolbar form { display:inline-flex; gap:4px; align-items:center; }
+.join-controls { display:flex; flex-direction:column; gap:0.5rem; }
+.join-controls .join-form { display:inline-flex; gap:0.5rem; align-items:center; }
+.join-approval-note { font-size:0.9rem; font-style:italic; }
+.join-request-status { padding:6px 8px; border-radius:6px; font-weight:600; }
+.join-request-status.info { background:var(--light-green); color:var(--dark-grey); }
+.join-request-status.error { background:var(--burnt-orange); color:#fff; }
+.join-requests { margin:24px 0; }
+.join-request-form { display:flex; flex-direction:column; gap:0.5rem; align-items:flex-start; }
+.join-request-actions { display:flex; gap:0.5rem; }
+.join-request-form textarea { width:100%; }
 .players-table { width:100%; border-collapse:collapse; }
 .players-table tbody { display:grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); }
 .players-table tr { display:contents; }

--- a/app/templates/admin/edit_tournament.html
+++ b/app/templates/admin/edit_tournament.html
@@ -77,6 +77,12 @@
         <td><input type="datetime-local" name="start_time" value="{{ t.start_time.strftime('%Y-%m-%dT%H:%M') if t.start_time else '' }}"></td>
       </tr>
       <tr>
+        <td>Require Join Approval</td>
+        <td>
+          <label><input type="checkbox" name="join_requires_approval" value="1"{% if t.join_requires_approval %} checked{% endif %}> Require staff approval before players join</label>
+        </td>
+      </tr>
+      <tr>
         <td colspan="2"><button class="btn" type="submit">Save</button></td>
       </tr>
     </tbody>

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -78,6 +78,12 @@
         <td><input type="datetime-local" name="start_time"></td>
       </tr>
       <tr>
+        <td>Require Join Approval</td>
+        <td>
+          <label><input type="checkbox" name="join_requires_approval" value="1"> Require staff approval before players join</label>
+        </td>
+      </tr>
+      <tr>
         <td colspan="2"><button class="btn" type="submit">Create</button></td>
       </tr>
     </tbody>

--- a/app/templates/admin/permissions.html
+++ b/app/templates/admin/permissions.html
@@ -2,10 +2,11 @@
 {% block content %}
 <h2>Permissions</h2>
 <table class="table">
-  <tr><th>Role</th><th>Granted Permissions</th></tr>
+  <tr><th>Role</th><th>Level</th><th>Granted Permissions</th></tr>
   {% for role in roles %}
   <tr>
     <td>{{ role.name }}</td>
+    <td>{{ role.level }}</td>
     <td>
       {% for key, val in role.permissions_dict().items() %}
         {% if val %}<div>{{ key }}</div>{% endif %}
@@ -17,6 +18,9 @@
 <h3>Create Role</h3>
 <form method="post">
   <input type="text" name="name" placeholder="Role name" required><br>
+  <label>Role Level
+    <input type="number" name="level" value="500" step="50" min="0">
+  </label><br>
   {% for cat, perms in permission_groups.items() %}
   <fieldset>
     <legend>{{ cat|capitalize }}</legend>

--- a/app/templates/admin/reports.html
+++ b/app/templates/admin/reports.html
@@ -8,26 +8,95 @@
 {% if not reports %}
 <p>No reports have been submitted.</p>
 {% else %}
-<table class="table">
+<table class="table reports-table">
   <tr>
+    <th>Status</th>
     <th>Type</th>
     <th>Reporter</th>
     <th>Reported User</th>
     <th>Submitted</th>
-    <th>Status</th>
+    <th>Assigned</th>
   </tr>
   {% for report in reports %}
-  <tr>
+  <tr class="{% if not report.is_read %}unread{% endif %}">
+    <td>{{ report.status.replace('_', ' ')|capitalize }}</td>
     <td>{{ 'Bug' if report.report_type == 'bug' else 'Player' }}</td>
     <td>{{ report.reporter.name if report.reporter else 'Unknown' }}</td>
     <td>{% if report.reported_user %}{{ report.reported_user.name }}{% else %}-{% endif %}</td>
     <td>{{ report.created_at }}</td>
-    <td>{{ report.status|capitalize }}</td>
+    <td>{{ report.assigned_to.name if report.assigned_to else 'Unassigned' }}</td>
   </tr>
-  <tr>
-    <td colspan="5">{{ report.description }}</td>
+  <tr class="report-details">
+    <td colspan="6">
+      <div class="report-description">{{ report.description | replace('\n', '<br>') | safe }}</div>
+      {% if report.actions_taken %}
+      <div class="report-actions-display"><strong>Actions Taken:</strong> {{ report.actions_taken | replace('\n', '<br>') | safe }}</div>
+      {% endif %}
+      <form class="report-update-form" method="post" action="{{ url_for('update_report', rid=report.id) }}">
+        <div class="form-row">
+          <label>Assigned To
+            <select name="assigned_to_id">
+              <option value="">Unassigned</option>
+              {% for user in assignees %}
+              <option value="{{ user.id }}"{% if report.assigned_to and report.assigned_to.id == user.id %} selected{% endif %}>{{ user.name }}</option>
+              {% endfor %}
+            </select>
+          </label>
+          <label>Status
+            <select name="status">
+              {% for status in status_options %}
+              <option value="{{ status }}"{% if report.status == status %} selected{% endif %}>{{ status.replace('_', ' ')|capitalize }}</option>
+              {% endfor %}
+            </select>
+          </label>
+          <label class="checkbox-label">
+            <input type="checkbox" name="is_read" value="1"{% if report.is_read %} checked{% endif %}> Mark as read
+          </label>
+        </div>
+        <label>Actions Taken
+          <textarea name="actions_taken" rows="3">{{ report.actions_taken or '' }}</textarea>
+        </label>
+        <button class="btn" type="submit">Save Changes</button>
+      </form>
+    </td>
   </tr>
   {% endfor %}
 </table>
 {% endif %}
+<style>
+.reports-table .unread > td {
+  font-weight: bold;
+}
+.report-update-form {
+  margin-top: 1rem;
+  padding: 0.5rem;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fafafa;
+}
+.report-update-form .form-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  margin-bottom: 0.75rem;
+}
+.report-update-form label {
+  display: flex;
+  flex-direction: column;
+  font-weight: 600;
+}
+.report-update-form .checkbox-label {
+  flex-direction: row;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+}
+.report-update-form textarea {
+  width: 100%;
+}
+.report-description,
+.report-actions-display {
+  margin-bottom: 0.75rem;
+}
+</style>
 {% endblock %}

--- a/app/templates/tournament/logs.html
+++ b/app/templates/tournament/logs.html
@@ -1,6 +1,7 @@
 {% extends 'base.html' %}
 {% block content %}
 <h2>{{ t.name }} Logs</h2>
+<p><a href="{{ url_for('view_tournament', tid=t.id) }}">&larr; Back to {{ t.name }}</a></p>
 <table>
   <tr><th>Time</th><th>User</th><th>Action</th><th>Result</th><th>Error</th></tr>
   {% for l in logs %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -21,14 +21,29 @@
 <div class="toolbar">
   <button class="btn" onclick="window.print()">Print</button>
   {% if not is_player %}
-  <form method="post" action="{{ url_for('join_tournament', tid=t.id) }}">
+  <div class="join-controls">
     {% if current_user.is_authenticated %}
-      <input type="text" name="passcode" maxlength="4" pattern="\d{4}" placeholder="Passcode" required>
-      <button class="btn" type="submit">Join</button>
+      {% set join_pending = user_join_request and user_join_request.status == 'pending' %}
+      {% set join_rejected = user_join_request and user_join_request.status == 'rejected' %}
+      {% if t.join_requires_approval %}
+        <div class="join-approval-note">Approval required before players may join this tournament.</div>
+      {% endif %}
+      {% if join_pending %}
+        <div class="join-request-status info">Your join request is pending approval.</div>
+      {% elif join_rejected %}
+        <div class="join-request-status error">Your previous join request was rejected{% if user_join_request.note %}: {{ user_join_request.note }}{% endif %}.</div>
+      {% endif %}
+      {% set allow_join_form = (not t.join_requires_approval) or (not join_pending) %}
+      {% if allow_join_form %}
+      <form method="post" action="{{ url_for('join_tournament', tid=t.id) }}" class="join-form">
+        <input type="text" name="passcode" maxlength="4" pattern="\d{4}" placeholder="Passcode" required>
+        <button class="btn" type="submit">{% if t.join_requires_approval %}Request Join{% else %}Join{% endif %}</button>
+      </form>
+      {% endif %}
     {% else %}
       <a class="btn" href="{{ url_for('login') }}">Login to Join</a>
     {% endif %}
-  </form>
+  </div>
   {% endif %}
   <a class="btn" href="{{ url_for('standings', tid=t.id) }}">Standings</a>
   {% if t.cut.startswith('top') %}
@@ -50,6 +65,39 @@
     <a class="btn" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
   {% endif %}
 </div>
+
+{% if current_user.is_authenticated and current_user.has_permission('tournaments.approve_join') and t.join_requires_approval %}
+<section class="join-requests">
+  <h3>Join Requests</h3>
+  {% if pending_join_requests %}
+  <table class="table">
+    <tr><th>Player</th><th>Requested</th><th>Existing Note</th></tr>
+    {% for req in pending_join_requests %}
+    <tr>
+      <td>{{ req.user.name if req.user else 'Unknown' }}</td>
+      <td>{{ req.created_at }}</td>
+      <td>{{ req.note or '-' }}</td>
+    </tr>
+    <tr>
+      <td colspan="3">
+        <form method="post" action="{{ url_for('approve_join_request', tid=t.id, req_id=req.id) }}" class="join-request-form">
+          <label>Note
+            <textarea name="note" rows="2">{{ req.note or '' }}</textarea>
+          </label>
+          <div class="join-request-actions">
+            <button class="btn" type="submit">Approve</button>
+            <button class="btn" type="submit" formaction="{{ url_for('reject_join_request', tid=t.id, req_id=req.id) }}">Reject</button>
+          </div>
+        </form>
+      </td>
+    </tr>
+    {% endfor %}
+  </table>
+  {% else %}
+  <p>No pending join requests.</p>
+  {% endif %}
+</section>
+{% endif %}
 
 {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
 <section class="inline-add-player">

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,7 @@ import os
 import json
 import pytest
 from app.app import create_app, db
-from app.models import Role, DEFAULT_ROLE_PERMISSIONS
+from app.models import Role, DEFAULT_ROLE_PERMISSIONS, DEFAULT_ROLE_LEVELS
 
 
 @pytest.fixture
@@ -16,7 +16,11 @@ def app(tmp_path, monkeypatch):
         db.create_all()
         # set up default roles
         for name, perms in DEFAULT_ROLE_PERMISSIONS.items():
-            role = Role(name=name, permissions=json.dumps(perms))
+            role = Role(
+                name=name,
+                permissions=json.dumps(perms),
+                level=DEFAULT_ROLE_LEVELS.get(name, 500),
+            )
             db.session.add(role)
         db.session.commit()
         yield application

--- a/tests/test_db_upgrade.py
+++ b/tests/test_db_upgrade.py
@@ -75,6 +75,67 @@ def test_report_table_created(tmp_path, monkeypatch):
         tables = inspector.get_table_names()
         assert 'report' in tables
         cols = [c['name'] for c in inspector.get_columns('report')]
-        for name in ('report_type', 'description', 'reporter_id', 'status'):
+        for name in (
+            'report_type',
+            'description',
+            'reporter_id',
+            'status',
+            'is_read',
+            'assigned_to_id',
+            'actions_taken',
+        ):
             assert name in cols
+        db.session.remove()
+
+
+def test_join_requires_approval_column_added(tmp_path, monkeypatch):
+    db_path = tmp_path / "pre.db"
+    log_path = tmp_path / "logs.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE tournament (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR(200) NOT NULL,
+            format VARCHAR(50) NOT NULL,
+            passcode VARCHAR(4) NOT NULL
+        )
+        """
+    )
+    conn.close()
+
+    monkeypatch.setenv("MTG_DB_PATH", str(db_path))
+    monkeypatch.setenv("MTG_LOG_DB_PATH", str(log_path))
+
+    app = create_app()
+    with app.app_context():
+        inspector = inspect(db.engine)
+        cols = [c['name'] for c in inspector.get_columns('tournament')]
+        assert 'join_requires_approval' in cols
+        db.session.remove()
+
+
+def test_role_level_column_added(tmp_path, monkeypatch):
+    db_path = tmp_path / "pre.db"
+    log_path = tmp_path / "logs.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE role (
+            id INTEGER PRIMARY KEY,
+            name VARCHAR(50) NOT NULL,
+            permissions TEXT NOT NULL
+        )
+        """
+    )
+    conn.close()
+
+    monkeypatch.setenv("MTG_DB_PATH", str(db_path))
+    monkeypatch.setenv("MTG_LOG_DB_PATH", str(log_path))
+
+    app = create_app()
+    with app.app_context():
+        inspector = inspect(db.engine)
+        cols = [c['name'] for c in inspector.get_columns('role')]
+        assert 'level' in cols
         db.session.remove()

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,5 +1,7 @@
 import json
+
 from app.app import db
+
 from app.models import User, Role
 
 
@@ -50,3 +52,20 @@ def test_user_permission_overrides(session):
     fetched = session.query(User).filter_by(email='override@example.com').one()
     assert fetched.has_permission('admin.panel')
     assert not fetched.has_permission('users.manage')
+
+
+def test_default_role_levels(session):
+    levels = {r.name: r.level for r in session.query(Role).all()}
+    assert levels['admin'] == 0
+    assert levels['manager'] == 100
+    assert levels['venue judge'] == 200
+    assert levels['event head judge'] == 300
+    assert levels['floor judge'] == 400
+    assert levels['user'] == 500
+
+
+def test_roles_can_approve_join(session):
+    roles = {r.name: r for r in session.query(Role).all()}
+    for name in ('manager', 'venue judge', 'event head judge', 'floor judge'):
+        perms = json.loads(roles[name].permissions)
+        assert perms.get('tournaments.approve_join')


### PR DESCRIPTION
## Summary
- add role levels and approval permission to support join request workflow
- allow tournaments to require join approval with admin/judge UI and CSS updates
- enhance report management with assignment, read status, and action tracking

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d1e41c8f6483208057986c6f728c49

## Summary by Sourcery

Implement tournament join approval workflow, extend report management tools, and introduce role levels for permissions

New Features:
- Support tournament join requests with submit, approve, and reject endpoints and UI controls
- Enable in-place report updates with status, assignment, read flag, and action tracking via admin endpoints and templates

Enhancements:
- Add join_requires_approval flag to tournaments and corresponding admin creation/edit interfaces
- Introduce role level field with default mappings and use level-based ordering in permissions UI
- Extend Report model and CSV exports with is_read, assigned_to, and actions_taken fields

Tests:
- Add migration tests for report upgrades, join_requires_approval, and role level columns
- Add tests for default role levels and permissions including join approval capability