### PR TITLE
Serve Flask app with Waitress

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@
    - change settings as needed in config.yaml
 
 2) Start Server
-   - run start-server.ps1 to install pre-reqs and start flask
+   - Windows: run start-server.ps1 to install pre-reqs and start the app with Waitress
+   - Linux/macOS: run start-server.sh to install pre-reqs and start the app with Waitress
 
 ## Features
    - Player & Admin login

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ cryptography==42.0.7
 psutil==5.9.8
 PyYAML==6.0.1
 Pillow==10.3.0
+waitress==3.0.2

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -1,6 +1,6 @@
 # PowerShell script to set up and run the MTG Tournament Swiss App.
 # Installs dependencies, initializes the database, creates an admin user,
-# and starts the Flask development server.
+# and starts the app with Waitress.
 # Load settings from YAML config
 $configPath = Join-Path $PSScriptRoot "config.yaml"
 if(!(Test-Path $configPath)){
@@ -66,7 +66,7 @@ if([string]::IsNullOrEmpty($PasswordSeed)){ $PasswordSeed = "dev-password-seed-c
 if([string]::IsNullOrEmpty($FlaskIP)){ $FlaskIP = "127.0.0.1" }
 if([string]::IsNullOrEmpty($FlaskPort)){ $FlaskPort = 5000 }
 
-#check if Flask is already running and stop it if necessary
+#check if Flask/Waitress is already running and stop it if necessary
 $flaskpid = try{
     Get-NetTCPConnection -LocalPort $FlaskPort -State Listen -ErrorAction Stop | Select-Object -ExpandProperty OwningProcess
 }catch{
@@ -78,6 +78,7 @@ if($flaskpid){
 }
 
 Stop-Process -Name "flask" -Force -ErrorAction SilentlyContinue | Out-Null
+Stop-Process -Name "waitress-serve" -Force -ErrorAction SilentlyContinue | Out-Null
 
 # Ensure the script runs from its own directory so relative paths work
 Set-Location -Path $PSScriptRoot
@@ -109,19 +110,18 @@ $env:MTG_LOG_DB_PATH = $LogDatabasePath
 Write-Host "Installing dependencies..."
 python -m pip install -r "$PSScriptRoot/requirements.txt" | Out-Null
 
-Write-Host "Setting Flask environment..."
-$env:FLASK_APP = "app.app:app"
-
 Write-Host "Initializing database..."
 python -m flask --app app.app db-init
 
 Write-Host "Creating default admin user..."
 python -m flask --app app.app create-admin --email $newadmin.UserName --password $newadmin.GetNetworkCredential().Password
 
-Write-Host "Starting Flask development server..."
-#python -m flask --app app.app run --debug
-
-Start-Process -NoNewWindow -FilePath "flask" -ArgumentList "--app app.app run --debug --host=$FlaskIP --port=$FlaskPort"
+Write-Host "Starting Waitress server..."
+$waitressLog = Join-Path $PSScriptRoot "waitress-server.log"
+$waitressErrorLog = Join-Path $PSScriptRoot "waitress-server.err.log"
+$waitressArgs = @("-m", "waitress", "--host=$FlaskIP", "--port=$FlaskPort", "app.app:app")
+Start-Process -NoNewWindow -FilePath "python" -ArgumentList $waitressArgs -RedirectStandardOutput $waitressLog -RedirectStandardError $waitressErrorLog
+Write-Host "Waitress server started. Logs: $waitressLog; errors: $waitressErrorLog"
 
 Start-Sleep -Seconds 3
 

--- a/start-server.sh
+++ b/start-server.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Bash script to set up and run the MTG Tournament Swiss App.
 # Installs dependencies, initializes the database, creates an admin user,
-# and starts the Flask development server.
+# and starts the app with Waitress.
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -211,7 +211,7 @@ export MTG_LOG_DB_PATH="$LOG_DB_FILE"
 printf 'Installing dependencies...\n'
 "$PYTHON_BIN" -m pip install -r "$REQUIREMENTS_FILE" >/dev/null
 
-printf 'Stopping existing Flask server on port %s if present...\n' "$FLASK_PORT"
+printf 'Stopping existing Flask/Waitress server on port %s if present...\n' "$FLASK_PORT"
 "$PYTHON_BIN" - "$FLASK_PORT" <<'PY'
 import os
 import sys
@@ -235,7 +235,8 @@ for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
         name = proc.info.get('name') or ''
         cmdline = proc.info.get('cmdline') or []
         first = os.path.basename(cmdline[0]) if cmdline else ''
-        if name == 'flask' or first == 'flask':
+        command_text = ' '.join(cmdline).lower()
+        if name == 'flask' or first == 'flask' or first == 'waitress-serve' or 'waitress' in command_text:
             pids.add(pid)
     except (psutil.NoSuchProcess, psutil.AccessDenied):
         continue
@@ -274,19 +275,16 @@ for pid in sorted(pids):
         pass
 PY
 
-printf 'Setting Flask environment...\n'
-export FLASK_APP="app.app:app"
-
 printf 'Initializing database...\n'
 "$PYTHON_BIN" -m flask --app app.app db-init
 
 printf 'Creating default admin user...\n'
 "$PYTHON_BIN" -m flask --app app.app create-admin --email "$ADMIN_EMAIL" --password "$ADMIN_PASS"
 
-printf 'Starting Flask development server...\n'
-nohup "$PYTHON_BIN" -m flask --app app.app run --debug --host="$FLASK_IP" --port="$FLASK_PORT" > "$SCRIPT_DIR/flask-server.log" 2>&1 &
-FLASK_PID=$!
-printf 'Flask server started with PID %s. Logs: %s\n' "$FLASK_PID" "$SCRIPT_DIR/flask-server.log"
+printf 'Starting Waitress server...\n'
+nohup "$PYTHON_BIN" -m waitress --host="$FLASK_IP" --port="$FLASK_PORT" app.app:app > "$SCRIPT_DIR/waitress-server.log" 2>&1 &
+WAITRESS_PID=$!
+printf 'Waitress server started with PID %s. Logs: %s\n' "$WAITRESS_PID" "$SCRIPT_DIR/waitress-server.log"
 
 sleep 3
 


### PR DESCRIPTION
### Motivation
- Provide a cross-platform production-capable server by running the Flask app under Waitress on both Windows and Linux/macOS.
- Ensure start/stop scripts handle previously-running `flask` or `waitress` processes so the service can be reliably restarted.

### Description
- Add `waitress==3.0.2` to `requirements.txt` to pin Waitress as a runtime dependency.
- Update `start-server.sh` to detect and stop existing Flask/Waitress listeners and launch the app with `python -m waitress app.app:app`, writing logs to `waitress-server.log`.
- Update `start-server.ps1` to stop `flask`/`waitress` processes and start Waitress via `python -m waitress` using `Start-Process`, redirecting stdout/stderr to `waitress-server.log` and `waitress-server.err.log`.
- Update `README.md` quickstart to document separate start instructions for Windows (`start-server.ps1`) and Linux/macOS (`start-server.sh`) when using Waitress.

### Testing
- Ran shell syntax check with `bash -n start-server.sh` which succeeded.
- Installed runtime deps with `python3 -m pip install -r requirements.txt` which installed `waitress` successfully.
- Verified Waitress CLI with `python3 -m waitress --help` which produced the expected usage output.
- Ran the test suite with `pytest -q` and all automated tests passed (`36 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cd37fb54083208b40037b08ca5eef)

## Summary by Sourcery

Serve the Flask application with Waitress in both shell and PowerShell startup scripts and update documentation and dependencies accordingly.

New Features:
- Run the application under Waitress instead of the Flask development server via the provided start scripts.

Enhancements:
- Ensure startup scripts detect and stop existing Flask or Waitress processes before launching the server.
- Add logging for Waitress server output and errors to dedicated log files in both Windows and Unix environments.

Build:
- Pin Waitress as a runtime dependency in requirements.txt.

Documentation:
- Update README quickstart instructions to describe platform-specific startup scripts using Waitress.