### PR TITLE
Handle Moxfield 403 responses and add deck image removal

### DIFF
--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -113,6 +113,11 @@
   <div class="deck-image">
     <h4>Deck Image</h4>
     <img src="{{ url_for('media_file', filename=player_deck.image_path) }}" alt="Deck image" loading="lazy">
+    {% if not deck_locked %}
+    <form method="post" action="{{ url_for('delete_deck_image', tid=t.id) }}" class="deck-form deck-image-delete-form">
+      <button class="btn danger" type="submit">Delete Deck Image</button>
+    </form>
+    {% endif %}
   </div>
   {% endif %}
   {% else %}


### PR DESCRIPTION
## Summary
- add configurable Moxfield user agent defaults and retry logic so 403 responses are retried when importing decks
- allow draft players to delete previously uploaded deck images and show a delete button in the deck view
- cover the new behaviours with tests for the retry logic and deck image cleanup

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68d34b69e1a08320afc3658a042098bb