### PR TITLE
Fix MTGJSON card database downloads

### DIFF
--- a/app/card_db.py
+++ b/app/card_db.py
@@ -6,10 +6,11 @@ import tempfile
 import zipfile
 from contextlib import contextmanager
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
-from urllib.request import urlopen
+from urllib.request import Request, urlopen
 
 ATOMIC_CARDS_URL = "https://mtgjson.com/api/v5/AtomicCards.json.zip"
 CURRENT_SCHEMA_VERSION = "3"
+CARD_DB_USER_AGENT = "Walter/1.0 (MTG tournament card database updater)"
 
 
 def _normalize_name(name: str) -> str:
@@ -241,12 +242,17 @@ def _read_atomic_cards_from_zip(path: str) -> List[Dict[str, Any]]:
         return records
 
 
+def _card_database_request(url: str) -> Request:
+    return Request(url, headers={'User-Agent': CARD_DB_USER_AGENT})
+
+
 def build_card_database(path: str, source_url: Optional[str] = None) -> None:
     ensure_directory(path)
     url = source_url or ATOMIC_CARDS_URL
+    request = _card_database_request(url)
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
         temp_name = tmp.name
-        with urlopen(url) as response:
+        with urlopen(request) as response:
             while True:
                 chunk = response.read(1024 * 1024)
                 if not chunk:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,46 @@ from app.models import Role, DEFAULT_ROLE_PERMISSIONS, DEFAULT_ROLE_LEVELS
 from app import card_db
 
 
+SAMPLE_CARDS = [
+    {'name': 'Strip Mine', 'is_land': True, 'is_basic_land': False},
+    {'name': 'Archon of Emeria'},
+    {'name': 'Black Lotus', 'is_vintage_restricted': True},
+    {'name': 'Mana Crypt'},
+    {'name': 'Karakas', 'is_land': True, 'is_basic_land': False},
+    {'name': 'Chancellor of the Annex'},
+    {'name': 'Chrome Mox'},
+    {'name': 'Solitude'},
+    {'name': 'Clarion Conqueror'},
+    {'name': 'Cavern of Souls', 'is_land': True, 'is_basic_land': False},
+    {'name': 'Mox Emerald'},
+    {'name': 'Mox Jet'},
+    {'name': 'Mox Pearl'},
+    {'name': 'Mox Ruby'},
+    {'name': 'Mox Sapphire'},
+    {'name': 'Plains', 'is_land': True, 'is_basic_land': True},
+    {'name': 'Seasoned Dungeoneer'},
+    {'name': 'Anointed Peacekeeper'},
+    {'name': 'Vexing Bauble'},
+    {'name': 'Wasteland', 'is_land': True, 'is_basic_land': False},
+    {'name': 'White Plume Adventurer'},
+    {
+        'name': 'Witch Enchanter // Witch-Blessed Meadow',
+        'face_names': ['Witch Enchanter', 'Witch-Blessed Meadow'],
+        'is_land': True,
+        'is_basic_land': False,
+    },
+    {'name': 'Ancient Tomb', 'is_land': True, 'is_basic_land': False},
+    {'name': 'Void Mirror'},
+    {'name': 'March of Otherworldly Light'},
+    {'name': 'Archon of Absolution'},
+    {'name': 'Leyline of the Void'},
+    {'name': 'Containment Priest'},
+    {'name': 'Swords to Plowshares'},
+    {'name': 'Null Rod'},
+    {'name': 'Hopeless Nightmare', 'is_standard_banned': True},
+]
+
+
 @pytest.fixture
 def app(tmp_path, monkeypatch):
     # use temporary SQLite databases for testing
@@ -19,6 +59,7 @@ def app(tmp_path, monkeypatch):
     monkeypatch.setenv("MTG_LOG_DB_PATH", str(tmp_path / "test_logs.db"))
     card_db_path = tmp_path / "cards.db"
     monkeypatch.setenv("MTG_CARD_DB_PATH", str(card_db_path))
+    card_db.populate_card_database(str(card_db_path), SAMPLE_CARDS)
     application = create_app()
     application.config['TESTING'] = True
     with application.app_context():
@@ -32,45 +73,6 @@ def app(tmp_path, monkeypatch):
             )
             db.session.add(role)
         db.session.commit()
