### PR TITLE
Add tournament deck management features

### DIFF
--- a/app/card_db.py
+++ b/app/card_db.py
@@ -1,0 +1,164 @@
+import io
+import json
+import os
+import sqlite3
+import tempfile
+import zipfile
+from contextlib import contextmanager
+from typing import Iterable, List, Optional
+from urllib.request import urlopen
+
+ATOMIC_CARDS_URL = "https://mtgjson.com/api/v5/AtomicCards.json.zip"
+
+
+def _normalize_name(name: str) -> str:
+    normalized = ''.join(ch for ch in name.lower() if ch.isalnum())
+    return normalized
+
+
+def ensure_directory(path: str) -> None:
+    directory = os.path.dirname(path)
+    if directory:
+        os.makedirs(directory, exist_ok=True)
+
+
+def _ensure_schema(connection: sqlite3.Connection) -> None:
+    connection.execute(
+        """
+        CREATE TABLE IF NOT EXISTS cards (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            name TEXT NOT NULL UNIQUE,
+            search_name TEXT NOT NULL,
+            normalized_name TEXT NOT NULL UNIQUE
+        )
+        """
+    )
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS idx_cards_search_name ON cards(search_name)"
+    )
+    connection.execute(
+        "CREATE INDEX IF NOT EXISTS idx_cards_normalized_name ON cards(normalized_name)"
+    )
+
+
+def populate_card_database(path: str, card_names: Iterable[str]) -> None:
+    ensure_directory(path)
+    connection = sqlite3.connect(path)
+    try:
+        _ensure_schema(connection)
+        existing = connection.execute("SELECT name FROM cards").fetchone()
+        if existing:
+            return
+        rows = [
+            (name, name.lower(), _normalize_name(name))
+            for name in card_names
+        ]
+        connection.executemany(
+            "INSERT OR IGNORE INTO cards(name, search_name, normalized_name) VALUES (?, ?, ?)",
+            rows,
+        )
+        connection.commit()
+    finally:
+        connection.close()
+
+
+def _read_atomic_cards_from_zip(path: str) -> List[str]:
+    with zipfile.ZipFile(path) as archive:
+        json_name = None
+        for member in archive.namelist():
+            if member.lower().endswith('.json'):
+                json_name = member
+                break
+        if not json_name:
+            raise RuntimeError("AtomicCards.json not found in archive")
+        with archive.open(json_name) as handle:
+            text_wrapper = io.TextIOWrapper(handle, encoding='utf-8')
+            data = json.load(text_wrapper)
+        cards = data.get('data', {})
+        if not isinstance(cards, dict):
+            raise RuntimeError("Unexpected AtomicCards format")
+        return list(cards.keys())
+
+
+def build_card_database(path: str, source_url: Optional[str] = None) -> None:
+    ensure_directory(path)
+    url = source_url or ATOMIC_CARDS_URL
+    with tempfile.NamedTemporaryFile(delete=False) as tmp:
+        temp_name = tmp.name
+        with urlopen(url) as response:
+            while True:
+                chunk = response.read(1024 * 1024)
+                if not chunk:
+                    break
+                tmp.write(chunk)
+    try:
+        card_names = _read_atomic_cards_from_zip(temp_name)
+        populate_card_database(path, sorted(card_names))
+    finally:
+        try:
+            os.unlink(temp_name)
+        except FileNotFoundError:
+            pass
+
+
+def ensure_card_database(path: str, source_url: Optional[str] = None) -> str:
+    if not os.path.exists(path) or os.path.getsize(path) == 0:
+        build_card_database(path, source_url=source_url)
+    return path
+
+
+@contextmanager
+def open_card_database(path: str):
+    connection = sqlite3.connect(path)
+    try:
+        yield connection
+    finally:
+        connection.close()
+
+
+def search_cards(path: str, query: str, limit: int = 20) -> List[str]:
+    if not query:
+        return []
+    normalized_query = query.strip().lower()
+    if not normalized_query:
+        return []
+    pattern = f"%{normalized_query}%"
+    with open_card_database(path) as connection:
+        _ensure_schema(connection)
+        rows = connection.execute(
+            "SELECT name FROM cards WHERE search_name LIKE ? ORDER BY name LIMIT ?",
+            (pattern, limit),
+        ).fetchall()
+    return [row[0] for row in rows]
+
+
+def lookup_card(path: str, name: str) -> Optional[str]:
+    normalized = _normalize_name(name)
+    if not normalized:
+        return None
+    with open_card_database(path) as connection:
+        _ensure_schema(connection)
+        row = connection.execute(
+            "SELECT name FROM cards WHERE normalized_name = ? LIMIT 1",
+            (normalized,),
+        ).fetchone()
+    if row:
+        return row[0]
+    return None
+
+
+def canonicalize_names(path: str, names: Iterable[str]) -> List[Optional[str]]:
+    normalized_names = [(_normalize_name(name), name) for name in names]
+    with open_card_database(path) as connection:
+        _ensure_schema(connection)
+        results = []
+        for normalized, original in normalized_names:
+            if not normalized:
+                results.append(None)
+                continue
+            row = connection.execute(
+                "SELECT name FROM cards WHERE normalized_name = ? LIMIT 1",
+                (normalized,),
+            ).fetchone()
+            results.append(row[0] if row else None)
+    return results

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -199,6 +199,95 @@ main { padding: 16px; }
   margin-bottom:24px;
 }
 
