### PR TITLE
Prevent rematches in Swiss pairings

### DIFF
--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,3 +1,5 @@
+import random
+
 from app.app import db
 from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult
 from app.pairing import pair_round, compute_standings
@@ -83,3 +85,49 @@ def test_tournament_start_time(session):
     session.commit()
     fetched = session.get(Tournament, t.id)
     assert fetched.start_time == start
+
+
+def test_swiss_pairings_avoid_repeats(session):
+    role_user = session.query(Role).filter_by(name='user').first()
+    t = Tournament(name='Swiss Event', format='Constructed')
+    session.add(t)
+    session.commit()
+
+    random.seed(123)
+
+    for i in range(4):
+        u = User(email=f'swiss{i}@ex.com', name=f'Swiss{i}', role=role_user)
+        session.add(u)
+        session.commit()
+        tp = TournamentPlayer(tournament_id=t.id, user_id=u.id)
+        session.add(tp)
+        session.commit()
+
+    r1 = Round(tournament_id=t.id, number=1)
+    session.add(r1)
+    session.commit()
+    matches_r1 = pair_round(t, r1, session)
+    assert len(matches_r1) == 2
+    first_round_pairs = {
+        frozenset({m.player1_id, m.player2_id})
+        for m in matches_r1
+        if m.player2_id is not None
+    }
+
+    # winners win 2-0 to avoid draws
+    for match in matches_r1:
+        result = MatchResult(player1_wins=2, player2_wins=0)
+        match.result = result
+        match.completed = True
+    session.commit()
+
+    r2 = Round(tournament_id=t.id, number=2)
+    session.add(r2)
+    session.commit()
+    matches_r2 = pair_round(t, r2, session)
+    assert len(matches_r2) == 2
+    for match in matches_r2:
+        if match.player2_id is None:
+            continue
+        pair = frozenset({match.player1_id, match.player2_id})
+        assert pair not in first_round_pairs


### PR DESCRIPTION
## Summary
- add pod-building helper for Swiss rounds that avoids pairing players who have already faced each other
- update Swiss pairing logic to use the new helper and keep matches free of rematches when possible
- add a regression test that ensures Swiss rounds do not repeat pairings across rounds

## Testing
- MTG_CARD_DB_URL=file:///tmp/atomic_cards_test.zip pytest tests/test_tournament.py::test_swiss_pairings_avoid_repeats


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690fc740dea48320984f1deb182e9fe6)

## Summary by Sourcery

Prevent rematches in Swiss tournaments by constructing optimized player pods and validating the logic with a regression test

New Features:
- Introduce a pod-building helper to group players and minimize rematches in Swiss rounds

Enhancements:
- Update Swiss pairing logic to use the new pod builder and avoid repeat matchups when possible

Tests:
- Add a regression test to verify Swiss pairings do not repeat opponents across rounds