### PR TITLE
Make `stop-server.sh` detect Python 3 and prefer project virtualenv

### DIFF
--- a/stop-server.sh
+++ b/stop-server.sh
@@ -7,6 +7,119 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="$SCRIPT_DIR/config.yaml"
 REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
+VENV_DIR="$SCRIPT_DIR/.venv"
+
+PYTHON_BIN=""
+
+detect_python() {
+  local candidate
+  for candidate in "$VENV_DIR/bin/python" python3 python; do
+    if [[ -x "$candidate" || "$candidate" != */* ]] && command -v "$candidate" >/dev/null 2>&1 && "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info.major >= 3 else 1)' >/dev/null 2>&1; then
+      PYTHON_BIN="$candidate"
+      return 0
+    fi
+  done
+  return 1
+}
+
+run_as_root() {
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    echo "Installing Python support packages requires root privileges. Re-run as root or install python3, python3-pip, and python3-venv manually." >&2
+    exit 1
+  fi
+}
+
+install_python() {
+  echo "Python 3 was not found. Attempting to install python3 and pip with the system package manager..." >&2
+
+  if command -v apt-get >/dev/null 2>&1; then
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y python3 python3-pip python3-venv
+  elif command -v dnf >/dev/null 2>&1; then
+    run_as_root dnf install -y python3 python3-pip
+  elif command -v yum >/dev/null 2>&1; then
+    run_as_root yum install -y python3 python3-pip
+  elif command -v zypper >/dev/null 2>&1; then
+    run_as_root zypper --non-interactive install python3 python3-pip
+  elif command -v pacman >/dev/null 2>&1; then
+    run_as_root pacman -Sy --noconfirm python python-pip
+  elif command -v apk >/dev/null 2>&1; then
+    run_as_root apk add --no-cache python3 py3-pip
+  elif command -v brew >/dev/null 2>&1; then
+    brew install python
+  else
+    echo "Python 3 is required, and no supported package manager was found. Install python3, python3-pip, and python3-venv manually." >&2
+    exit 1
+  fi
+}
+
+install_python_package_support() {
+  echo "Python packaging support was not found. Attempting to install pip and venv support with the system package manager..." >&2
+
+  if command -v apt-get >/dev/null 2>&1; then
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y python3-pip python3-venv
+  elif command -v dnf >/dev/null 2>&1; then
+    run_as_root dnf install -y python3-pip
+  elif command -v yum >/dev/null 2>&1; then
+    run_as_root yum install -y python3-pip
+  elif command -v zypper >/dev/null 2>&1; then
+    run_as_root zypper --non-interactive install python3-pip
+  elif command -v pacman >/dev/null 2>&1; then
+    run_as_root pacman -Sy --noconfirm python-pip
+  elif command -v apk >/dev/null 2>&1; then
+    run_as_root apk add --no-cache py3-pip
+  elif command -v brew >/dev/null 2>&1; then
+    brew install python
+  else
+    echo "pip/venv support is required, and no supported package manager was found. Install python3-pip and python3-venv manually." >&2
+    exit 1
+  fi
+}
+
+ensure_venv() {
+  if [[ -x "$VENV_DIR/bin/python" ]]; then
+    PYTHON_BIN="$VENV_DIR/bin/python"
+    return 0
+  fi
+
+  if ! "$PYTHON_BIN" -m venv "$VENV_DIR"; then
+    rm -rf "$VENV_DIR"
+    install_python_package_support
+    "$PYTHON_BIN" -m venv "$VENV_DIR"
+  fi
+
+  PYTHON_BIN="$VENV_DIR/bin/python"
+}
+
+ensure_pip() {
+  if "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  if "$PYTHON_BIN" -m ensurepip --upgrade >/dev/null 2>&1 && "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+    return 0
+  fi
+
+  install_python_package_support
+  "$PYTHON_BIN" -m ensurepip --upgrade >/dev/null 2>&1 || true
+  if ! "$PYTHON_BIN" -m pip --version >/dev/null 2>&1; then
+    echo "pip is still unavailable for $PYTHON_BIN after installing package support." >&2
+    exit 1
+  fi
+}
+
+if ! detect_python; then
+  install_python
+  if ! detect_python; then
+    echo "Python 3 installation completed, but no usable python3/python command was found." >&2
+    exit 1
+  fi
+fi
 
 if [[ ! -f "$CONFIG_FILE" ]]; then
   echo "Missing config.yaml" >&2
@@ -15,7 +128,10 @@ fi
 
 # Ensure PyYAML is available so config.yaml can be parsed, then install the full
 # requirements so psutil is available for process discovery.
-python - <<'PY'
+ensure_venv
+ensure_pip
+
+"$PYTHON_BIN" - <<'PY'
 import subprocess
 import sys
 try:
@@ -25,9 +141,9 @@ except ModuleNotFoundError:
 PY
 
 printf 'Installing dependencies...\n'
-python -m pip install -r "$REQUIREMENTS_FILE" >/dev/null
+"$PYTHON_BIN" -m pip install -r "$REQUIREMENTS_FILE" >/dev/null
 
-eval "$(python - "$CONFIG_FILE" <<'PY'
+eval "$("$PYTHON_BIN" - "$CONFIG_FILE" <<'PY'
 import shlex
 import sys
 
@@ -53,7 +169,7 @@ else
 fi
 
 printf 'Stopping server on port %s\n' "$FLASK_PORT"
-python - "$FLASK_PORT" "$DB_PATH" <<'PY'
+"$PYTHON_BIN" - "$FLASK_PORT" "$DB_PATH" <<'PY'
 import os
 import sys
 import time


### PR DESCRIPTION
### Motivation
- The existing `stop-server.sh` assumed a usable `python` command was present, which can fail on systems without a global `python` binary or when the project virtualenv should be preferred. 
- The goal is to make the stop script robust across environments by selecting a Python 3 interpreter (prefer the project venv) and bootstrapping packaging support if needed.

### Description
- Add `VENV_DIR` and a `detect_python()` routine that prefers `'$VENV_DIR/bin/python'` then `python3` and `python`, storing the result in `PYTHON_BIN`.
- Add helper functions `run_as_root()`, `install_python()`, `install_python_package_support()`, `ensure_venv()`, and `ensure_pip()` to bootstrap Python/pip/venv support when required.
- Invoke `ensure_venv`/`ensure_pip` and switch all in-script Python invocations from `python` to `"$PYTHON_BIN"`, including PyYAML installation, dependency installation (`-m pip install -r`), config parsing (`"$PYTHON_BIN" - "$CONFIG_FILE"`), and the server-stop logic (`"$PYTHON_BIN" - "$FLASK_PORT" "$DB_PATH"`).
- Keep original process-discovery and DB-lock checking logic but run it through the detected interpreter so the script no longer fails if `python` is absent.

### Testing
- Ran a syntax check with `bash -n stop-server.sh`, which completed successfully. 
- Executed `./stop-server.sh` in the project workspace, which ran the dependency/bootstrap steps and the shutdown logic successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cd1d4b724832083a52af0ca546676)

## Summary by Sourcery

Improve the stop-server script to reliably use Python 3, preferring the project virtual environment and bootstrapping Python/pip/venv support when needed.

Enhancements:
- Add Python 3 autodetection that prioritizes the project virtualenv and falls back to system python3/python.
- Introduce helper routines to install Python and packaging support via common package managers when Python 3 or pip/venv are missing.
- Ensure dependencies are installed and all embedded Python invocations run through the detected interpreter from the project virtualenv.