+.player-deck {
+  margin:24px 0;
+  background:#fff;
+  padding:16px;
+  border-radius:12px;
+  box-shadow:0 2px 6px rgba(0,0,0,0.1);
+}
+.player-deck .deck-meta {
+  margin-bottom:12px;
+  font-size:0.95rem;
+  color:#555;
+}
+.player-deck .deck-lists {
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+}
+.player-deck .deck-list {
+  flex:1 1 240px;
+  background:#fffaf0;
+  border:1px solid var(--light-green);
+  border-radius:10px;
+  padding:12px;
+}
+.player-deck .deck-list ul {
+  list-style:none;
+  margin:0;
+  padding:0;
+}
+.player-deck .deck-list li {
+  padding:2px 0;
+}
+.player-deck .deck-image {
+  margin-top:16px;
+}
+.player-deck .deck-image img {
+  max-width:100%;
+  height:auto;
+  border-radius:10px;
+  border:1px solid var(--light-green);
+}
+.player-deck .deck-forms {
+  display:flex;
+  flex-wrap:wrap;
+  gap:16px;
+  margin-top:16px;
+}
+.player-deck .deck-form {
+  flex:1 1 260px;
+  display:flex;
+  flex-direction:column;
+  gap:8px;
+  background:#fffaf0;
+  border:1px solid var(--light-green);
+  border-radius:10px;
+  padding:12px;
+}
+.player-deck .deck-form textarea {
+  width:100%;
+  min-height:150px;
+}
+.player-deck .deck-form input[type="text"],
+.player-deck .deck-form input[type="file"] {
+  width:100%;
+}
+.card-search-widget {
+  margin-top:16px;
+}
+.card-search-widget input {
+  width:100%;
+}
+.card-search-results {
+  margin-top:8px;
+  min-height:1.5em;
+}
+.card-search-results ul {
+  list-style:none;
+  margin:0;
+  padding:0;
+  display:grid;
+  gap:6px;
+}
+.card-search-results li {
+  padding:4px 6px;
+  border:1px solid var(--light-green);
+  border-radius:6px;
+  background:#fff;
+}
+
 .message-meta {
   display:grid;
   grid-template-columns: auto 1fr;

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -62,9 +62,144 @@
     {% if t.format == 'Draft' %}
     <a class="btn" href="{{ url_for('draft_seating', tid=t.id) }}">Draft Seating</a>
     {% endif %}
-    <a class="btn" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
-  {% endif %}
+  <a class="btn" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
+{% endif %}
 </div>
+
+{% if is_player %}
+<section class="player-deck">
+  <h3>Your Deck</h3>
+  {% if player_deck %}
+  <p class="deck-meta">
+    Source: {{ player_deck.source|capitalize }}{% if player_deck.updated_at %} · Updated {{ player_deck.updated_at }}{% elif player_deck.created_at %} · Updated {{ player_deck.created_at }}{% endif %}
+    {% if player_deck.moxfield_url %}· <a href="{{ player_deck.moxfield_url }}" target="_blank" rel="noopener">View on Moxfield</a>{% endif %}
+  </p>
+  <div class="deck-lists">
+    <div class="deck-list">
+      <h4>Mainboard ({{ player_deck.total_mainboard() }})</h4>
+      {% set main_cards = player_deck.mainboard_cards() %}
+      {% if main_cards %}
+      <ul>
+        {% for card in main_cards %}
+        <li>{{ card.count }} × {{ card.name }}</li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p>No mainboard cards submitted.</p>
+      {% endif %}
+    </div>
+    <div class="deck-list">
+      <h4>Sideboard ({{ player_deck.total_sideboard() }})</h4>
+      {% set side_cards = player_deck.sideboard_cards() %}
+      {% if side_cards %}
+      <ul>
+        {% for card in side_cards %}
+        <li>{{ card.count }} × {{ card.name }}</li>
+        {% endfor %}
+      </ul>
+      {% else %}
+      <p>No sideboard submitted.</p>
+      {% endif %}
+    </div>
+  </div>
+  {% if player_deck.image_path %}
+  <div class="deck-image">
+    <h4>Deck Image</h4>
+    <img src="{{ url_for('media_file', filename=player_deck.image_path) }}" alt="Deck image" loading="lazy">
+  </div>
+  {% endif %}
+  {% else %}
+  <p>No deck information submitted yet.</p>
+  {% endif %}
+
+  <div class="deck-forms">
+    <form method="post" action="{{ url_for('upload_manual_deck', tid=t.id) }}" class="deck-form">
+      <label>Enter deck list
+        <textarea name="deck_text" rows="10" placeholder="4 Archon of Emeria
+4 Chrome Mox
+...
+Sideboard
+2 March of Otherworldly Light"></textarea>
+      </label>
+      <button class="btn" type="submit">Save Deck</button>
+    </form>
+
+    <form method="post" action="{{ url_for('import_moxfield_deck', tid=t.id) }}" class="deck-form">
+      <label>Moxfield deck link or ID
+        <input type="text" name="moxfield_url" placeholder="https://www.moxfield.com/decks/abcdef" required>
+      </label>
+      <button class="btn" type="submit">Import from Moxfield</button>
+    </form>
+
+    <form method="post" action="{{ url_for('upload_mtgo_deck', tid=t.id) }}" enctype="multipart/form-data" class="deck-form">
+      <label>MTGO deck file (.txt)
+        <input type="file" name="mtgo_file" accept=".txt" required>
+      </label>
+      <button class="btn" type="submit">Upload MTGO Deck</button>
+    </form>
+
+    {% if t.format == 'Draft' %}
+    <form method="post" action="{{ url_for('upload_deck_image', tid=t.id) }}" enctype="multipart/form-data" class="deck-form">
+      <label>Deck image (PNG/JPG)
+        <input type="file" name="deck_image" accept="image/*" required>
+      </label>
+      <button class="btn" type="submit">Upload Deck Image</button>
+    </form>
+    {% endif %}
+  </div>
+
+  {% if deck_search_url %}
+  <div class="card-search-widget">
+    <label>Search card database
+      <input type="text" id="card-search-input" placeholder="Card name">
+    </label>
+    <div id="card-search-results" class="card-search-results" aria-live="polite"></div>
+  </div>
+  <script>
+    document.addEventListener('DOMContentLoaded', function(){
+      const searchUrl = {{ deck_search_url|tojson }};
+      const input = document.getElementById('card-search-input');
+      const results = document.getElementById('card-search-results');
+      if (!searchUrl || !input || !results) {
+        return;
+      }
+      let timer = null;
+      input.addEventListener('input', function(){
+        const query = input.value.trim();
+        if (timer) {
+          clearTimeout(timer);
+        }
+        if (query.length < 2) {
+          results.textContent = '';
+          return;
+        }
+        timer = setTimeout(function(){
+          fetch(searchUrl + '?q=' + encodeURIComponent(query))
+            .then(function(resp){ return resp.json(); })
+            .then(function(data){
+              results.innerHTML = '';
+              if (!data || !Array.isArray(data.results) || data.results.length === 0) {
+                results.textContent = 'No results';
+                return;
+              }
+              const list = document.createElement('ul');
+              data.results.forEach(function(name){
+                const item = document.createElement('li');
+                item.textContent = name;
+                list.appendChild(item);
+              });
+              results.appendChild(list);
+            })
+            .catch(function(){
+              results.textContent = 'Search failed';
+            });
+        }, 250);
+      });
+    });
+  </script>
+  {% endif %}
+</section>
+{% endif %}
 
 {% if current_user.is_authenticated and current_user.has_permission('tournaments.approve_join') and t.join_requires_approval %}
 <section class="join-requests">

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ cryptography==42.0.7
 psutil==5.9.8
 PyYAML==6.0.1
 Pillow==10.3.0
+requests==2.32.3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,15 @@
-import os
 import json
+import os
+import sys
+
+PROJECT_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), '..'))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
 import pytest
 from app.app import create_app, db
 from app.models import Role, DEFAULT_ROLE_PERMISSIONS, DEFAULT_ROLE_LEVELS