-        sample_cards = [
-            {'name': 'Strip Mine', 'is_land': True, 'is_basic_land': False},
-            {'name': 'Archon of Emeria'},
-            {'name': 'Black Lotus', 'is_vintage_restricted': True},
-            {'name': 'Mana Crypt'},
-            {'name': 'Karakas', 'is_land': True, 'is_basic_land': False},
-            {'name': 'Chancellor of the Annex'},
-            {'name': 'Chrome Mox'},
-            {'name': 'Solitude'},
-            {'name': 'Clarion Conqueror'},
-            {'name': 'Cavern of Souls', 'is_land': True, 'is_basic_land': False},
-            {'name': 'Mox Emerald'},
-            {'name': 'Mox Jet'},
-            {'name': 'Mox Pearl'},
-            {'name': 'Mox Ruby'},
-            {'name': 'Mox Sapphire'},
-            {'name': 'Plains', 'is_land': True, 'is_basic_land': True},
-            {'name': 'Seasoned Dungeoneer'},
-            {'name': 'Anointed Peacekeeper'},
-            {'name': 'Vexing Bauble'},
-            {'name': 'Wasteland', 'is_land': True, 'is_basic_land': False},
-            {'name': 'White Plume Adventurer'},
-            {
-                'name': 'Witch Enchanter // Witch-Blessed Meadow',
-                'face_names': ['Witch Enchanter', 'Witch-Blessed Meadow'],
-                'is_land': True,
-                'is_basic_land': False,
-            },
-            {'name': 'Ancient Tomb', 'is_land': True, 'is_basic_land': False},
-            {'name': 'Void Mirror'},
-            {'name': 'March of Otherworldly Light'},
-            {'name': 'Archon of Absolution'},
-            {'name': 'Leyline of the Void'},
-            {'name': 'Containment Priest'},
-            {'name': 'Swords to Plowshares'},
-            {'name': 'Null Rod'},
-            {'name': 'Hopeless Nightmare', 'is_standard_banned': True},
-        ]
-        card_db.populate_card_database(str(card_db_path), sample_cards)
         yield application
         db.session.remove()
 

--- a/tests/test_card_db.py
+++ b/tests/test_card_db.py
@@ -1,0 +1,53 @@
+import json
+import zipfile
+
+from app import card_db
+
+
+def _atomic_cards_zip(path):
+    payload = {
+        'data': {
+            'Black Lotus': [
+                {
+                    'types': ['Artifact'],
+                    'supertypes': [],
+                    'subtypes': [],
+                    'legalities': {'vintage': 'Restricted'},
+                }
+            ]
+        }
+    }
+    with zipfile.ZipFile(path, 'w') as archive:
+        archive.writestr('AtomicCards.json', json.dumps(payload))
+
+
+def test_build_card_database_sends_user_agent(monkeypatch, tmp_path):
+    source_zip = tmp_path / 'AtomicCards.json.zip'
+    _atomic_cards_zip(source_zip)
+    seen = {}
+
+    class FakeResponse:
+        def __init__(self, request):
+            seen['request'] = request
+            self.handle = open(source_zip, 'rb')
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.handle.close()
+
+        def read(self, size=-1):
+            return self.handle.read(size)
+
+    def fake_urlopen(request):
+        return FakeResponse(request)
+
+    monkeypatch.setattr(card_db, 'urlopen', fake_urlopen)
+
+    db_path = tmp_path / 'cards.db'
+    card_db.build_card_database(str(db_path), source_url='https://mtgjson.example/cards.zip')
+
+    assert seen['request'].full_url == 'https://mtgjson.example/cards.zip'
+    assert seen['request'].get_header('User-agent') == card_db.CARD_DB_USER_AGENT
+    assert card_db.lookup_card(str(db_path), 'Black Lotus') == 'Black Lotus'


### PR DESCRIPTION
### Motivation
- MTGJSON AtomicCards downloads could be rejected by hosts that require a User-Agent header, causing startup database preparation to fail; the downloader needed a polite client identity.
- The test fixture previously allowed live downloads during app creation which made the test suite less deterministic.
- Add unit coverage to ensure the HTTP request includes the expected header and the downloaded archive is parsed into the DB.

### Description
- Add `CARD_DB_USER_AGENT` and use `urllib.request.Request` to wrap the download URL with a `User-Agent` header, via a helper `_card_database_request`, and pass that to `urlopen` in `build_card_database` (`app/card_db.py`).
- Add a focused unit test `tests/test_card_db.py` that monkeypatches `urlopen`, verifies the request `User-Agent` and confirms the database is populated after `build_card_database` runs.
- Pre-populate the test card database in `tests/conftest.py` with `SAMPLE_CARDS` using `card_db.populate_card_database(...)` to avoid live network calls during fixture setup.

### Testing
- Ran the test suite with `pytest -q` and the run succeeded with all tests passing (`37 passed, 21 warnings`).
- The new unit test `test_build_card_database_sends_user_agent` passed (`1 passed`).
- Verified the change exercises `build_card_database` and `populate_card_database` paths under test via the stubbed `urlopen`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cd51fb99483209a15acb544fca0e8)

## Summary by Sourcery

Ensure MTGJSON card database downloads send an explicit User-Agent and are reliably tested without live network access.

Bug Fixes:
- Prevent MTGJSON AtomicCards downloads from being rejected by hosts that require a User-Agent header by sending a dedicated client identifier.

Enhancements:
- Refactor card database downloads to build a Request object with a consistent User-Agent header before calling urlopen.
- Centralize and reuse a shared SAMPLE_CARDS definition for populating the test card database fixture.

Tests:
- Add a unit test that stubs urlopen to verify the download request URL, assert the User-Agent header, and confirm the resulting archive populates the card database.
- Adjust the app fixture to pre-populate the card database using SAMPLE_CARDS during test setup, avoiding live network calls.