### PR TITLE
Add TLS 1.3 Nginx support with Let's Encrypt and FIPS AES-GCM ciphers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,24 @@ The installer copies the config to `/etc/nginx/sites-available` and enables it v
 
 If you still see the default Nginx welcome page after installing, re-run `./scripts/install_nginx_config.sh` and confirm that Nginx reloaded successfully. If you see a `502 Bad Gateway` page instead, make sure the Waitress host and port in `config.yaml` match the upstream address in `nginx/walter.conf`; the included config expects Waitress at `127.0.0.1:5000`.
 
+### HTTPS with TLS 1.3 and Let's Encrypt
+
+For production, create the Let's Encrypt certificate files on the production machine first. Do **not** add `fullchain.pem`, `privkey.pem`, `chain.pem`, or any other certificate/private-key material to this repository.
+
+One common webroot flow is:
+
+1) Install Nginx with the HTTP config so Certbot can complete HTTP-01 validation:
+   - `./scripts/install_nginx_config.sh`
+
+2) Create the certificate on the server, replacing the domain and email:
+   - `sudo mkdir -p /var/www/letsencrypt/.well-known/acme-challenge`
+   - `sudo certbot certonly --webroot -w /var/www/letsencrypt -d tournaments.example.com --email admin@example.com --agree-tos --no-eff-email`
+
+3) Install the TLS config rendered for your production domain:
+   - `./scripts/install_nginx_config.sh --tls-domain tournaments.example.com`
+
+The TLS template lives at `nginx/walter-tls.conf`. It serves HTTPS on port 443, redirects normal HTTP traffic to HTTPS, leaves `/.well-known/acme-challenge/` available on port 80 for Let's Encrypt renewals, only enables TLS 1.3, and restricts TLS 1.3 cipher suites to the FIPS-suitable AES-GCM suites `TLS_AES_256_GCM_SHA384` and `TLS_AES_128_GCM_SHA256`. If your certificate lives somewhere other than `/etc/letsencrypt/live/<domain>`, pass `--cert-dir /path/to/live/certdir`; if your ACME challenge webroot differs, pass `--acme-webroot /path/to/webroot`.
+
 ## Features
    - Player & Admin login
    - Tournaments: Commander, Draft, Constructed

