### PR TITLE
Disable pytest plugin autoload on Windows to avoid pytest-ansible crashes

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -p no:pytest_ansible

--- a/sitecustomize.py
+++ b/sitecustomize.py
@@ -1,0 +1,19 @@
+"""Project-level Python startup customizations.
+
+When pytest starts on Windows, third-party setuptools plugins can be auto-loaded
+before command-line or ini-level plugin suppression is applied. Some globally
+installed plugins (e.g. pytest-ansible) import POSIX-only modules such as
+``fcntl`` and crash test startup.
+
+To keep local Windows test runs working, disable external pytest plugin
+autoloading only on Windows. Builtin pytest plugins remain available.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+
+if os.name == "nt" and any("pytest" in arg.lower() for arg in sys.argv):
+    os.environ.setdefault("PYTEST_DISABLE_PLUGIN_AUTOLOAD", "1")


### PR DESCRIPTION
### Motivation

- Prevent third-party pytest plugins that are globally installed (notably `pytest-ansible`) from being auto-loaded on Windows where they may import POSIX-only modules like `fcntl` and crash test startup.  
- Ensure local Windows test runs keep builtin pytest plugins while blocking external plugin autoloading via an environment toggle.

### Description

- Add `sitecustomize.py` that sets `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1` when running on Windows and `pytest` is present in `sys.argv`, which disables pytest's plugin autoloading at process start.  
- Add `pytest.ini` containing `addopts = -p no:pytest_ansible` to explicitly disable the `pytest-ansible` plugin for test runs.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0f21e7e08320b08078a212f770b3)

## Summary by Sourcery

Disable automatic loading of external pytest plugins on Windows to prevent crashes from incompatible globally installed plugins during test startup.

New Features:
- Introduce a sitecustomize module that conditionally disables pytest plugin autoloading via environment configuration when running tests on Windows.

Enhancements:
- Configure pytest to explicitly skip loading the pytest-ansible plugin via pytest.ini for all test runs.