### PR TITLE
Fix Nginx reverse proxy default site handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,9 @@ This repository includes a sample Nginx reverse-proxy config for running the app
 2) Install and enable the Nginx site config:
    - `./scripts/install_nginx_config.sh`
 
-The installer copies the config to `/etc/nginx/sites-available` and enables it via `/etc/nginx/sites-enabled` on Debian/Ubuntu-style systems. On systems that use `/etc/nginx/conf.d`, it installs `walter.conf` there instead. Use `./scripts/install_nginx_config.sh --help` to see options such as `--dry-run`, `--config`, `--site-name`, and `--no-reload`.
+The installer copies the config to `/etc/nginx/sites-available` and enables it via `/etc/nginx/sites-enabled` on Debian/Ubuntu-style systems. On systems that use `/etc/nginx/conf.d`, it installs `walter.conf` there instead. It also disables the packaged default Nginx site so requests to the server IP show Walter instead of the "Welcome to nginx!" page. Use `./scripts/install_nginx_config.sh --help` to see options such as `--dry-run`, `--config`, `--site-name`, `--no-reload`, and `--keep-default-site`.
+
+If you still see the default Nginx welcome page after installing, re-run `./scripts/install_nginx_config.sh` and confirm that Nginx reloaded successfully. If you see a `502 Bad Gateway` page instead, make sure the Waitress host and port in `config.yaml` match the upstream address in `nginx/walter.conf`; the included config expects Waitress at `127.0.0.1:5000`.
 
 ## Features
    - Player & Admin login

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,6 @@ admin_email: admin@example.com
 admin_pass: admin123
 flask_secret: dev-secret-change-me
 password_seed: dev-password-seed-change-me
-#flask_ip: 10.147.17.136
-flask_ip: 192.168.1.85
+flask_ip: 127.0.0.1
 flask_port: 5000
 last_table_number: 200

--- a/nginx/walter.conf
+++ b/nginx/walter.conf
@@ -4,7 +4,7 @@
 # If your config.yaml uses a different flask_port, update the port below.
 
 upstream walter_app {
-    server 192.168.1.7:5000;
+    server 127.0.0.1:5000;
     keepalive 16;
 }
 

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -10,6 +10,7 @@ CONFIG_FILE="$DEFAULT_CONFIG"
 SITE_NAME="walter"
 DRY_RUN=0
 RELOAD_NGINX=1
+DISABLE_DEFAULT_SITE=1
 
 usage() {
   cat <<USAGE
@@ -24,6 +25,8 @@ Options:
   -n, --site-name NAME  Installed site name (default: $SITE_NAME)
       --dry-run         Print actions without changing files
       --no-reload       Do not validate or reload Nginx after installing
+      --keep-default-site
+                        Leave the packaged default Nginx site enabled
   -h, --help            Show this help
 USAGE
 }
@@ -78,6 +81,10 @@ while [[ $# -gt 0 ]]; do
       RELOAD_NGINX=0
       shift
       ;;
+    --keep-default-site)
+      DISABLE_DEFAULT_SITE=0
+      shift
+      ;;
     -h|--help)
       usage
       exit 0
@@ -105,6 +112,29 @@ if [[ ! -d /etc/nginx && "$DRY_RUN" -ne 1 ]]; then
   exit 1
 fi
 
+
+disable_packaged_default_site() {
+  if [[ "$DISABLE_DEFAULT_SITE" -ne 1 ]]; then
+    return 0
+  fi
+
+  local default_site="/etc/nginx/sites-enabled/default"
+  if [[ -e "$default_site" || -L "$default_site" ]]; then
+    log "Disabling packaged default site at $default_site so Walter answers port 80"
+    if [[ -L "$default_site" ]]; then
+      run_root rm -f "$default_site"
+    else
+      run_root mv -f "$default_site" "/etc/nginx/default.disabled"
+    fi
+  fi
+
+  local default_conf="/etc/nginx/conf.d/default.conf"
+  if [[ -e "$default_conf" || -L "$default_conf" ]]; then
+    log "Disabling packaged default config at $default_conf so Walter answers port 80"
+    run_root mv -f "$default_conf" "$default_conf.disabled"
+  fi
+}
+
 if [[ -d /etc/nginx/sites-available ]]; then
   TARGET_AVAILABLE="/etc/nginx/sites-available/$SITE_NAME"
   TARGET_ENABLED="/etc/nginx/sites-enabled/$SITE_NAME"
@@ -130,6 +160,8 @@ else
   log "Installing $CONFIG_FILE to $TARGET_CONF"
   run_root install -m 0644 "$CONFIG_FILE" "$TARGET_CONF"
 fi
+
+disable_packaged_default_site
 
 if [[ "$RELOAD_NGINX" -eq 1 ]]; then
   log "Validating Nginx configuration"


### PR DESCRIPTION
### Motivation
- Prevent the packaged Nginx "Welcome to nginx!" page from hiding the Walter site after installing the bundled Nginx config. 
- Make the sample Nginx upstream match the local Waitress default so the packaged config works out-of-the-box.

### Description
- Change the sample upstream in `nginx/walter.conf` to use `127.0.0.1:5000` instead of a stale LAN IP. 
- Update `config.yaml` to use `flask_ip: 127.0.0.1` so the app and Nginx settings are aligned. 
- Add `DISABLE_DEFAULT_SITE=1` default behavior and a `--keep-default-site` opt-out flag to `scripts/install_nginx_config.sh`. 
- Add a `disable_packaged_default_site()` helper that disables or removes the packaged default site (`/etc/nginx/sites-enabled/default` and `/etc/nginx/conf.d/default.conf`) and invoke it during install before reload. 
- Document the change and troubleshooting (including how to recover from the default welcome page or a `502 Bad Gateway`) in `README.md`.

### Testing
- Ran a shell syntax check with `bash -n scripts/install_nginx_config.sh` which succeeded. 
- Executed the installer in dry-run mode with `./scripts/install_nginx_config.sh --dry-run --no-reload` which produced the expected dry-run output. 
- Ran the full test suite with `pytest -q` which passed: `37 passed, 21 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cdccea51883208881edb02786516a)

## Summary by Sourcery

Align Nginx reverse proxy behavior and configuration with the local Walter/Waitress setup and ensure the app, not the default Nginx site, answers on port 80.

New Features:
- Add an option to keep the packaged default Nginx site enabled when installing the Walter Nginx config.

Bug Fixes:
- Ensure the sample Nginx upstream and application configuration both target Waitress on 127.0.0.1:5000 so the bundled config works out-of-the-box.
- Disable the packaged default Nginx site during installation so Walter is served instead of the Nginx welcome page.

Enhancements:
- Document default-site handling and common Nginx troubleshooting steps in the README, including guidance for the Nginx welcome page and 502 Bad Gateway errors.

Documentation:
- Expand README instructions to cover automatic disabling of the default Nginx site and how to troubleshoot welcome page and 502 errors.