--- a/nginx/walter-tls.conf
+++ b/nginx/walter-tls.conf
@@ -1,0 +1,77 @@
+# Nginx reverse proxy for the Walter Flask/Waitress application with HTTPS.
+#
+# This file is a template used by scripts/install_nginx_config.sh --tls-domain.
+# The installer replaces __WALTER_DOMAIN__, __WALTER_CERT_DIR__, and
+# __WALTER_ACME_WEBROOT__. Do not commit certificate material to this repo.
+
+upstream walter_app {
+    server 127.0.0.1:5000;
+    keepalive 16;
+}
+
+server {
+    listen 80;
+    listen [::]:80;
+
+    server_name __WALTER_DOMAIN__;
+
+    # Certbot webroot HTTP-01 challenge directory. Keep this available on port
+    # 80 so Let's Encrypt renewals can complete before HTTP traffic is
+    # redirected to HTTPS.
+    location ^~ /.well-known/acme-challenge/ {
+        root __WALTER_ACME_WEBROOT__;
+        default_type "text/plain";
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+
+    server_name __WALTER_DOMAIN__;
+
+    client_max_body_size 25m;
+
+    access_log /var/log/nginx/walter.access.log;
+    error_log /var/log/nginx/walter.error.log;
+
+    # Let's Encrypt certificate paths created on the production machine, e.g.:
+    #   certbot certonly --webroot -w __WALTER_ACME_WEBROOT__ -d __WALTER_DOMAIN__
+    ssl_certificate __WALTER_CERT_DIR__/fullchain.pem;
+    ssl_certificate_key __WALTER_CERT_DIR__/privkey.pem;
+    ssl_trusted_certificate __WALTER_CERT_DIR__/chain.pem;
+
+    # Only permit TLS 1.3. The configured cipher suites are the TLS 1.3
+    # AES-GCM suites that are suitable for FIPS-mode OpenSSL deployments.
+    # ChaCha20-Poly1305 is intentionally omitted because it is not FIPS-approved.
+    ssl_protocols TLSv1.3;
+    ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256;
+    ssl_prefer_server_ciphers off;
+
+    ssl_session_timeout 1d;
+    ssl_session_cache shared:WalterTLS:10m;
+    ssl_session_tickets off;
+
+    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+    add_header X-Content-Type-Options nosniff always;
+
+    location / {
+        proxy_pass http://walter_app;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+}

--- a/nginx/walter.conf
+++ b/nginx/walter.conf
@@ -2,6 +2,9 @@
 #
 # The application is expected to be running locally with start-server.sh.
 # If your config.yaml uses a different flask_port, update the port below.
+# For production HTTPS with TLS 1.3, FIPS-approved cipher suites, and
+# Let's Encrypt certificates, install nginx/walter-tls.conf via
+# scripts/install_nginx_config.sh --tls-domain your.domain.example.
 
 upstream walter_app {
     server 127.0.0.1:5000;

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -5,12 +5,18 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEFAULT_CONFIG="$REPO_DIR/nginx/walter.conf"
+DEFAULT_TLS_CONFIG="$REPO_DIR/nginx/walter-tls.conf"
 
 CONFIG_FILE="$DEFAULT_CONFIG"
 SITE_NAME="walter"
 DRY_RUN=0
 RELOAD_NGINX=1
 DISABLE_DEFAULT_SITE=1
+TLS_DOMAIN=""
+CERT_DIR=""
+ACME_WEBROOT="/var/www/letsencrypt"
+GENERATED_CONFIG=""
+CONFIG_EXPLICIT=0
 
 usage() {
   cat <<USAGE
@@ -22,6 +28,10 @@ Copies the Walter Nginx config into the correct Linux Nginx location:
 
 Options:
   -c, --config PATH     Source Nginx config to install (default: $DEFAULT_CONFIG)
+      --tls-domain NAME  Render and install the TLS 1.3 Let's Encrypt config for NAME
+      --cert-dir PATH    Let's Encrypt live cert directory (default: /etc/letsencrypt/live/NAME)
+      --acme-webroot PATH
+                        Webroot for HTTP-01 challenges (default: $ACME_WEBROOT)
   -n, --site-name NAME  Installed site name (default: $SITE_NAME)
       --dry-run         Print actions without changing files
       --no-reload       Do not validate or reload Nginx after installing
@@ -62,6 +72,7 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       CONFIG_FILE="$2"
+      CONFIG_EXPLICIT=1
       shift 2
       ;;
     -n|--site-name)
@@ -71,6 +82,33 @@ while [[ $# -gt 0 ]]; do
         exit 1
       fi
       SITE_NAME="$2"
+      shift 2
+      ;;
+    --tls-domain)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log "Missing value for $1" >&2
+        usage >&2
+        exit 1
+      fi
+      TLS_DOMAIN="$2"
+      shift 2
+      ;;
+    --cert-dir)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log "Missing value for $1" >&2
+        usage >&2
+        exit 1
+      fi
+      CERT_DIR="$2"
+      shift 2
+      ;;
+    --acme-webroot)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log "Missing value for $1" >&2
+        usage >&2
+        exit 1
+      fi
+      ACME_WEBROOT="$2"
       shift 2
       ;;
     --dry-run)
@@ -97,6 +135,31 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+
+if [[ -n "$TLS_DOMAIN" ]]; then
+  if [[ "$CONFIG_EXPLICIT" -eq 0 ]]; then
+    CONFIG_FILE="$DEFAULT_TLS_CONFIG"
+  fi
+
+  if [[ "$TLS_DOMAIN" == *"/"* || "$TLS_DOMAIN" == *" "* ]]; then
+    log "TLS domain must be a DNS name, not a path or value with spaces: $TLS_DOMAIN" >&2
+    exit 1
+  fi
+
+  CERT_DIR="${CERT_DIR:-/etc/letsencrypt/live/$TLS_DOMAIN}"
+
+  if [[ "$DRY_RUN" -ne 1 ]]; then
+    for cert_file in "$CERT_DIR/fullchain.pem" "$CERT_DIR/privkey.pem" "$CERT_DIR/chain.pem"; do
+      if [[ ! -f "$cert_file" ]]; then
+        log "Missing Let's Encrypt certificate file: $cert_file" >&2
+        log "Create certificates on this machine first, for example:" >&2
+        log "  certbot certonly --webroot -w $ACME_WEBROOT -d $TLS_DOMAIN" >&2
+        exit 1
+      fi
+    done
+  fi
+fi
+
 if [[ -z "$CONFIG_FILE" || ! -f "$CONFIG_FILE" ]]; then
   log "Nginx config not found: $CONFIG_FILE" >&2
   exit 1
@@ -112,6 +175,37 @@ if [[ ! -d /etc/nginx && "$DRY_RUN" -ne 1 ]]; then
   exit 1
 fi
 
+
+
+escape_sed_replacement() {
+  printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
+}
+
+render_tls_config() {
+  if [[ -z "$TLS_DOMAIN" ]]; then
+    return 0
+  fi
+
+  local escaped_domain escaped_cert_dir escaped_acme_webroot
+  escaped_domain="$(escape_sed_replacement "$TLS_DOMAIN")"
+  escaped_cert_dir="$(escape_sed_replacement "$CERT_DIR")"
+  escaped_acme_webroot="$(escape_sed_replacement "$ACME_WEBROOT")"
+
+  GENERATED_CONFIG="$(mktemp)"
+  sed \
+    -e "s/__WALTER_DOMAIN__/$escaped_domain/g" \
+    -e "s/__WALTER_CERT_DIR__/$escaped_cert_dir/g" \
+    -e "s/__WALTER_ACME_WEBROOT__/$escaped_acme_webroot/g" \
+    "$CONFIG_FILE" > "$GENERATED_CONFIG"
+  CONFIG_FILE="$GENERATED_CONFIG"
+}
+
+cleanup_generated_config() {
+  if [[ -n "$GENERATED_CONFIG" && -f "$GENERATED_CONFIG" ]]; then
+    rm -f "$GENERATED_CONFIG"
+  fi
+}
+trap cleanup_generated_config EXIT
 
 disable_packaged_default_site() {
   if [[ "$DISABLE_DEFAULT_SITE" -ne 1 ]]; then
@@ -134,6 +228,13 @@ disable_packaged_default_site() {
     run_root mv -f "$default_conf" "$default_conf.disabled"
   fi
 }
+
+render_tls_config
+
+if [[ -n "$TLS_DOMAIN" ]]; then
+  log "Ensuring ACME challenge webroot exists at $ACME_WEBROOT"
+  run_root mkdir -p "$ACME_WEBROOT/.well-known/acme-challenge"
+fi
 
 if [[ -d /etc/nginx/sites-available ]]; then
   TARGET_AVAILABLE="/etc/nginx/sites-available/$SITE_NAME"


### PR DESCRIPTION
### Motivation

- Provide a production-ready HTTPS Nginx config that enforces TLS 1.3 and FIPS-suitable AES-GCM cipher suites while keeping private keys out of the repository. 
- Make it straightforward to obtain and install Let's Encrypt certificates on the target machine using the HTTP-01 (webroot) flow and keep ACME challenge paths available on port 80 for renewals. 

### Description

- Add `nginx/walter-tls.conf`, a TLS-enabled Nginx template that redirects HTTP->HTTPS, exposes `/.well-known/acme-challenge/` for HTTP-01, and restricts TLS to `TLSv1.3` with AES-GCM suites (`TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256`).
- Extend `scripts/install_nginx_config.sh` with `--tls-domain`, `--cert-dir`, and `--acme-webroot` options and implement template rendering, safe substitution, and checks for required Let's Encrypt files so certificates are provided on the host at install time.
- Make the installer create the ACME webroot when TLS mode is used and support rendering the TLS template to a temporary file before installation, cleaning up generated artifacts on exit.
- Update `nginx/walter.conf` with a pointer to the TLS deployment path and add a README section documenting the recommended Let’s Encrypt webroot flow and the explicit requirement not to commit certificate/private-key material.

### Testing

- Ran a syntax check: `bash -n scripts/install_nginx_config.sh`, which completed successfully. 
- Performed a dry-run of the installer with TLS rendering: `./scripts/install_nginx_config.sh --dry-run --no-reload --tls-domain tournaments.example.com --cert-dir /etc/letsencrypt/live/tournaments.example.com`, which completed (dry-run) without errors. 
- Ran the test suite: `python -m pytest`, which passed (`37 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ce3367d748320aed6d2f1a533bca1)

## Summary by Sourcery

Add a production-focused HTTPS Nginx configuration and installer support for TLS 1.3 with Let's Encrypt certificates and FIPS-suitable AES-GCM cipher suites.

New Features:
- Introduce a TLS-enabled Nginx template that serves HTTPS, redirects HTTP to HTTPS, and preserves ACME HTTP-01 challenge handling.
- Extend the Nginx config installer script with options to render a TLS config for a specific domain using Let's Encrypt certificate directories and a configurable ACME webroot.

Enhancements:
- Ensure the installer safely renders a temporary TLS config file from a template, validates required certificate files on the host, and cleans up generated artifacts on exit.
- Document the recommended Let's Encrypt webroot flow and reference the TLS deployment configuration from the main Nginx config.