### PR TITLE
Add wiki documentation and sample data seeder

### DIFF
--- a/docs/wiki/01-dashboard-and-navigation.md
+++ b/docs/wiki/01-dashboard-and-navigation.md
@@ -1,0 +1,12 @@
+# 1. Dashboard & global navigation
+
+The landing page highlights every active tournament with live operations context:
+
+* Tournament cards list format, cut, REL, current player count, assigned head judge, and live timer chips that update automatically when any phase clock is running.【F:app/templates/index.html†L3-L44】
+* Manager-level controls expose edit and delete actions inline so staff can adjust events without leaving the overview.【F:app/templates/index.html†L37-L43】
+* The persistent header provides authenticated users with shortcuts to tournaments, messaging, Lost &amp; Found, incident reports, staff tools, and administrative consoles, adapting the dropdown menus based on each permission flag.【F:app/templates/base.html†L22-L63】
+* Built-in JavaScript powers the responsive menu, dropdown toggles, timer countdowns, and shared user lookup widget used throughout the application.【F:app/templates/base.html†L82-L200】
+
+![Dashboard overview](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-dashboard.png)
+
+Timers that appear on the dashboard leverage the shared timer bar component; each entry tracks server time, supports round/draft/deck phases, and exposes start, pause, stop, and restart controls for tournament managers.【F:app/templates/tournament/_timer_bar.html†L1-L27】

--- a/docs/wiki/02-authentication-and-accounts.md
+++ b/docs/wiki/02-authentication-and-accounts.md
@@ -1,0 +1,10 @@
+# 2. Authentication & accounts
+
+Account management flows let judges and players get online quickly:
+
+* The login form requires email + password and presents a branded welcome panel to match the rest of the UI.【F:app/templates/login.html†L1-L19】
+* New users can register with name, email, password confirmation, and optionally join a tournament immediately by supplying a passcode during signup.【F:app/templates/register.html†L1-L33】
+* A default super-user (`admin@example.com` / `admin123`) is created during `flask db-init`, giving local environments instant access to administrative tooling.【F:README.md†L20-L26】
+* Admins can register players individually or in bulk, optionally attaching them to an event at the same time to streamline onsite desk operations.【F:app/templates/admin/register_player.html†L3-L39】【F:app/templates/admin/bulk_register_players.html†L3-L27】
+
+![Login screen](browser:/invocations/putorxrg/artifacts/artifacts/wiki-login.png)

--- a/docs/wiki/03-tournament-lifecycle.md
+++ b/docs/wiki/03-tournament-lifecycle.md
@@ -1,0 +1,20 @@
+# 3. Tournament lifecycle management
+
+This section tracks an event from configuration through staffing.
+
+## Configure events
+* The **New Tournament** form captures structure, REL, commander scoring, round lengths, draft/deck timers, seating start, and optional join approval in a single table-driven editor.【F:app/templates/admin/new_tournament.html†L3-L114】
+* Cube-only toggles, start time pickers, and cut presets help organisers standardise their offerings while still allowing overrides when needed.【F:app/templates/admin/new_tournament.html†L21-L114】
+
+## Assign staff & judges
+* Dedicated judge assignment lets organisers select a head judge and toggle any number of floor judges per event.【F:app/templates/admin/judges.html†L3-L20】
+* The **Staff Management** view aggregates every tournament with its staffing plan, offering one-click break timers for judges and live countdowns until they return.【F:app/templates/admin/staff.html†L3-L29】
+
+## Publish schedules
+* The schedule table estimates start/end times for each tournament and ships with quick export/print buttons for venue signage or social posts.【F:app/templates/admin/schedule.html†L3-L19】
+
+## Monitor the live hub
+* Tournament detail pages surface head/floor judges, passcode visibility, join workflows, pairing controls, and quick links into standings, brackets, and logs.【F:app/templates/tournament/view.html†L3-L67】
+* Players see their deck submission status, and staff can collect lists via the built-in card searcher, paste, MTGO file upload, or deck photos to match paper requirements.【F:app/templates/tournament/view.html†L69-L195】
+
+![Tournament overview](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-tournament-overview.png)