+from app import card_db
 
 
 @pytest.fixture
@@ -10,6 +17,8 @@ def app(tmp_path, monkeypatch):
     # use temporary SQLite databases for testing
     monkeypatch.setenv("MTG_DB_PATH", str(tmp_path / "test.db"))
     monkeypatch.setenv("MTG_LOG_DB_PATH", str(tmp_path / "test_logs.db"))
+    card_db_path = tmp_path / "cards.db"
+    monkeypatch.setenv("MTG_CARD_DB_PATH", str(card_db_path))
     application = create_app()
     application.config['TESTING'] = True
     with application.app_context():
@@ -23,6 +32,17 @@ def app(tmp_path, monkeypatch):
             )
             db.session.add(role)
         db.session.commit()
+        sample_cards = [
+            'Strip Mine', 'Archon of Emeria', 'Black Lotus', 'Mana Crypt', 'Karakas',
+            'Chancellor of the Annex', 'Chrome Mox', 'Solitude', 'Clarion Conqueror',
+            'Cavern of Souls', 'Mox Emerald', 'Mox Jet', 'Mox Pearl', 'Mox Ruby',
+            'Mox Sapphire', 'Plains', 'Seasoned Dungeoneer', 'Anointed Peacekeeper',
+            'Vexing Bauble', 'Wasteland', 'White Plume Adventurer', 'Witch Enchanter',
+            'Ancient Tomb', 'Void Mirror', 'March of Otherworldly Light',
+            'Archon of Absolution', 'Leyline of the Void', 'Containment Priest',
+            'Swords to Plowshares', 'Null Rod'
+        ]
+        card_db.populate_card_database(str(card_db_path), sample_cards)
         yield application
         db.session.remove()
 
