### PR TITLE
Fix db-init CLI for Flask-SQLAlchemy 3

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -181,7 +181,7 @@ def create_app():
     @app.cli.command('db-init')
     def db_init():
         db.create_all()
-        db.create_all(bind='media')
+        db.create_all(bind_key='media')
         # Ensure default roles
         for name, perms in DEFAULT_ROLE_PERMISSIONS.items():
             level = DEFAULT_ROLE_LEVELS.get(name, 500)


### PR DESCRIPTION
## Summary
- update the db-init CLI command to use the modern `bind_key` argument when initializing the media database

## Testing
- PYTHONPATH=. pytest

------
https://chatgpt.com/codex/tasks/task_e_68d33439c9fc83209edfc2bf54d6604b