### PR TITLE
Revamp messaging UI and align admin forms

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -358,6 +358,87 @@ p {
   color: var(--brand-muted);
 }
 
+.user-settings-section {
+  margin-bottom: 32px;
+  background: var(--brand-surface);
+  padding: 24px;
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-soft);
+  border: 1px solid var(--border-soft);
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.user-settings-section h3 {
+  margin: 0;
+}
+
+.user-settings-form {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  max-width: 720px;
+}
+
+.user-settings-form .form-row {
+  display: grid;
+  grid-template-columns: minmax(180px, 220px) minmax(0, 1fr);
+  gap: 16px;
+  align-items: center;
+}
+
+.user-settings-form .form-row > label {
+  font-weight: 600;
+  color: var(--brand-muted);
+}
+
+.user-settings-form .form-row input,
+.user-settings-form .form-row select,
+.user-settings-form .form-row textarea {
+  width: 100%;
+}
+
+.user-settings-form .form-row--textarea {
+  align-items: flex-start;
+}
+
+.user-settings-form details {
+  background: rgba(148, 163, 184, 0.08);
+  border-radius: var(--radius-md);
+  padding: 16px;
+}
+
+.user-settings-form fieldset {
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  padding: 16px;
+  margin: 16px 0;
+}
+
+.user-settings-form fieldset legend {
+  font-weight: 600;
+  color: var(--brand-text);
+}
+
+.user-settings-form fieldset label {
+  display: grid;
+  grid-template-columns: minmax(180px, 1fr) minmax(0, 220px);
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 12px;
+  font-weight: 500;
+  color: var(--brand-text);
+}
+
+.user-settings-form fieldset label span {
+  color: var(--brand-muted);
+}
+
+.user-settings-form fieldset select {
+  width: 100%;
+}
+
 input,
 select,
 textarea {
@@ -508,6 +589,16 @@ textarea {
 
 .card-actions form {
   display: inline-flex;
+}
+
+.card-description {
+  margin: 0;
+  color: var(--brand-muted);
+  line-height: 1.5;
+}
+
+.message-options .card {
+  min-height: 220px;
 }
 
 .timer {

--- a/app/templates/admin/panel.html
+++ b/app/templates/admin/panel.html
@@ -2,7 +2,7 @@
 {% block content %}
 <h2>Admin Debug Panel</h2>
 <ul>
-  <li>Encryption type: {{ encryption_type }}</li>
+  <li>Hash type: {{ encryption_type }}</li>
   <li>Database size: {{ db_size }}</li>
   <li>RAM usage: {{ ram_usage }}</li>
   <li>CPU usage: {{ cpu_usage }}%</li>

--- a/app/templates/admin/user_detail.html
+++ b/app/templates/admin/user_detail.html
@@ -12,25 +12,30 @@
   <form method="post" action="{{ url_for('admin_update_user', uid=user.id) }}" class="user-settings-form">
     <input type="hidden" name="search_query" value="{{ search_query }}">
     <input type="hidden" name="next" value="{{ detail_url }}">
-    <label>Email<br>
-      <input type="email" name="email" value="{{ user.email or '' }}">
-    </label>
-    <label>Notes<br>
-      <textarea name="notes" rows="3" cols="30">{{ user.notes or '' }}</textarea>
-    </label>
-    <label>Role<br>
-      <select name="role_id">
+    <div class="form-row">
+      <label for="user-email">Email</label>
+      <input id="user-email" type="email" name="email" value="{{ user.email or '' }}">
+    </div>
+    <div class="form-row form-row--textarea">
+      <label for="user-notes">Notes</label>
+      <textarea id="user-notes" name="notes" rows="3" cols="30">{{ user.notes or '' }}</textarea>
+    </div>
+    <div class="form-row">
+      <label for="user-role">Role</label>
+      <select id="user-role" name="role_id">
         {% for r in roles %}
         <option value="{{ r.id }}" {% if user.role_id == r.id %}selected{% endif %}>{{ r.name }}</option>
         {% endfor %}
       </select>
-    </label>
-    <label>Set Password<br>
-      <input type="password" name="password" placeholder="New password">
-    </label>
-    <label>Confirm Password<br>
-      <input type="password" name="password_confirm" placeholder="Confirm password">
-    </label>
+    </div>
+    <div class="form-row">
+      <label for="user-password">Set Password</label>
+      <input id="user-password" type="password" name="password" placeholder="New password">
+    </div>
+    <div class="form-row">
+      <label for="user-password-confirm">Confirm Password</label>
+      <input id="user-password-confirm" type="password" name="password_confirm" placeholder="Confirm password">
+    </div>
     {% if can_manage_overrides %}
     <details>
       <summary>Permission Overrides</summary>
@@ -41,7 +46,8 @@
         {% for perm, desc in perms.items() %}
         {% set key = cat ~ '.' ~ perm %}
         {% set value = overrides.get(key) %}
-        <label>{{ desc }}
+        <label>
+          <span>{{ desc }}</span>
           <select name="perm_override_{{ key }}">
             <option value="" {% if not value %}selected{% endif %}>Inherit</option>
             <option value="allow" {% if value == 'allow' %}selected{% endif %}>Allow</option>
@@ -76,13 +82,14 @@
   <form method="post" action="{{ url_for('admin_add_user_to_tournament', uid=user.id) }}" class="user-settings-form">
     <input type="hidden" name="search_query" value="{{ search_query }}">
     <input type="hidden" name="next" value="{{ detail_url }}">
-    <label>Add to tournament
-      <select name="tournament_id">
+    <div class="form-row">
+      <label for="assign-tournament">Add to tournament</label>
+      <select id="assign-tournament" name="tournament_id">
         {% for t in tournaments %}
         <option value="{{ t.id }}">{{ t.name }}</option>
         {% endfor %}
       </select>
-    </label>
+    </div>
     <button class="btn" type="submit">Add</button>
   </form>
 </section>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,7 +21,13 @@
       <div class="card-meta">
         <span><strong>Format</strong>{{ t.format }}</span>
         <span><strong>Cut</strong>{{ t.cut|upper }}</span>
+        {% if t.rules_enforcement_level %}
+        <span><strong>REL</strong>{{ t.rules_enforcement_level }}</span>
+        {% endif %}
         <span><strong>Players</strong>{{ player_counts[t.id] }}</span>
+        {% if t.head_judge %}
+        <span><strong>Head Judge</strong>{{ t.head_judge.name }}</span>
+        {% endif %}
         {% set end = t.round_timer_end or t.draft_timer_end or t.deck_timer_end %}
         {% if t.round_timer_end %}{% set ttype = 'round' %}{% elif t.draft_timer_end %}{% set ttype = 'draft' %}{% elif t.deck_timer_end %}{% set ttype = 'deck' %}{% endif %}
         {% if end %}

--- a/app/templates/messages/index.html
+++ b/app/templates/messages/index.html
@@ -1,15 +1,52 @@
 {% extends 'base.html' %}
 {% block content %}
-<h2>Messages</h2>
-<p>Select the messaging option that matches what you need to do.</p>
-<ul class="message-nav">
-  <li><a href="{{ url_for('messages_inbox') }}">Player Inbox</a> – read your encrypted messages and compose direct replies.</li>
-  <li><a href="{{ url_for('messages_sent') }}">Sent Messages</a> – review anything you have sent.</li>
+<section class="page-header">
+  <div class="page-header__title">
+    <h2>Messages</h2>
+    <p class="page-description">Choose how you want to communicate with your players, judges, or staff.</p>
+  </div>
+</section>
+
+<ul class="cards message-options">
+  <li class="card">
+    <div class="card-header">
+      <h3 class="card-title">Player Inbox</h3>
+    </div>
+    <p class="card-description">Read encrypted messages from players and compose direct replies.</p>
+    <div class="card-actions">
+      <a class="btn" href="{{ url_for('messages_inbox') }}">Open Inbox</a>
+    </div>
+  </li>
+  <li class="card">
+    <div class="card-header">
+      <h3 class="card-title">Sent Messages</h3>
+    </div>
+    <p class="card-description">Review every announcement or direct message you have previously sent.</p>
+    <div class="card-actions">
+      <a class="btn secondary" href="{{ url_for('messages_sent') }}">View Sent Items</a>
+    </div>
+  </li>
   {% if judge_access %}
-  <li><a href="{{ url_for('messages_judge') }}">Judge Broadcast</a> – send announcements to all players in a tournament.</li>
+  <li class="card">
+    <div class="card-header">
+      <h3 class="card-title">Judge Broadcast</h3>
+    </div>
+    <p class="card-description">Send an announcement to every registered player in a selected tournament.</p>
+    <div class="card-actions">
+      <a class="btn" href="{{ url_for('messages_judge') }}">Compose Broadcast</a>
+    </div>
+  </li>
   {% endif %}
   {% if admin_access %}
-  <li><a href="{{ url_for('messages_admin') }}">Admin Broadcast</a> – send announcements to everyone in a role or to all users.</li>
+  <li class="card">
+    <div class="card-header">
+      <h3 class="card-title">Admin Broadcast</h3>
+    </div>
+    <p class="card-description">Reach everyone in a role—or your entire user base—with one secure message.</p>
+    <div class="card-actions">
+      <a class="btn" href="{{ url_for('messages_admin') }}">Send Admin Message</a>
+    </div>
+  </li>
   {% endif %}
 </ul>
 {% endblock %}


### PR DESCRIPTION
## Summary
- restyled the messages landing page with cards and call-to-action buttons to match the rest of the site
- added REL level and head judge details to tournament cards on the dashboard
- aligned admin user management forms and clarified the debug panel hash label

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddaef2f85c8320861e45f0df99546b