### PR TITLE
Prevent repeat Swiss pairings before cut and avoid assigning second bye

### DIFF
--- a/app/pairing.py
+++ b/app/pairing.py
@@ -63,28 +63,62 @@ def matches_for(tp: TournamentPlayer, session):
         (Match.player3_id == tp.id) | (Match.player4_id == tp.id)
     ).all()
 
-def have_played(a_id, b_id, session):
+def have_played(a_id, b_id, session, *, up_to_round_number=None):
     if a_id == b_id:
         return True
-    q = session.query(Match).filter(
+    q = session.query(Match).join(Round, Match.round_id == Round.id).filter(
         ((Match.player1_id==a_id) | (Match.player2_id==a_id) | (Match.player3_id==a_id) | (Match.player4_id==a_id)) &
         ((Match.player1_id==b_id) | (Match.player2_id==b_id) | (Match.player3_id==b_id) | (Match.player4_id==b_id))
     )
+    if up_to_round_number is not None:
+        q = q.filter(Round.number <= up_to_round_number)
     return session.query(q.exists()).scalar()
 
-def _group_conflicts(group, session):
+
+def _round_limit_for_tournament(t: Tournament, player_count: int) -> int:
+    if t.rounds_override:
+        return t.rounds_override
+    return recommended_rounds(player_count)
+
+
+def _is_post_cut_round(t: Tournament, r: Round, player_count: int) -> bool:
+    if t.structure == 'single_elim' or not (t.cut or '').startswith('top'):
+        return False
+    return r.number > _round_limit_for_tournament(t, player_count)
+
+
+def _player_has_bye(tp_id: int, tournament_id: int, session) -> bool:
+    q = session.query(Match).join(Round).filter(
+        Round.tournament_id == tournament_id,
+        (
+            ((Match.player1_id == tp_id) & (Match.player2_id.is_(None))) |
+            ((Match.player2_id == tp_id) & (Match.player1_id.is_(None)))
+        )
+    )
+    return session.query(q.exists()).scalar()
+
+
+def _select_swiss_bye_player(players, tournament_id: int, session):
+    if len(players) % 2 == 0:
+        return None
+    for idx in range(len(players) - 1, -1, -1):
+        if not _player_has_bye(players[idx].id, tournament_id, session):
+            return players.pop(idx)
+    return players.pop()
+
+def _group_conflicts(group, session, *, up_to_round_number=None):
     if len(group) < 2:
         return 0
-    return sum(1 for a, b in combinations(group, 2) if have_played(a.id, b.id, session))
+    return sum(1 for a, b in combinations(group, 2) if have_played(a.id, b.id, session, up_to_round_number=up_to_round_number))
 
 
-def _build_pods(players, group_size, session):
+def _build_pods(players, group_size, session, *, up_to_round_number=None, allow_repeat_pairings=True):
     def helper(remaining):
         if not remaining:
             return 0, []
         if len(remaining) <= group_size:
             group = remaining[:]
-            return _group_conflicts(group, session), [group]
+            return _group_conflicts(group, session, up_to_round_number=up_to_round_number), [group]
 
         first = remaining[0]
         rest = remaining[1:]
@@ -96,11 +130,13 @@ def _build_pods(players, group_size, session):
         best = None
         for combo in combinations(idx_pool, pick):
             group = [first] + [rest[i] for i in combo]
-            conflicts = _group_conflicts(group, session)
+            conflicts = _group_conflicts(group, session, up_to_round_number=up_to_round_number)
             selected = set(combo)
             new_remaining = [rest[i] for i in range(len(rest)) if i not in selected]
             result = helper(new_remaining)
             if result is None:
+                continue
+            if not allow_repeat_pairings and conflicts > 0:
                 continue
             total_conflicts = conflicts + result[0]
             grouping = [group] + result[1]
@@ -108,10 +144,14 @@ def _build_pods(players, group_size, session):
                 best = (total_conflicts, grouping)
                 if total_conflicts == 0:
                     break
+        if best is None and not allow_repeat_pairings:
+            return None
         return best
 
     total = helper(players)
     if total is None:
+        if not allow_repeat_pairings:
+            raise ValueError('Unable to create non-repeating pairings before cut.')
         return [players[i:i+group_size] for i in range(0, len(players), group_size)]
     return total[1]
 
@@ -147,7 +187,18 @@ def swiss_pair_round(t: Tournament, r: Round, session):
             -rank[tp.id][0], -rank[tp.id][1], -rank[tp.id][2], -rank[tp.id][3], rank[tp.id][4]
         )
     )
-    pods = _build_pods(players, group_size, session)
+    is_post_cut = _is_post_cut_round(t, r, len(players))
+    if group_size == 2:
+        bye_player = _select_swiss_bye_player(players, t.id, session)
+    else:
+        bye_player = None
+    pods = _build_pods(
+        players,
+        group_size,
+        session,
+        up_to_round_number=r.number - 1,
+        allow_repeat_pairings=is_post_cut
+    )
     table = t.start_table_number or 1
     created = []
     for pod in pods:
@@ -161,6 +212,10 @@ def swiss_pair_round(t: Tournament, r: Round, session):
         session.add(m)
         created.append(m)
         table += 1
+    if bye_player is not None:
+        m = Match(round_id=r.id, table_number=table, player1_id=bye_player.id, player2_id=None)
+        session.add(m)
+        created.append(m)
     session.commit()
     return created
 

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -177,3 +177,70 @@ def test_swiss_32_players_all_round_result_combinations(session):
         standings = compute_standings(tournament, session)
         assert len(standings) == 32
         assert all(0 <= row['points'] <= 15 for row in standings)