--- a/docs/wiki/04-rounds-and-results.md
+++ b/docs/wiki/04-rounds-and-results.md
@@ -1,0 +1,17 @@
+# 4. Rounds, pairings & results
+
+## Pairing control room
+* Round pages list every table with format-aware rendering (BYE detection for Swiss, four-player pods for Commander) and quick links to report or edit results based on staff/player permissions.【F:app/templates/tournament/round.html†L1-L75】
+* Managers can re-pair or delete a round (before results are posted) directly from the same screen, saving time during judge calls.【F:app/templates/tournament/round.html†L6-L15】
+* The shared timer bar keeps the round/draft/deck clocks front-and-centre so the scorekeeper and judges stay in sync.【F:app/templates/tournament/round.html†L4-L5】【F:app/templates/tournament/_timer_bar.html†L1-L27】
+
+![Round control panel](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-round-pairings.png)
+
+## Entering results
+* The reporting form adapts by format: Commander captures placements for up to four players plus drops/draws, while Constructed events capture game wins, draws, and drop toggles (and auto-awards BYEs).【F:app/templates/match/report.html†L1-L90】
+
+## Tracking standings
+* Standings display the full tiebreak suite (points, OMW%, GW%, OGW%) and include print-friendly formatting for quick posting.【F:app/templates/tournament/standings.html†L1-L25】
+* When a cut is configured, the projected top is highlighted so staff know where the bubble currently sits.【F:app/templates/tournament/standings.html†L27-L36】
+
+![Standings table](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-standings.png)

--- a/docs/wiki/05-player-engagement.md
+++ b/docs/wiki/05-player-engagement.md
@@ -1,0 +1,9 @@
+# 5. Player tools & deck submission
+
+Tournament detail pages double as the player hub:
+
+* Passcode-protected join forms honour approval workflows and communicate pending/rejected status directly to the player, while unauthenticated users are prompted to log in first.【F:app/templates/tournament/view.html†L21-L46】
+* Once registered, players can monitor deck submission status, including timestamps and whether deck changes are locked after round one.【F:app/templates/tournament/view.html†L69-L129】
+* Multiple submission channels—interactive card search, bulk paste, MTGO `.txt` upload, and optional deck imagery for draft events—cover both digital and paper workflows.【F:app/templates/tournament/view.html†L130-L194】
+
+![Player hub & deck tools](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-tournament-overview.png)

--- a/docs/wiki/06-communications.md
+++ b/docs/wiki/06-communications.md
@@ -1,0 +1,9 @@
+# 6. Messaging & announcements
+
+WaLTER includes a built-in encrypted messaging suite:
+
+* The messaging hub routes staff to the player inbox, sent archive, judge broadcasts, and admin-wide announcements based on their access level.【F:app/templates/messages/index.html†L3-L51】
+* Player inboxes display unread states, previews, and shortcuts to compose or review sent mail, keeping conversations centralised.【F:app/templates/messages/player.html†L3-L28】
+* Judges can target a specific tournament for a mass message, while admins can reach entire roles or the whole user base through dedicated broadcast forms.【F:app/templates/messages/judge.html†L3-L22】【F:app/templates/messages/admin.html†L3-L23】
+
+![Messaging hub](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-messages-hub.png)

--- a/docs/wiki/07-support-and-ops.md
+++ b/docs/wiki/07-support-and-ops.md
@@ -1,0 +1,14 @@
+# 7. Support desks: Lost & Found + incident reports
+
+## Lost & Found kiosk
+* Staff can log items with photos, location, reporter details, and status, while the list view shows cards with timestamps and quick update forms to mark returns or replace images.【F:app/templates/lost_found/index.html†L3-L94】
+
+![Lost & Found board](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-lost-found.png)
+
+## Incident intake
+* Players submit bug reports or misconduct complaints via separate forms; misconduct entries include a user search helper to identify the reported player accurately.【F:app/templates/reports/index.html†L3-L36】
+
+## Admin triage
+* The reports dashboard summarises status, type, reporter, assignee, and submission time, and embeds inline editing for assignments, statuses, read tracking, and action notes, alongside CSV export and print buttons.【F:app/templates/admin/reports.html†L3-L102】
+
+![Incident triage](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-reports.png)

