### PR TITLE
Add tournament join QR page with account-aware onboarding

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -367,6 +367,8 @@ def create_app():
     def register():
         from .models import User, Tournament, TournamentPlayer, Role
         tournaments = db.session.query(Tournament).order_by(Tournament.created_at.desc()).all()
+        prefill_tournament_id = request.args.get('tournament_id', '').strip()
+        prefill_passcode = request.args.get('passcode', '').strip()
         if request.method == 'POST':
             email = request.form['email'].strip().lower()
             name = request.form['name'].strip()
@@ -398,11 +400,17 @@ def create_app():
                 db.session.add(tp)
                 db.session.commit()
             flash("Registered. Please login.", "success")
-            return redirect(url_for('login'))
-        return render_template('register.html', tournaments=tournaments)
+            return redirect(url_for('login', next=request.args.get('next')))
+        return render_template(
+            'register.html',
+            tournaments=tournaments,
+            prefill_tournament_id=prefill_tournament_id,
+            prefill_passcode=prefill_passcode,
+        )
 
     @app.route('/login', methods=['GET','POST'])
     def login():
+        next_url = request.args.get('next')
         if request.method == 'POST':
             email = request.form['email'].strip().lower()
             password = request.form['password']
@@ -417,10 +425,32 @@ def create_app():
                 except Exception:
                     session['private_key'] = None
                 log_site('login', 'success')
+                if next_url:
+                    parsed = urlparse(next_url)
+                    if not parsed.netloc and parsed.path.startswith('/'):
+                        return redirect(next_url)
                 return redirect(url_for('index'))
             flash("Invalid credentials", "error")
             log_site('login', 'failure', 'invalid credentials')
         return render_template('login.html')
+
+    @app.route('/t/<int:tid>/join-link')
+    def tournament_join_link(tid):
+        from .models import Tournament, TournamentPlayer
+        t = db.session.get(Tournament, tid)
+        if not t:
+            abort(404)
+        join_url = url_for('tournament_join_link', tid=tid, _external=True)
+        qr_url = f"https://api.qrserver.com/v1/create-qr-code/?size=320x320&data={join_url}"
+        is_player = False
+        if current_user.is_authenticated:
+            is_player = (
+                db.session.query(TournamentPlayer)
+                .filter_by(tournament_id=tid, user_id=current_user.id)
+                .first()
+                is not None
+            )
+        return render_template('tournament/join_link.html', t=t, join_url=join_url, qr_url=qr_url, is_player=is_player)
 
     @app.route('/logout')
     @login_required

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1271,3 +1271,30 @@ ul.flashes {
     display: none;
   }
 }
+
+.join-qr-card {
+  max-width: 520px;
+  margin: 0 auto;
+  text-align: center;
+  background: var(--brand-surface-soft);
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-lg);
+  padding: 1.5rem;
+}
+
+.join-qr-image {
+  width: 320px;
+  max-width: 100%;
+  margin: 1rem auto;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: #fff;
+  padding: 0.75rem;
+}
+
+.join-qr-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  align-items: center;
+}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -25,13 +25,13 @@
       <select id="tournament_id" name="tournament_id">
         <option value="">-- None --</option>
         {% for t in tournaments %}
-        <option value="{{t.id}}">{{t.name}}</option>
+        <option value="{{t.id}}"{% if prefill_tournament_id and prefill_tournament_id|int == t.id %} selected{% endif %}>{{t.name}}</option>
         {% endfor %}
       </select>
     </div>
     <div class="form-field">
       <label for="passcode">Tournament Passcode</label>
-      <input id="passcode" name="passcode" maxlength="4">
+      <input id="passcode" name="passcode" maxlength="4" value="{{ prefill_passcode }}">
     </div>
     <div class="form-actions">
       <button class="btn" type="submit">Create Account</button>

