### PR TITLE
Add Nginx reverse-proxy config and installer script for Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,19 @@
    - Windows: run start-server.ps1 to install pre-reqs and start the app with Waitress
    - Linux/macOS: run start-server.sh to install pre-reqs and start the app with Waitress
 
+
+## Nginx reverse proxy (Linux)
+
+This repository includes a sample Nginx reverse-proxy config for running the app behind Nginx on port 80. The config proxies traffic to Waitress at `127.0.0.1:5000`; update `nginx/walter.conf` if your `config.yaml` uses a different `flask_port` or if you want to set a real `server_name`.
+
+1) Start the app with Waitress:
+   - `./start-server.sh`
+
+2) Install and enable the Nginx site config:
+   - `./scripts/install_nginx_config.sh`
+
+The installer copies the config to `/etc/nginx/sites-available` and enables it via `/etc/nginx/sites-enabled` on Debian/Ubuntu-style systems. On systems that use `/etc/nginx/conf.d`, it installs `walter.conf` there instead. Use `./scripts/install_nginx_config.sh --help` to see options such as `--dry-run`, `--config`, `--site-name`, and `--no-reload`.
+
 ## Features
    - Player & Admin login
    - Tournaments: Commander, Draft, Constructed

--- a/nginx/walter.conf
+++ b/nginx/walter.conf
@@ -1,0 +1,40 @@
+# Nginx reverse proxy for the Walter Flask/Waitress application.
+#
+# The application is expected to be running locally with start-server.sh.
+# If your config.yaml uses a different flask_port, update the port below.
+
+upstream walter_app {
+    server 127.0.0.1:5000;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    # Replace _ with your domain name when one is available, for example:
+    # server_name tournaments.example.com;
+    server_name _;
+
+    client_max_body_size 25m;
+
+    access_log /var/log/nginx/walter.access.log;
+    error_log /var/log/nginx/walter.error.log;
+
+    location / {
+        proxy_pass http://walter_app;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port $server_port;
+
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+# Install the Walter Nginx reverse-proxy configuration on Linux.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEFAULT_CONFIG="$REPO_DIR/nginx/walter.conf"
+
+CONFIG_FILE="$DEFAULT_CONFIG"
+SITE_NAME="walter"
+DRY_RUN=0
+RELOAD_NGINX=1
+
+usage() {
+  cat <<USAGE
+Usage: $0 [options]
+
+Copies the Walter Nginx config into the correct Linux Nginx location:
+  - /etc/nginx/sites-available + sites-enabled when those directories exist
+  - /etc/nginx/conf.d otherwise
+
+Options:
+  -c, --config PATH     Source Nginx config to install (default: $DEFAULT_CONFIG)
+  -n, --site-name NAME  Installed site name (default: $SITE_NAME)
+      --dry-run         Print actions without changing files
+      --no-reload       Do not validate or reload Nginx after installing
+  -h, --help            Show this help
+USAGE
+}
+
+log() {
+  printf '%s\n' "$*"
+}
+
+run_root() {
+  if [[ "$DRY_RUN" -eq 1 ]]; then
+    printf '[dry-run]'
+    printf ' %q' "$@"
+    printf '\n'
+    return 0
+  fi
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    "$@"
+  elif command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    log "This script needs root privileges. Re-run as root or install sudo." >&2
+    exit 1
+  fi
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    -c|--config)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log "Missing value for $1" >&2
+        usage >&2
+        exit 1
+      fi
+      CONFIG_FILE="$2"
+      shift 2
+      ;;
+    -n|--site-name)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log "Missing value for $1" >&2
+        usage >&2
+        exit 1
+      fi
+      SITE_NAME="$2"
+      shift 2
+      ;;
+    --dry-run)
+      DRY_RUN=1
+      shift
+      ;;
+    --no-reload)
+      RELOAD_NGINX=0
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      log "Unknown option: $1" >&2
+      usage >&2
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$CONFIG_FILE" || ! -f "$CONFIG_FILE" ]]; then
+  log "Nginx config not found: $CONFIG_FILE" >&2
+  exit 1
+fi
+
+if [[ -z "$SITE_NAME" || "$SITE_NAME" == */* ]]; then
+  log "Site name must be a non-empty filename, not a path: $SITE_NAME" >&2
+  exit 1
+fi
+
+if [[ ! -d /etc/nginx && "$DRY_RUN" -ne 1 ]]; then
+  log "/etc/nginx does not exist. Install Nginx first, then re-run this script." >&2
+  exit 1
+fi
+
+if [[ -d /etc/nginx/sites-available ]]; then
+  TARGET_AVAILABLE="/etc/nginx/sites-available/$SITE_NAME"
+  TARGET_ENABLED="/etc/nginx/sites-enabled/$SITE_NAME"
+
+  log "Installing $CONFIG_FILE to $TARGET_AVAILABLE"
+  run_root install -m 0644 "$CONFIG_FILE" "$TARGET_AVAILABLE"
+
+  if [[ ! -d /etc/nginx/sites-enabled ]]; then
+    log "Creating /etc/nginx/sites-enabled"
+    run_root mkdir -p /etc/nginx/sites-enabled
+  fi
+
+  log "Enabling site at $TARGET_ENABLED"
+  run_root ln -sfn "$TARGET_AVAILABLE" "$TARGET_ENABLED"
+else
+  TARGET_CONF="/etc/nginx/conf.d/$SITE_NAME.conf"
+
+  if [[ ! -d /etc/nginx/conf.d ]]; then
+    log "Creating /etc/nginx/conf.d"
+    run_root mkdir -p /etc/nginx/conf.d
+  fi
+
+  log "Installing $CONFIG_FILE to $TARGET_CONF"
+  run_root install -m 0644 "$CONFIG_FILE" "$TARGET_CONF"
+fi
+
+if [[ "$RELOAD_NGINX" -eq 1 ]]; then
+  log "Validating Nginx configuration"
+  run_root nginx -t
+
+  if command -v systemctl >/dev/null 2>&1; then
+    log "Reloading Nginx with systemctl"
+    run_root systemctl reload nginx
+  else
+    log "Reloading Nginx with nginx -s reload"
+    run_root nginx -s reload
+  fi
+else
+  log "Skipping Nginx validation and reload (--no-reload)."
+fi
+
+log "Nginx config installation complete."


### PR DESCRIPTION
### Motivation
- Provide a packaged Nginx reverse-proxy configuration for running the Waitress-backed Flask app behind Nginx on Linux.
- Make it easy to install and enable the site config on common Linux layouts (`sites-available`/`sites-enabled` or `conf.d`) and to validate/reload Nginx after installation.

### Description
- Add `nginx/walter.conf`, a sample reverse-proxy config that proxies traffic to `127.0.0.1:5000` and sets common forwarded headers and logging paths.
- Add `scripts/install_nginx_config.sh`, an executable installer that copies the config into `/etc/nginx/sites-available` + `/etc/nginx/sites-enabled` when present or `/etc/nginx/conf.d` otherwise, creates needed directories, and creates/updates the enabled symlink.
- The installer supports `--config`, `--site-name`, `--dry-run`, and `--no-reload`, runs actions with `sudo` when not root, validates Nginx (`nginx -t`) and reloads via `systemctl` or `nginx -s reload` unless `--no-reload` is used.
- Update `README.md` with a short `Nginx reverse proxy (Linux)` section describing the config and how to use the installer.

### Testing
- `bash -n scripts/install_nginx_config.sh` succeeded (syntax check passed).
- `./scripts/install_nginx_config.sh --dry-run --no-reload` ran in dry-run mode and printed the intended actions successfully.
- `python -m pytest` ran the test suite and reported `37 passed` (all tests passed).
- `nginx -t` was attempted but failed because `nginx` is not installed in the container (`command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cd94e0208832084641f45441776c5)

## Summary by Sourcery

Add a packaged Nginx reverse-proxy configuration and Linux installer script for running the app behind Nginx, and document how to use them.

New Features:
- Provide an example Nginx reverse-proxy configuration for the Walter Flask/Waitress application listening on port 80 and proxying to localhost.
- Introduce a Linux shell script to install and enable the Nginx site configuration across common Nginx directory layouts, with options for customization and dry-run behavior.

Deployment:
- Automate Nginx config deployment with validation and reload support, including running privileged actions via sudo when needed.

Documentation:
- Document how to run the app behind Nginx on Linux and how to use the installer script in the README.