+
+def test_swiss_no_second_bye_when_alternative_exists(session):
+    role_user = session.query(Role).filter_by(name='user').first()
+    t = Tournament(name='Swiss Bye Event', format='Constructed')
+    session.add(t)
+    session.commit()
+
+    random.seed(7)
+    players = []
+    for i in range(5):
+        u = User(email=f'bye{i}@ex.com', name=f'Bye{i}', role=role_user)
+        session.add(u)
+        session.commit()
+        tp = TournamentPlayer(tournament_id=t.id, user_id=u.id)
+        session.add(tp)
+        session.commit()
+        players.append(tp)
+
+    bye_counts = {tp.id: 0 for tp in players}
+    for rnd in range(1, 3):
+        r = Round(tournament_id=t.id, number=rnd)
+        session.add(r)
+        session.commit()
+        matches = pair_round(t, r, session)
+        for m in matches:
+            if m.player2_id is None:
+                bye_counts[m.player1_id] += 1
+            else:
+                m.result = MatchResult(player1_wins=2, player2_wins=0)
+                m.completed = True
+        session.commit()
+
+    assert max(bye_counts.values()) == 1
+
+
+def test_swiss_all_unique_until_cut_then_repeat_allowed(session):
+    role_user = session.query(Role).filter_by(name='user').first()
+    t = Tournament(name='Swiss Cut Event', format='Constructed', cut='top4', rounds_override=2)
+    session.add(t)
+    session.commit()
+
+    random.seed(21)
+    for i in range(4):
+        u = User(email=f'cut{i}@ex.com', name=f'Cut{i}', role=role_user)
+        session.add(u)
+        session.commit()
+        tp = TournamentPlayer(tournament_id=t.id, user_id=u.id)
+        session.add(tp)
+        session.commit()
+
+    seen_pairs = set()
+    for rnd in range(1, 4):
+        r = Round(tournament_id=t.id, number=rnd)
+        session.add(r)
+        session.commit()
+        matches = pair_round(t, r, session)
+
+        for m in matches:
+            if m.player2_id is None:
+                continue
+            pair = frozenset({m.player1_id, m.player2_id})
+            if rnd <= 2:
+                assert pair not in seen_pairs
+            seen_pairs.add(pair)
+            m.result = MatchResult(player1_wins=2, player2_wins=0)
+            m.completed = True
+        session.commit()


### PR DESCRIPTION
### Motivation
- Ensure no player receives a second bye when another eligible player exists by rotating byes in odd-player Swiss rounds. 
- Prevent repeat opponents during Swiss rounds prior to the cut and only permit repeats after the Swiss round limit when a Top-X cut is configured. 
- Scope pairing-repeat checks to prior rounds only so current-round decisions don't consider future matches.

### Description
- Added a round-scoped `up_to_round_number` parameter to `have_played` and used it when computing group conflicts so repeat checks only consider earlier rounds. 
- Introduced `_round_limit_for_tournament` and `_is_post_cut_round` to determine when repeat pairings may be allowed relative to a configured cut and optional `rounds_override`. 
- Implemented `_player_has_bye` and `_select_swiss_bye_player` to pick the lowest-ranked eligible player who has not yet received a bye, and only fall back when everyone already had a bye. 
- Extended `_build_pods` to accept `up_to_round_number` and `allow_repeat_pairings`, skip candidate groupings that conflict when repeats are disallowed, and raise a `ValueError` when a non-repeating pre-cut pairing cannot be generated. 
- Updated `swiss_pair_round` to select and append a bye match for odd-player rounds and to pass pre-cut constraints into pod construction. 
- Fixed an UnboundLocalError in the round-robin pairing path by removing an erroneous leftover bye check.

### Testing
- Ran `pytest -q tests/test_tournament.py` and all tests passed (7 passed). 
- Added tests `test_swiss_no_second_bye_when_alternative_exists` and `test_swiss_all_unique_until_cut_then_repeat_allowed`, both of which pass under the new logic. 
- Verified the round-robin pairing uniqueness and existing swiss pairing tests continue to pass under the updated pairing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14cdaa96ac8320bf09dae925553901)

## Summary by Sourcery

Adjust Swiss pairing logic to avoid repeat pre-cut matchups, rotate byes among players, and allow controlled repeats only after the configured Swiss round limit.

Bug Fixes:
- Prevent assigning a second Swiss bye to a player when other eligible players are available.
- Avoid considering future rounds when checking for prior opponent conflicts in Swiss pairing logic.
- Fix an UnboundLocalError in the round-robin pairing path caused by a leftover bye check.

Enhancements:
- Introduce round-scoped conflict checks so Swiss pairings only consider matches from earlier rounds.
- Add support for enforcing no-repeat Swiss pairings until a tournament’s configured cut or round limit, then allowing repeats afterwards.
- Update Swiss pod construction to optionally forbid repeat pairings and to fail fast when a valid non-repeating configuration cannot be found.
- Select Swiss bye recipients based on rankings and prior bye history to ensure fair bye distribution in odd-player rounds.

Tests:
- Add tests to ensure Swiss byes are not given to the same player twice when alternatives exist.
- Add tests to verify all Swiss pairings are unique up to the cut, and that repeat pairings are allowed only after the cut while maintaining existing pairing test coverage.