--- a/docs/wiki/08-admin-toolbox.md
+++ b/docs/wiki/08-admin-toolbox.md
@@ -1,0 +1,15 @@
+# 8. Admin toolbox
+
+## Diagnostics & secrets
+* The admin debug panel surfaces encryption mode, database footprint, RAM/CPU usage, connection counts, uptime, and a password-gated secret seed reveal for troubleshooting.【F:app/templates/admin/panel.html†L3-L20】
+
+![Admin panel](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-admin-panel.png)
+
+## User operations
+* The users screen supports name/email/role search with an inline autocomplete, and provides per-user management links.【F:app/templates/admin/users.html†L3-L37】
+* Detailed user pages edit contact info, notes, roles, password resets, permission overrides, and tournament assignments with remove/add forms plus a guarded delete option.【F:app/templates/admin/user_detail.html†L1-L66】【F:app/templates/admin/user_detail.html†L67-L112】
+
+![User management](browser:/invocations/ggqhabqb/artifacts/artifacts/wiki-user-management.png)
+
+## Role governance
+* The permissions console lists role levels and granted flags, and includes a role builder with per-permission checkboxes so admins can tune access without touching code.【F:app/templates/admin/permissions.html†L3-L33】

--- a/docs/wiki/README.md
+++ b/docs/wiki/README.md
@@ -1,0 +1,35 @@
+# WaLTER Operations Wiki
+
+## Quick setup
+1. Create and activate a virtual environment, then install dependencies:
+   ```bash
+   python -m venv .venv
+   source .venv/bin/activate
+   pip install -r requirements.txt
+   ```
+   These commands mirror the quickstart documented in the project README.【F:README.md†L3-L26】
+2. Set the Flask environment variables (at minimum `FLASK_APP=app.app:app`). Optional knobs such as `PASSWORD_SEED` and `MTG_LOG_DB_PATH` match the upstream defaults.【F:README.md†L10-L18】
+3. Initialize the database and default admin account:
+   ```bash
+   flask --app app.app db-init
+   ```
+   The command seeds `admin@example.com` / `admin123` for local administration.【F:README.md†L20-L26】
+4. (Optional) Load the curated demo dataset used for the screenshots in this guide:
+   ```bash
+   python scripts/seed_sample_data.py --reset
+   ```
+   The script rebuilds the schema, provisions staff & player accounts, schedules tournaments, pairs round one, and records supporting artefacts such as messages, lost-and-found items, and conduct reports.【F:scripts/seed_sample_data.py†L21-L219】
+5. Run the development server:
+   ```bash
+   flask --app app.app run --debug
+   ```
+
+## Page directory
+1. [Dashboard & global navigation](01-dashboard-and-navigation.md)
+2. [Authentication & accounts](02-authentication-and-accounts.md)
+3. [Tournament lifecycle management](03-tournament-lifecycle.md)
+4. [Rounds, pairings & results](04-rounds-and-results.md)
+5. [Player tools & deck submission](05-player-engagement.md)
+6. [Messaging & announcements](06-communications.md)
+7. [Support desks: Lost & Found + incident reports](07-support-and-ops.md)
+8. [Admin toolbox](08-admin-toolbox.md)

