### PR TITLE
Add table assignment controls and deck sorting improvements

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -211,6 +211,7 @@ class Tournament(db.Model):
     rules_enforcement_level = db.Column(db.String(20), default='None')
     is_cube = db.Column(db.Boolean, default=False)
     rounds_override = db.Column(db.Integer, nullable=True)
+    start_table_number = db.Column(db.Integer, default=1)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     # Comma separated points for Commander: first, second, third, fourth, draw
     commander_points = db.Column(db.String(50), default='3,2,1,0,1')

--- a/app/pairing.py
+++ b/app/pairing.py
@@ -76,7 +76,7 @@ def swiss_pair_round(t: Tournament, r: Round, session):
     group_size = 4 if t.format.lower() == 'commander' else 2
     if r.number == 1:
         random.shuffle(players)
-        table = 1
+        table = t.start_table_number or 1
         created = []
         i = 0
         while i < len(players):
@@ -102,7 +102,7 @@ def swiss_pair_round(t: Tournament, r: Round, session):
             -rank[tp.id][0], -rank[tp.id][1], -rank[tp.id][2], -rank[tp.id][3], rank[tp.id][4]
         )
     )
-    table = 1
+    table = t.start_table_number or 1
     created = []
     i = 0
     while i < len(players):

--- a/app/templates/admin/edit_tournament.html
+++ b/app/templates/admin/edit_tournament.html
@@ -73,6 +73,10 @@
         <td><input type="number" name="deck_build_time" value="{{ t.deck_build_time or '' }}"></td>
       </tr>
       <tr>
+        <td>Starting Table Number</td>
+        <td><input type="number" name="start_table_number" min="1" value="{{ request.form.get('start_table_number', t.start_table_number or 1) }}"></td>
+      </tr>
+      <tr>
         <td>Start Time</td>
         <td><input type="datetime-local" name="start_time" value="{{ t.start_time.strftime('%Y-%m-%dT%H:%M') if t.start_time else '' }}"></td>
       </tr>

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -74,6 +74,10 @@
         <td><input type="number" name="deck_build_time"></td>
       </tr>
       <tr>
+        <td>Starting Table Number</td>
+        <td><input type="number" name="start_table_number" min="1" value="{{ request.form.get('start_table_number', 1) }}"></td>
+      </tr>
+      <tr>
         <td>Start Time</td>
         <td><input type="datetime-local" name="start_time"></td>
       </tr>

--- a/app/templates/tournament/player_deck.html
+++ b/app/templates/tournament/player_deck.html
@@ -13,14 +13,23 @@
     {% endif %}
   </span>
 </p>
+<form method="get" class="deck-sort-form">
+  <label>Sort by
+    <select name="sort" onchange="this.form.submit()">
+      <option value="name"{% if sort_mode != 'type' %} selected{% endif %}>Name</option>
+      <option value="type"{% if sort_mode == 'type' %} selected{% endif %}>Card Type</option>
+    </select>
+  </label>
+  <noscript><button class="btn" type="submit">Apply</button></noscript>
+</form>
 <div class="deck-lists">
   <div class="deck-list">
     <h3>Mainboard ({{ deck.total_mainboard() }})</h3>
-    {% set main_cards = deck.mainboard_cards() %}
     {% if main_cards %}
     <ul>
       {% for card in main_cards %}
-      <li>{{ card.count }} × {{ card.name }}</li>
+      {% set info = card_metadata.get(card.name) if card_metadata else None %}
+      <li{% if info and info.type_line %} title="{{ info.type_line }}"{% endif %}>{{ card.count }} × {{ card.name }}</li>
       {% endfor %}
     </ul>
     {% else %}
@@ -29,11 +38,11 @@
   </div>
   <div class="deck-list">
     <h3>Sideboard ({{ deck.total_sideboard() }})</h3>
-    {% set side_cards = deck.sideboard_cards() %}
     {% if side_cards %}
     <ul>
       {% for card in side_cards %}
-      <li>{{ card.count }} × {{ card.name }}</li>
+      {% set info = card_metadata.get(card.name) if card_metadata else None %}
+      <li{% if info and info.type_line %} title="{{ info.type_line }}"{% endif %}>{{ card.count }} × {{ card.name }}</li>
       {% endfor %}
     </ul>
     {% else %}

--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,4 @@ password_seed: dev-password-seed-change-me
 #flask_ip: 10.147.17.136
 flask_ip: 192.168.1.85
 flask_port: 5000
+last_table_number: 200

--- a/start-server.sh
+++ b/start-server.sh
@@ -24,6 +24,7 @@ FLASK_SECRET=$(read_yaml "$CONFIG_FILE" flask_secret)
 PASSWORD_SEED=$(read_yaml "$CONFIG_FILE" password_seed)
 FLASK_IP=$(read_yaml "$CONFIG_FILE" flask_ip)
 FLASK_PORT=$(read_yaml "$CONFIG_FILE" flask_port)
+LAST_TABLE_NUMBER=$(read_yaml "$CONFIG_FILE" last_table_number)
 
 if [ -z "$DB_FILE" ]; then
   DB_FILE="$DEFAULT_DB_FILE"
@@ -49,6 +50,9 @@ fi
 if [ -z "$FLASK_PORT" ]; then
   FLASK_PORT="5000"
 fi
+if [ -z "$LAST_TABLE_NUMBER" ]; then
+  LAST_TABLE_NUMBER=""
+fi
 
 if [ "$DB_FILE" = "$DEFAULT_DB_FILE" ]; then
   TS=$(date +%Y%m%d%H%M%S)
@@ -65,6 +69,7 @@ export FLASK_SECRET="$FLASK_SECRET"
 export PASSWORD_SEED="$PASSWORD_SEED"
 export FLASK_RUN_HOST="$FLASK_IP"
 export FLASK_RUN_PORT="$FLASK_PORT"
+export MTG_LAST_TABLE_NUMBER="$LAST_TABLE_NUMBER"
 python -m pip install -r requirements.txt >/dev/null
 python -m flask db-init
 python -m flask create-admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASS"


### PR DESCRIPTION
## Summary
- allow setting a tournament starting table number, enforce venue limits from configuration, and reuse that range during pairing
- ensure the card database is downloaded at startup and capture card type metadata to support admin deck sorting by type
- require submitted decks before pairing round one at Competitive/Professional REL events and expose the new venue table limit in configuration/startup scripts

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ddb39147708320aac888b40351631a

## Summary by Sourcery

Provide configurability and validation for tournament table assignments, enforce deck submission rules at Competitive/Professional REL, and enhance deck view sorting with card type metadata.

New Features:
- Introduce configurable starting table number per tournament with validation against venue limits and overlapping events
- Update pairing logic to respect tournament-specific start_table_number in all formats
- Require all players to submit a deck list before pairing round one at Competitive and Professional REL events
- Add deck view sorting by card type or name and display card type tooltips using fetched metadata

Enhancements:
- Ensure the card database is fetched at startup and bump schema to include type_line and primary_type for sorting

Build:
- Update start-server.sh to read last_table_number from config and export MTG_LAST_TABLE_NUMBER

Documentation:
- Add last_table_number setting to default config.yaml