### PR TITLE
Add deck builder removal controls

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -52,6 +52,13 @@ main { padding: 16px; }
   background:#b24400;
   transform:translateY(-2px);
 }
+.btn.danger {
+  background:#b13b2e;
+  border-color:#8d2f23;
+}
+.btn.danger:hover {
+  background:#8d2f23;
+}
 .btn:active {
   transform:translateY(0);
 }
@@ -356,6 +363,12 @@ main { padding: 16px; }
 }
 .btn-small:hover {
   background:var(--dark-green);
+}
+.btn-small.danger {
+  background:#b13b2e;
+}
+.btn-small.danger:hover {
+  background:#8d2f23;
 }
 .deck-builder-actions {
   display:flex;

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -154,6 +154,7 @@
         </div>
       </div>
       <div class="deck-builder-actions">
+        <button class="btn danger" type="button" id="deck-clear-button">Clear Deck</button>
         <button class="btn" type="submit" name="action" value="save">Save Deck</button>
         <button class="btn primary" type="submit" name="action" value="submit">Submit Deck</button>
       </div>
@@ -277,6 +278,9 @@ Sideboard
             button.dataset.board = board;
             button.dataset.cardName = card.name;
             button.textContent = pair[0];
+            if (pair[1] === 'remove') {
+              button.classList.add('danger');
+            }
             actions.appendChild(button);
           });
           item.appendChild(count);
@@ -335,6 +339,15 @@ Sideboard
         }
       }
 
+      function clearDeck() {
+        if (state.main.length === 0 && state.side.length === 0) {
+          return;
+        }
+        state.main = [];
+        state.side = [];
+        renderAll();
+      }
+
       form.addEventListener('click', function(event){
         const target = event.target;
         if (!(target instanceof HTMLElement)) {
@@ -357,6 +370,13 @@ Sideboard
           removeCard(board, cardName);
         }
       });
+
+      const clearButton = document.getElementById('deck-clear-button');
+      if (clearButton) {
+        clearButton.addEventListener('click', function(){
+          clearDeck();
+        });
+      }
 
       if (searchInput && results && searchUrl) {
         let timer = null;


### PR DESCRIPTION
## Summary
- add a clear deck button and hook it up to wipe the builder state
- highlight removal controls so individual cards can be removed directly

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d346d4bdb08320bf390f418f7e9d7a