### PR TITLE
Fix deprecations in app startup (timezone-aware timestamps & engine lookup)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -19,7 +19,7 @@ from flask_login import (
     login_required,
     current_user,
 )
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import math
 import os
 import random
@@ -64,7 +64,7 @@ def create_app():
     if existing_media:
         media_db_path = existing_media[-1]
     else:
-        timestamp = datetime.utcnow().strftime('%Y%m%d%H%M%S')
+        timestamp = datetime.now(timezone.utc).strftime('%Y%m%d%H%M%S')
         media_db_filename = f"{db_base}_media_{timestamp}.db"
         media_db_path = os.path.join(app.instance_path, media_db_filename)
     if not os.path.exists(media_db_path):
@@ -204,7 +204,7 @@ def create_app():
         TournamentJoinRequest.__table__.create(bind=db.engine, checkfirst=True)
         from .models import LostFoundItem, TournamentPlayerDeck
 
-        media_engine = db.get_engine(app, bind='media')
+        media_engine = db.engines['media']
         LostFoundItem.__table__.create(bind=media_engine, checkfirst=True)
         if 'tournament_player_deck' in inspector.get_table_names():
             columns = [c['name'] for c in inspector.get_columns('tournament_player_deck')]


### PR DESCRIPTION
### Motivation
- Remove app-level deprecation warnings observed during startup by making timestamp generation timezone-aware and updating Flask-SQLAlchemy engine access.
- Prevent future breakage from the upcoming removals of `datetime.utcnow()` and `db.get_engine` usage.

### Description
- Added `timezone` to the `from datetime import` import in `app/app.py`.
- Replaced `datetime.utcnow().strftime(...)` used for the media DB filename with `datetime.now(timezone.utc).strftime(...)` in `app/app.py`.
- Replaced `db.get_engine(app, bind='media')` with `db.engines['media']` when creating/inspecting the media bind in `app/app.py`.

### Testing
- Ran `python -m pytest -q tests/test_tournament.py -k swiss_32_players_all_round_result_combinations` which completed successfully with `1 passed, 4 deselected`.
- Application-level deprecation warnings were removed; remaining warnings are from SQLAlchemy internals in dependency code.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0d16870f208320b75c0d33b2cfccb5)

## Summary by Sourcery

Update app startup to use timezone-aware timestamps and the current Flask‑SQLAlchemy engine access pattern.

Enhancements:
- Generate media database filenames using timezone-aware UTC timestamps instead of naive datetimes.
- Access the media database engine through the Flask‑SQLAlchemy engines mapping rather than the deprecated get_engine helper.