--- a/app/templates/tournament/join_link.html
+++ b/app/templates/tournament/join_link.html
@@ -1,0 +1,28 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="join-qr-card">
+  <h2>Join {{ t.name }}</h2>
+  <p>Scan the QR code or open the join link to register/login and join this tournament.</p>
+  <img src="{{ qr_url }}" alt="QR code for joining {{ t.name }}" class="join-qr-image">
+  <p><a href="{{ join_url }}">{{ join_url }}</a></p>
+
+  {% if current_user.is_authenticated %}
+    {% if is_player %}
+      <p>You are already registered for this tournament.</p>
+      <p><a class="btn" href="{{ url_for('view_tournament', tid=t.id) }}">Back to Tournament</a></p>
+    {% else %}
+      <form method="post" action="{{ url_for('join_tournament', tid=t.id) }}" class="join-form">
+        <input type="text" name="passcode" maxlength="4" pattern="\d{4}" placeholder="Passcode" required>
+        <button class="btn" type="submit">{% if t.join_requires_approval %}Request Join{% else %}Join Tournament{% endif %}</button>
+      </form>
+    {% endif %}
+  {% else %}
+    <div class="join-qr-actions">
+      <a class="btn" href="{{ url_for('login', next=url_for('tournament_join_link', tid=t.id)) }}">I already have an account</a>
+      <a class="btn" href="{{ url_for('register', tournament_id=t.id, passcode=t.passcode, next=url_for('tournament_join_link', tid=t.id)) }}">Create account & join</a>
+    </div>
+  {% endif %}
+
+  <p><button class="btn" onclick="window.print()">Print QR</button></p>
+</section>
+{% endblock %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -22,6 +22,7 @@
   <button class="btn" onclick="window.print()">Print</button>
   {% if not is_player %}
   <div class="join-controls">
+    <a class="btn" href="{{ url_for('tournament_join_link', tid=t.id) }}" target="_blank" rel="noopener">Player Join QR</a>
     {% if current_user.is_authenticated %}
       {% set join_pending = user_join_request and user_join_request.status == 'pending' %}
       {% set join_rejected = user_join_request and user_join_request.status == 'rejected' %}


### PR DESCRIPTION
### Motivation
- Provide a simple, printable QR/link flow so players can join a tournament from a phone or kiosk without manual URL entry.
- Support both existing accounts (login then join) and new users (start registration with tournament/passcode prefilled) to streamline onboarding.

### Description
- Added a new route and view `GET /t/<tid>/join-link` that renders a printable QR image and direct join URL for the tournament, and adapts UI when the viewer is already registered (`app/app.py`).
- Added a new template `app/templates/tournament/join_link.html` and CSS rules in `app/static/style.css` to show the QR card, printable button, and account-aware actions.
- Added a "Player Join QR" shortcut button on the tournament toolbar that opens the join-link page from the tournament view (`app/templates/tournament/view.html`).
- Updated the registration flow to accept prefilled `tournament_id` and `passcode` from query parameters and populate the registration form (`register`); updated login to respect safe relative `next` redirects so users return to the join flow after authentication (`app/app.py`, `app/templates/register.html`).
- QR images are generated via `https://api.qrserver.com/v1/create-qr-code` using the external join-link URL.

### Testing
- Ran `pytest -q tests/test_tournament.py tests/test_users.py` which passed locally with `11 passed`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13c44107788320b59b69c8209579e0)

## Summary by Sourcery

Add a tournament join link and QR-based onboarding flow with account-aware actions for existing and new players.

New Features:
- Introduce a tournament join-link page that displays a QR code and direct join URL for players to join a specific tournament.
- Add account-aware join actions on the join-link page to either join directly when logged in or guide users to login or registration when not authenticated.
- Prefill tournament and passcode fields in the registration form when provided via query parameters to streamline onboarding from shared links.
- Add a toolbar shortcut button on the tournament view to open the player join QR page.

Enhancements:
- Update the login flow to safely honor relative next URLs so users are redirected back into the join flow after authentication.
- Add styling for the join QR card, image, and action buttons to support a clean printable layout.