--- a/scripts/seed_sample_data.py
+++ b/scripts/seed_sample_data.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python
+"""Populate the development database with rich demo data."""
+from __future__ import annotations
+
+import argparse
+import json
+from datetime import datetime, timedelta, timezone
+from typing import Iterable, Sequence
+
+from pathlib import Path
+import sys
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from app.app import create_app, db
+from app import models
+
+
+def ensure_roles() -> dict[str, models.Role]:
+    """Ensure the default roles exist with up-to-date permissions."""
+    roles: dict[str, models.Role] = {}
+    for name, permissions in models.DEFAULT_ROLE_PERMISSIONS.items():
+        role = models.Role.query.filter_by(name=name).first()
+        if role is None:
+            role = models.Role(name=name)
+        role.permissions = json.dumps(permissions)
+        role.level = models.DEFAULT_ROLE_LEVELS.get(name, 500)
+        db.session.add(role)
+        roles[name] = role
+    db.session.commit()
+    return roles
+
+
+def ensure_admin_user() -> models.User:
+    admin = models.User.query.filter_by(email="admin@example.com").first()
+    if admin is None:
+        admin = models.User(
+            email="admin@example.com",
+            name="Admin User",
+            is_admin=True,
+        )
+        admin.set_password("admin123")
+        db.session.add(admin)
+        db.session.commit()
+    return admin
+
+
+def create_user(name: str, email: str, role: models.Role, password: str = "player123") -> models.User:
+    user = models.User.query.filter_by(email=email).first()
+    if user is None:
+        user = models.User(name=name, email=email, role=role)
+        user.set_password(password)
+        db.session.add(user)
+    return user
+
+
+def attach_players(tournament: models.Tournament, users: Sequence[models.User]) -> list[models.TournamentPlayer]:
+    entries: list[models.TournamentPlayer] = []
+    for user in users:
+        entry = models.TournamentPlayer.query.filter_by(
+            tournament_id=tournament.id, user_id=user.id
+        ).first()
+        if entry is None:
+            entry = models.TournamentPlayer(tournament=tournament, user=user)
+            db.session.add(entry)
+        entries.append(entry)
+    db.session.commit()
+    return entries
+
+
+def create_round(
+    tournament: models.Tournament,
+    number: int,
+    tables: Iterable[Sequence[models.TournamentPlayer | None]],
+) -> models.Round:
+    rnd = models.Round.query.filter_by(tournament_id=tournament.id, number=number).first()
+    if rnd is None:
+        rnd = models.Round(tournament=tournament, number=number)
+        db.session.add(rnd)
+        db.session.commit()
+    with db.session.no_autoflush:
+        for table_index, seats in enumerate(tables, start=1):
+            match = models.Match.query.filter_by(
+                round_id=rnd.id, table_number=table_index
+            ).first()
+            if match is None:
+                match = models.Match(round=rnd, table_number=table_index)
+            db.session.add(match)
+            for seat, player in enumerate(seats, start=1):
+                setattr(match, f"player{seat}_id", player.id if player else None)
+            if match.result is None:
+                match.result = models.MatchResult()
+            db.session.add(match.result)
+            match.result.player1_wins = 2
+            match.result.player2_wins = 1
+            match.result.draws = 0
+            if len([p for p in seats if p]) == 4:
+                match.result.is_draw = False
+                match.result.p1_place = 1
+                match.result.p2_place = 2
+                match.result.p3_place = 3
+                match.result.p4_place = 4
+            match.completed = True
+    db.session.commit()
+    return rnd
+
+
+def build_sample_world(reset: bool = False) -> None:
+    if reset:
+        db.drop_all()
+        db.create_all()
+    roles = ensure_roles()
+    ensure_admin_user()
+
+    manager = create_user("Morgan Reid", "morgan@example.com", roles["manager"], "manager123")
+    floor_judge = create_user("Kira Lopez", "kira@example.com", roles["floor judge"], "floor123")
+    venue_judge = create_user("Asher Patel", "asher@example.com", roles["venue judge"], "venue123")
+
+    player_details = [
+        ("Lena Hart", "lena@example.com"),
+        ("Noah Kim", "noah@example.com"),
+        ("Eli Turner", "eli@example.com"),
+        ("Zara Brooks", "zara@example.com"),
+        ("Theo White", "theo@example.com"),
+        ("Maya Singh", "maya@example.com"),
+        ("Riley Chen", "riley@example.com"),
+        ("Sofia Martins", "sofia@example.com"),
+        ("Jonah Price", "jonah@example.com"),
+        ("Aria Wells", "aria@example.com"),
+        ("Miles Becker", "miles@example.com"),
+        ("Priya Das", "priya@example.com"),
+    ]
+    players = [create_user(name, email, roles["user"]) for name, email in player_details]
+    db.session.commit()
+
+    now = datetime.now(timezone.utc)
+
+    def ensure_tournament(name: str, fmt: str, cut: str, round_length: int, hours_from_now: int) -> models.Tournament:
+        tournament = models.Tournament.query.filter_by(name=name).first()
+        if tournament is None:
+            tournament = models.Tournament(name=name, format=fmt)
+        tournament.cut = cut
+        tournament.round_length = round_length
+        tournament.rules_enforcement_level = "Regular"
+        tournament.head_judge = manager
+        tournament.start_time = now + timedelta(hours=hours_from_now)
+        tournament.round_timer_end = now + timedelta(minutes=round_length)
+        tournament.draft_time = 45 if fmt == "Draft" else None
+        tournament.deck_build_time = 30 if fmt != "Commander" else None
+        tournament.start_table_number = 11
+        db.session.add(tournament)
+        db.session.commit()
+        return tournament
+
+    modern = ensure_tournament("Modern Showdown", "Constructed", "top8", 50, 1)
+    commander = ensure_tournament("Commander League", "Commander", "none", 75, 3)
+    draft = ensure_tournament("Midnight Draft", "Draft", "top4", 40, 5)
+
+    modern_players = attach_players(modern, players[:8])
+    commander_players = attach_players(commander, players[:6])
+    draft_players = attach_players(draft, players[6:12])
+
+    create_round(modern, 1, [
+        (modern_players[0], modern_players[1]),
+        (modern_players[2], modern_players[3]),
+        (modern_players[4], modern_players[5]),
+        (modern_players[6], modern_players[7]),
+    ])
+    create_round(commander, 1, [
+        (commander_players[0], commander_players[1], commander_players[2], commander_players[3]),
+        (commander_players[4], commander_players[5]),
+    ])
+    create_round(draft, 1, [
+        (draft_players[0], draft_players[1]),
+        (draft_players[2], draft_players[3]),
+        (draft_players[4], draft_players[5]),
+    ])
+
+    if models.LostFoundItem.query.count() == 0:
+        db.session.add(
+            models.LostFoundItem(
+                title="Binder with Modern Staples",
+                description="Blue Ultimate Guard binder with Jace sleeves.",
+                location="Main Stage",
+                reporter_name="Morgan Reid",
+            )
+        )
+
+    if models.Report.query.count() == 0:
+        db.session.add(
+            models.Report(
+                reporter=manager,
+                reported_user=players[2],
+                report_type="conduct",
+                description="Player reported marked sleeves during Round 2.",
+                status="investigating",
+                assigned_to=floor_judge,
+                actions_taken="Sleeves replaced, match result stands.",
+            )
+        )
+
+    if models.Message.query.count() == 0:
+        db.session.add(
+            models.Message(
+                sender=manager,
+                recipient=players[0],
+                key_encrypted=b"key",
+                sender_key_encrypted=b"sender",
+                title_encrypted=b"title",
+                title_nonce=b"nonce1",
+                body_encrypted=b"body",
+                body_nonce=b"nonce2",
+            )
+        )
+
+    db.session.commit()
+    print("Database populated with demo content.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--reset", action="store_true", help="drop and recreate the database before loading data")
+    args = parser.parse_args()
+
+    app = create_app()
+    with app.app_context():
+        build_sample_world(reset=args.reset)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a docs/wiki knowledge base that covers setup, navigation, tournaments, rounds, player tooling, communications, support workflows, and admin utilities with inline citations and screenshots
- add scripts/seed_sample_data.py to populate a demo dataset used throughout the wiki and for local testing

## Testing
- python scripts/seed_sample_data.py --reset

------
https://chatgpt.com/codex/tasks/task_e_68ddce6c2e948320aabf788a46f471c2