### PR TITLE
Disable pytest-ansible plugin loading to avoid Windows fcntl error

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:pytest_ansible


### PR DESCRIPTION
### Motivation
- Prevent `pytest` from auto-loading the `pytest_ansible` plugin which triggers `ModuleNotFoundError: No module named 'fcntl'` on Windows and breaks local test runs.

### Description
- Add a `pytest.ini` file containing `addopts = -p no:pytest_ansible` to explicitly disable the `pytest_ansible` plugin during test collection.

### Testing
- Ran `pytest -q tests/test_tournament.py -k swiss_32_players_all_round_result_combinations` and it passed with `1 passed, 4 deselected`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0f21e7e08320b08078a212f770b3)

## Summary by Sourcery

Tests:
- Configure pytest to skip loading the pytest-ansible plugin via pytest.ini to prevent Windows-specific fcntl import failures during local testing.