### PR TITLE
Fix Python 3.10 UTC import

### DIFF
--- a/app/models.py
+++ b/app/models.py
@@ -1,6 +1,6 @@
 from .app import db
 from flask_login import UserMixin
-from datetime import datetime, UTC
+from datetime import datetime, timezone
 from sqlalchemy import UniqueConstraint
 import uuid
 import os
@@ -68,7 +68,7 @@ DEFAULT_ROLE_PERMISSIONS = {
 
 
 def utc_now():
-    return datetime.now(UTC).replace(tzinfo=None)
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 DEFAULT_ROLE_LEVELS = {
     'admin': 0,


### PR DESCRIPTION
### Motivation
- Ensure compatibility with Python 3.10 by replacing the Python 3.11-only `datetime.UTC` usage while preserving the existing naive-UTC timestamp behavior.

### Description
- Replace `from datetime import datetime, UTC` with `from datetime import datetime, timezone` and update `utc_now()` to use `datetime.now(timezone.utc).replace(tzinfo=None)`.

### Testing
- Ran unit tests with `python -m pytest -q` which passed (`36 passed`), and exercised the Flask CLI initialization with `flask --app app.app:app db-init` and the Flask help (`flask --app app.app:app --help`), both of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cd005de8c832081031b5184476f82)

## Summary by Sourcery

Bug Fixes:
- Adjust UTC timestamp generation to avoid relying on Python 3.11-only datetime.UTC and support Python 3.10.