### PR TITLE
Add Nginx to Linux prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 2) Start Server
    - Windows: run start-server.ps1 to install pre-reqs and start the app with Waitress
    - Linux/macOS: run start-server.sh to install pre-reqs and start the app with Waitress
+     - On Linux, this also ensures Nginx is installed for the included reverse-proxy setup.
 
 
 ## Nginx reverse proxy (Linux)

--- a/start-server.sh
+++ b/start-server.sh
@@ -57,6 +57,37 @@ install_python() {
   fi
 }
 
+
+install_nginx() {
+  if [[ "${OSTYPE:-}" != linux* ]]; then
+    return 0
+  fi
+
+  if command -v nginx >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "Nginx was not found. Attempting to install nginx with the system package manager..." >&2
+
+  if command -v apt-get >/dev/null 2>&1; then
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y nginx
+  elif command -v dnf >/dev/null 2>&1; then
+    run_as_root dnf install -y nginx
+  elif command -v yum >/dev/null 2>&1; then
+    run_as_root yum install -y nginx
+  elif command -v zypper >/dev/null 2>&1; then
+    run_as_root zypper --non-interactive install nginx
+  elif command -v pacman >/dev/null 2>&1; then
+    run_as_root pacman -Sy --noconfirm nginx
+  elif command -v apk >/dev/null 2>&1; then
+    run_as_root apk add --no-cache nginx
+  else
+    echo "Nginx is required on Linux, and no supported package manager was found. Install nginx manually." >&2
+    exit 1
+  fi
+}
+
 install_python_package_support() {
   echo "Python packaging support was not found. Attempting to install pip and venv support with the system package manager..." >&2
 
@@ -112,6 +143,8 @@ ensure_pip() {
     exit 1
   fi
 }
+
+install_nginx
 
 if ! detect_python; then
   install_python


### PR DESCRIPTION
### Motivation
- Ensure the provided Nginx reverse-proxy workflow works out-of-the-box on Linux by making `start-server.sh` install Nginx when it is missing.

### Description
- Add an `install_nginx()` function to `start-server.sh` that is no-op on non-Linux hosts and returns early if `nginx` is already available. 
- The installer attempts to install Nginx via supported package managers (`apt-get`, `dnf`, `yum`, `zypper`, `pacman`, `apk`) and errors with guidance if no supported manager is found. 
- Call `install_nginx` early in the startup flow before Python detection so Linux hosts have Nginx available for the included reverse-proxy setup. 
- Update the Quickstart in `README.md` to document that `start-server.sh` ensures Nginx is installed on Linux.

### Testing
- Validated shell scripts with `bash -n start-server.sh scripts/install_nginx_config.sh`, which succeeded. 
- Ran `git diff --check` to verify no whitespace/patch issues, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cdbb960608320b0f308f238e6455b)

## Summary by Sourcery

Ensure Nginx is automatically installed on Linux when running the server startup script so the bundled reverse-proxy setup works out-of-the-box.

New Features:
- Add automatic Nginx installation to the Linux startup flow via the server bootstrap script.

Enhancements:
- Invoke Nginx installation before Python detection in the startup sequence to guarantee reverse-proxy availability on Linux hosts.

Documentation:
- Update the Quickstart documentation to note that the Linux startup script ensures Nginx is installed for the reverse-proxy configuration.