### PR TITLE
Add 32-player Swiss tournament outcome-combination unit test

### DIFF
--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,4 +1,5 @@
 import random
+from itertools import product
 
 from app.app import db
 from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult
@@ -131,3 +132,48 @@ def test_swiss_pairings_avoid_repeats(session):
             continue
         pair = frozenset({match.player1_id, match.player2_id})
         assert pair not in first_round_pairs
+
+
+def test_swiss_32_players_all_round_result_combinations(session):
+    role_user = session.query(Role).filter_by(name='user').first()
+    tournament = Tournament(name='Swiss 32 Combo Event', format='Constructed')
+    session.add(tournament)
+    session.commit()
+
+    random.seed(2026)
+
+    for i in range(32):
+        user = User(email=f'combo32_{i}@ex.com', name=f'Combo32_{i}', role=role_user)
+        session.add(user)
+        session.commit()
+        session.add(TournamentPlayer(tournament_id=tournament.id, user_id=user.id))
+        session.commit()
+
+    total_rounds = 5
+    round_matches = {}
+    for round_number in range(1, total_rounds + 1):
+        rnd = Round(tournament_id=tournament.id, number=round_number)
+        session.add(rnd)
+        session.commit()
+        matches = pair_round(tournament, rnd, session)
+        assert len(matches) == 16
+        round_matches[round_number] = matches
+
+        for match in matches:
+            match.result = MatchResult(player1_wins=2, player2_wins=0)
+            match.completed = True
+        session.commit()
+
+    for choices in product((0, 1), repeat=total_rounds):
+        for round_number, player1_wins in enumerate(choices, start=1):
+            for match in round_matches[round_number]:
+                if player1_wins:
+                    match.result = MatchResult(player1_wins=2, player2_wins=0)
+                else:
+                    match.result = MatchResult(player1_wins=0, player2_wins=2)
+                match.completed = True
+        session.commit()
+
+        standings = compute_standings(tournament, session)
+        assert len(standings) == 32
+        assert all(0 <= row['points'] <= 15 for row in standings)


### PR DESCRIPTION
### Motivation
- Verify the Swiss pairing and standings logic for a full 32-player event across every combination of per-round win direction over the recommended number of rounds.
- Ensure pair counts, standings completeness, and point bounds remain valid when applying extreme per-round result patterns.

### Description
- Add `from itertools import product` to support exhaustive combination iteration in tests.
- Add `test_swiss_32_players_all_round_result_combinations` which creates a 32-player Swiss tournament, pairs the expected 5 rounds (16 matches per round), and stores the round matches for reuse.
- The test iterates over all `2^5` combinations of per-round win direction (applying the same direction to every match in a round), applies results, recomputes standings, and asserts standings include 32 players and that points are within the valid range (0–15).

### Testing
- Ran `pytest -q tests/test_tournament.py -k swiss_32_players_all_round_result_combinations` and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0cd971fc8320a79795d1dfd7bf5d)

## Summary by Sourcery

Tests:
- Add a 32‑player Swiss tournament test that iterates over all per‑round win direction combinations across five rounds and validates match counts and standings point ranges.