### PR TITLE
Add round robin tournament pairing option

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -208,6 +208,8 @@ class Tournament(db.Model):
     format = db.Column(db.String(50), nullable=False)  # Commander, Draft, Constructed
     structure = db.Column(db.String(20), default='swiss')  # swiss or single_elim
     cut = db.Column(db.String(10), default='none')     # none, top8, top4
+    pairing_type = db.Column(db.String(20), default='swiss')  # swiss, round_robin
+    pairing_options = db.Column(db.Text, nullable=True)
     rules_enforcement_level = db.Column(db.String(20), default='None')
     is_cube = db.Column(db.Boolean, default=False)
     rounds_override = db.Column(db.Integer, nullable=True)

--- a/app/templates/admin/edit_tournament.html
+++ b/app/templates/admin/edit_tournament.html
@@ -34,6 +34,16 @@
         </td>
       </tr>
       <tr>
+        <td>Pairing Type</td>
+        <td>
+          {% set pairing_choice = (t.pairing_type or 'swiss').lower() %}
+          <select name="pairing_type">
+            <option value="swiss"{% if pairing_choice == 'swiss' %} selected{% endif %}>Swiss (standings based)</option>
+            <option value="round_robin"{% if pairing_choice == 'round_robin' %} selected{% endif %}>Round Robin</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
         <td>Rules Enforcement Level</td>
         <td>
           <select name="rules_enforcement_level">

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -34,6 +34,16 @@
         </td>
       </tr>
       <tr>
+        <td>Pairing Type</td>
+        <td>
+          {% set pairing_choice = request.form.get('pairing_type', 'swiss') %}
+          <select name="pairing_type">
+            <option value="swiss"{% if pairing_choice == 'swiss' %} selected{% endif %}>Swiss (standings based)</option>
+            <option value="round_robin"{% if pairing_choice == 'round_robin' %} selected{% endif %}>Round Robin</option>
+          </select>
+        </td>
+      </tr>
+      <tr>
         <td>Rules Enforcement Level</td>
         <td>
           <select name="rules_enforcement_level">

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,6 +1,6 @@
 from app.app import db
 from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult
-from app.pairing import swiss_pair_round, compute_standings
+from app.pairing import pair_round, compute_standings
 from datetime import datetime
 
 
@@ -26,7 +26,7 @@ def test_tournament_create_pairing_standings(session):
     r1 = Round(tournament_id=t.id, number=1)
     session.add(r1)
     session.commit()
-    matches = swiss_pair_round(t, r1, session)
+    matches = pair_round(t, r1, session)
     assert len(matches) == 1
 
     # record a result
@@ -44,6 +44,36 @@ def test_tournament_create_pairing_standings(session):
     session.delete(t)
     session.commit()
     assert session.query(Tournament).count() == 0
+
+
+def test_round_robin_pairings_unique(session):
+    role_user = session.query(Role).filter_by(name='user').first()
+    t = Tournament(name='Round Robin Event', format='Constructed', pairing_type='round_robin')
+    session.add(t)
+    session.commit()
+
+    for i in range(4):
+        u = User(email=f'rr{i}@ex.com', name=f'RR{i}', role=role_user)
+        session.add(u)
+        session.commit()
+        tp = TournamentPlayer(tournament_id=t.id, user_id=u.id)
+        session.add(tp)
+        session.commit()
+
+    seen_pairs = set()
+    total_rounds = 3
+    for rnd in range(1, total_rounds + 1):
+        r = Round(tournament_id=t.id, number=rnd)
+        session.add(r)
+        session.commit()
+        matches = pair_round(t, r, session)
+        assert matches
+        for m in matches:
+            if m.player2_id is None:
+                continue
+            pair = frozenset({m.player1_id, m.player2_id})
+            assert pair not in seen_pairs
+            seen_pairs.add(pair)
 
 
 def test_tournament_start_time(session):


### PR DESCRIPTION
## Summary
- add a pairing_type field to tournaments and persist round-robin state
- expose a round robin pairing option in tournament create/edit views and recommend it for very small events
- implement round robin pairing logic with standard tie breakers and extend tests for the new mode

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e5a73623a48320b07095a308af577a

## Summary by Sourcery

Add support for round-robin tournament pairing alongside the existing Swiss system

New Features:
- Introduce a pairing_type field and pairing_options on Tournament to persist round-robin state
- Implement round-robin pairing logic with standard tiebreakers and stateful ordering
- Expose pairing_type choice in tournament creation and edit forms and recommend round robin for small events

Enhancements:
- Replace direct swiss pairing calls with a unified pair_round dispatcher
- Adjust round-limit calculation to accommodate round-robin schedules

Tests:
- Update tests to invoke pair_round and add verification of unique round-robin matchups