@@ -30,3 +50,8 @@ def app(tmp_path, monkeypatch):
 @pytest.fixture
 def session(app):
     return db.session
+
+
+@pytest.fixture
+def client(app):
+    return app.test_client()

--- a/tests/test_decklists.py
+++ b/tests/test_decklists.py
@@ -1,0 +1,175 @@
+import base64
+import io
+
+import pytest
+
+from app.app import db
+from app.models import (
+    Role,
+    Tournament,
+    TournamentPlayer,
+    TournamentPlayerDeck,
+    User,
+)
+
+
+@pytest.fixture
+def user(session):
+    role = session.query(Role).filter_by(name='user').first()
+    player = User(email='player@example.com', name='Player One', role=role)
+    player.set_password('secret')
+    session.add(player)
+    session.commit()
+    return player
+
+
+def create_tournament(session, name='Deck Event', fmt='Constructed'):
+    tournament = Tournament(name=name, format=fmt, passcode='0000')
+    session.add(tournament)
+    session.commit()
+    return tournament
+
+
+def register_player(session, tournament, user):
+    tp = TournamentPlayer(tournament_id=tournament.id, user_id=user.id)
+    session.add(tp)
+    session.commit()
+    return tp
+
+
+def login(client, user):
+    return client.post(
+        '/login',
+        data={'email': user.email, 'password': 'secret'},
+        follow_redirects=True,
+    )
+
+
+def test_manual_deck_submission(client, session, user):
+    tournament = create_tournament(session)
+    tp = register_player(session, tournament, user)
+    login(client, user)
+
+    deck_text = '1 Black Lotus\n1 Strip Mine\nSideboard\n2 Null Rod'
+    response = client.post(
+        f'/t/{tournament.id}/deck/manual',
+        data={'deck_text': deck_text},
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    session.refresh(tp)
+    deck = tp.deck
+    assert deck is not None
+    assert deck.source == 'manual'
+    assert any(card['name'] == 'Black Lotus' for card in deck.mainboard_cards())
+    assert deck.total_sideboard() == 2
+
+
+def test_moxfield_import(client, session, user, monkeypatch):
+    tournament = create_tournament(session)
+    tp = register_player(session, tournament, user)
+    login(client, user)
+
+    sample_payload = {
+        'mainboard': {
+            '1': {'quantity': 2, 'card': {'name': 'Archon of Emeria'}},
+            '2': {'quantity': 1, 'card': {'name': 'Black Lotus'}},
+        },
+        'sideboard': {
+            'a': {'quantity': 1, 'card': {'name': 'Null Rod'}},
+        },
+    }
+
+    class DummyResponse:
+        status_code = 200
+
+        def json(self):
+            return sample_payload
+
+    monkeypatch.setattr('app.app.requests.get', lambda url, timeout=15: DummyResponse())
+
+    deck_url = 'https://www.moxfield.com/decks/abc123'
+    response = client.post(
+        f'/t/{tournament.id}/deck/moxfield',
+        data={'moxfield_url': deck_url},
+    )
+    assert response.status_code == 302
+
+    session.refresh(tp)
+    deck = tp.deck
+    assert deck is not None
+    assert deck.source == 'moxfield'
+    assert deck.moxfield_url == deck_url
+    names = {card['name'] for card in deck.mainboard_cards()}
+    assert {'Archon of Emeria', 'Black Lotus'} <= names
+
+
+def test_mtgo_deck_upload(client, session, user):
+    tournament = create_tournament(session)
+    tp = register_player(session, tournament, user)
+    login(client, user)
+
+    mtgo_text = '1 Strip Mine\n1 Black Lotus\nSideboard\n1 Null Rod\n'
+    response = client.post(
+        f'/t/{tournament.id}/deck/mtgo',
+        data={'mtgo_file': (io.BytesIO(mtgo_text.encode('utf-8')), 'deck.txt')},
+        content_type='multipart/form-data',
+    )
+    assert response.status_code == 302
+
+    session.refresh(tp)
+    deck = tp.deck
+    assert deck is not None
+    assert deck.source == 'mtgo'
+    assert deck.total_mainboard() == 2
+    assert deck.total_sideboard() == 1
+
+
+def test_deck_image_upload_for_draft(client, session, user):
+    tournament = create_tournament(session, fmt='Draft')
+    tp = register_player(session, tournament, user)
+    login(client, user)
+
+    png_bytes = base64.b64decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5lH2gAAAAASUVORK5CYII='
+    )
+    response = client.post(
+        f'/t/{tournament.id}/deck/image',
+        data={'deck_image': (io.BytesIO(png_bytes), 'deck.png')},
+        content_type='multipart/form-data',
+    )
+    assert response.status_code == 302
+
+    session.refresh(tp)
+    deck = tp.deck
+    assert deck is not None
+    assert deck.image_path
+
+    # Ensure non-draft events reject image uploads
+    other = create_tournament(session, name='Constructed', fmt='Constructed')
+    register_player(session, other, user)
+    response = client.post(
+        f'/t/{other.id}/deck/image',
+        data={'deck_image': (io.BytesIO(png_bytes), 'deck2.png')},
+        content_type='multipart/form-data',
+    )
+    assert response.status_code == 302
+    other_tp = (
+        session.query(TournamentPlayer)
+        .filter_by(tournament_id=other.id, user_id=user.id)
+        .first()
+    )
+    assert other_tp.deck is None
+
+
+def test_card_search_endpoint(client, session, user):
+    tournament = create_tournament(session)
+    register_player(session, tournament, user)
+    login(client, user)
+
+    response = client.get(f'/t/{tournament.id}/deck/search?q=archon')
+    assert response.status_code == 200
+    data = response.get_json()
+    assert 'results' in data
+    assert any('Archon of Emeria' == name for name in data['results'])


### PR DESCRIPTION
## Summary
- add a local card database builder backed by MTGJSON atomic data and expose card search utilities
- allow players to upload decks via manual entry, MTGO files, Moxfield imports, and draft deck images with new UI controls
- style the deck management panel and add automated tests covering the new flows

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d338349d9c83209f74ac438a4a8a88

## Summary by Sourcery

Enable full tournament deck management by creating a TournamentPlayerDeck model and related database table, integrating a local card database for name lookup and search, exposing new web endpoints and UI controls for submitting and reviewing decks, and styling the deck panel with form support and automated tests.

New Features:
- Allow players to submit and save tournament decks via manual text entry, MTGO files, Moxfield imports, and draft deck images
- Provide a local MTG card database with search, name canonicalization, and automatic population from MTGJSON

Enhancements:
- Render a styled deck management panel in the tournament view with live card search widget
- Introduce shared parsing utilities to normalize, combine, and validate deck entries before saving

Tests:
- Add automated pytest tests covering manual, MTGO, Moxfield, image uploads, and card search endpoint