### PR TITLE
Add pytest.ini to disable pytest plugin autoload

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts =
+    --disable-plugin-autoload


### PR DESCRIPTION
### Motivation

- Prevent pytest from automatically loading external plugins to make test runs deterministic by adding a configuration file.

### Description

- Add `pytest.ini` with `[pytest]` and `addopts = --disable-plugin-autoload` to disable plugin autoloading.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d0f21e7e08320b08078a212f770b3)

## Summary by Sourcery

Build:
- Introduce a pytest.ini configuration that sets addopts to disable pytest plugin autoloading.