### PR TITLE
start-server.sh: detect/install Python 3 and use selected interpreter for all invocations

### DIFF
--- a/start-server.sh
+++ b/start-server.sh
@@ -8,6 +8,62 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="$SCRIPT_DIR/config.yaml"
 REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
 
+PYTHON_BIN=""
+
+detect_python() {
+  local candidate
+  for candidate in python3 python; do
+    if command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info.major >= 3 else 1)' >/dev/null 2>&1; then
+      PYTHON_BIN="$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_as_root() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    echo "Installing Python requires root privileges. Re-run as root or install python3 and python3-pip manually." >&2
+    exit 1
+  fi
+}
+
+install_python() {
+  echo "Python 3 was not found. Attempting to install python3 and pip with the system package manager..." >&2
+
+  if command -v apt-get >/dev/null 2>&1; then
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip
+  elif command -v dnf >/dev/null 2>&1; then
+    run_as_root dnf install -y python3 python3-pip
+  elif command -v yum >/dev/null 2>&1; then
+    run_as_root yum install -y python3 python3-pip
+  elif command -v zypper >/dev/null 2>&1; then
+    run_as_root zypper --non-interactive install python3 python3-pip
+  elif command -v pacman >/dev/null 2>&1; then
+    run_as_root pacman -Sy --noconfirm python python-pip
+  elif command -v apk >/dev/null 2>&1; then
+    run_as_root apk add --no-cache python3 py3-pip
+  elif command -v brew >/dev/null 2>&1; then
+    brew install python
+  else
+    echo "Python 3 is required, and no supported package manager was found. Install python3 and python3-pip manually." >&2
+    exit 1
+  fi
+}
+
+if ! detect_python; then
+  install_python
+  if ! detect_python; then
+    echo "Python 3 installation completed, but no usable python3/python command was found." >&2
+    exit 1
+  fi
+fi
+
 if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "Missing config.yaml" >&2
   exit 1
@@ -15,7 +71,7 @@ fi
 
 # Ensure PyYAML is available so config.yaml can be parsed before installing the
 # rest of the application requirements.
-python - <<'PY'
+"$PYTHON_BIN" - <<'PY'
 import subprocess
 import sys
 try:
@@ -25,7 +81,7 @@ except ModuleNotFoundError:
 PY
 
 # Load settings from YAML config.
-eval "$(python - "$CONFIG_FILE" <<'PY'
+eval "$("$PYTHON_BIN" - "$CONFIG_FILE" <<'PY'
 import shlex
 import sys
 
@@ -93,10 +149,10 @@ export MTG_DB_PATH="$DB_FILE"
 export MTG_LOG_DB_PATH="$LOG_DB_FILE"
 
 printf 'Installing dependencies...\n'
-python -m pip install -r "$REQUIREMENTS_FILE" >/dev/null
+"$PYTHON_BIN" -m pip install -r "$REQUIREMENTS_FILE" >/dev/null
 
 printf 'Stopping existing Flask server on port %s if present...\n' "$FLASK_PORT"
-python - "$FLASK_PORT" <<'PY'
+"$PYTHON_BIN" - "$FLASK_PORT" <<'PY'
 import os
 import sys
 import time
@@ -162,13 +218,13 @@ printf 'Setting Flask environment...\n'
 export FLASK_APP="app.app:app"
 
 printf 'Initializing database...\n'
-python -m flask --app app.app db-init
+"$PYTHON_BIN" -m flask --app app.app db-init
 
 printf 'Creating default admin user...\n'
-python -m flask --app app.app create-admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASS"
+"$PYTHON_BIN" -m flask --app app.app create-admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASS"
 
 printf 'Starting Flask development server...\n'
-nohup python -m flask --app app.app run --debug --host="$FLASK_IP" --port="$FLASK_PORT" > "$SCRIPT_DIR/flask-server.log" 2>&1 &
+nohup "$PYTHON_BIN" -m flask --app app.app run --debug --host="$FLASK_IP" --port="$FLASK_PORT" > "$SCRIPT_DIR/flask-server.log" 2>&1 &
 FLASK_PID=$!
 printf 'Flask server started with PID %s. Logs: %s\n' "$FLASK_PID" "$SCRIPT_DIR/flask-server.log"
 


### PR DESCRIPTION
### Motivation

- Ensure the startup script works on systems where `python3` exists but `python` is missing, and to make the script able to install Python 3 automatically when feasible.
- Avoid mixing different Python executables by selecting a single, validated interpreter for all runtime and pip invocations.
- Improve robustness of dependency installation and privilege escalation when system packages need to be installed.

### Description

- Added `detect_python` to prefer `python3`/`python` and set `PYTHON_BIN` to the chosen interpreter, and added `install_python` and `run_as_root` helpers to attempt installing `python3`/`pip` via common package managers with `sudo` if needed.
- Replaced all direct `python` calls with `"$PYTHON_BIN"` so `pip`, `flask`, and embedded Python one-liners use the detected interpreter consistently.
- Updated the prereq step to install `PyYAML` using the detected interpreter and adjusted the config parsing `eval` invocation to call the chosen Python binary.
- Left existing behavior intact for environment export, DB initialization, admin creation, and starting the Flask server while logging the server PID and output to `flask-server.log` in the script directory.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ccc2502648320b61973c19ab7ad70)

## Summary by Sourcery

Detect and standardize the Python 3 interpreter used by the server startup script, and fall back to installing it when missing.

New Features:
- Introduce automatic detection of a usable Python 3 interpreter and store it in a dedicated environment variable for subsequent use.
- Add optional automatic installation of Python 3 and pip using common system package managers with privilege escalation when necessary.

Enhancements:
- Update the startup flow so all Python, pip, and Flask invocations consistently use the detected Python interpreter.