### PR TITLE
Add Let's Encrypt startup certificate handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,9 +26,20 @@ If you still see the default Nginx welcome page after installing, re-run `./scri
 
 ### HTTPS with TLS 1.3 and Let's Encrypt
 
-For production, create the Let's Encrypt certificate files on the production machine first. Do **not** add `fullchain.pem`, `privkey.pem`, `chain.pem`, or any other certificate/private-key material to this repository.
+For production, set `tls_domain` in `config.yaml` to your public DNS name before running `./start-server.sh`. The startup script then checks `/etc/letsencrypt/live/<domain>/fullchain.pem`; if the certificate is missing or expires within `letsencrypt_renewal_days` days (default: 30), it installs Certbot/OpenSSL if needed, installs the HTTP Nginx config for HTTP-01 validation, requests a Let's Encrypt certificate, and then installs the rendered HTTPS Nginx config. Do **not** add `fullchain.pem`, `privkey.pem`, `chain.pem`, or any other certificate/private-key material to this repository.
 
-One common webroot flow is:
+Example `config.yaml` options:
+
+```yaml
+tls_domain: tournaments.example.com
+letsencrypt_email: admin@example.com
+# Optional overrides:
+# letsencrypt_renewal_days: 30
+# tls_cert_dir: /etc/letsencrypt/live/tournaments.example.com
+# acme_webroot: /var/www/letsencrypt
+```
+
+You can still manage the Nginx config manually:
 
 1) Install Nginx with the HTTP config so Certbot can complete HTTP-01 validation:
    - `./scripts/install_nginx_config.sh`

--- a/config.yaml
+++ b/config.yaml
@@ -7,3 +7,9 @@ password_seed: dev-password-seed-change-me
 flask_ip: 127.0.0.1
 flask_port: 5000
 last_table_number: 200
+# Optional production HTTPS settings. When tls_domain is set, start-server.sh
+# checks for a Let's Encrypt certificate and requests or renews it as needed.
+# tls_domain: tournaments.example.com
+# letsencrypt_email: admin@example.com
+# letsencrypt_renewal_days: 30
+# acme_webroot: /var/www/letsencrypt

--- a/nginx/walter.conf
+++ b/nginx/walter.conf
@@ -21,6 +21,14 @@ server {
 
     client_max_body_size 25m;
 
+    # Certbot webroot HTTP-01 challenge directory. Keep this available so
+    # start-server.sh can request the first Let's Encrypt certificate before
+    # switching Nginx to the HTTPS configuration.
+    location ^~ /.well-known/acme-challenge/ {
+        root __WALTER_ACME_WEBROOT__;
+        default_type "text/plain";
+    }
+
     access_log /var/log/nginx/walter.access.log;
     error_log /var/log/nginx/walter.error.log;
 

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -181,11 +181,7 @@ escape_sed_replacement() {
   printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
 }
 
-render_tls_config() {
-  if [[ -z "$TLS_DOMAIN" ]]; then
-    return 0
-  fi
-
+render_config() {
   local escaped_domain escaped_cert_dir escaped_acme_webroot
   escaped_domain="$(escape_sed_replacement "$TLS_DOMAIN")"
   escaped_cert_dir="$(escape_sed_replacement "$CERT_DIR")"
@@ -229,7 +225,7 @@ disable_packaged_default_site() {
   fi
 }
 
-render_tls_config
+render_config
 
 if [[ -n "$TLS_DOMAIN" ]]; then
   log "Ensuring ACME challenge webroot exists at $ACME_WEBROOT"
@@ -270,10 +266,10 @@ if [[ "$RELOAD_NGINX" -eq 1 ]]; then
 
   if command -v systemctl >/dev/null 2>&1; then
     log "Reloading Nginx with systemctl"
-    run_root systemctl reload nginx
+    run_root systemctl reload nginx || run_root systemctl restart nginx
   else
     log "Reloading Nginx with nginx -s reload"
-    run_root nginx -s reload
+    run_root nginx -s reload || run_root nginx
   fi
 else
   log "Skipping Nginx validation and reload (--no-reload)."

--- a/start-server.sh
+++ b/start-server.sh
@@ -8,6 +8,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CONFIG_FILE="$SCRIPT_DIR/config.yaml"
 REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
 VENV_DIR="$SCRIPT_DIR/.venv"
+NGINX_INSTALL_SCRIPT="$SCRIPT_DIR/scripts/install_nginx_config.sh"
 
 PYTHON_BIN=""
 
@@ -87,6 +88,114 @@ install_nginx() {
     exit 1
   fi
 }
+install_certbot() {
+  if [[ "${OSTYPE:-}" != linux* ]]; then
+    return 0
+  fi
+
+  if command -v certbot >/dev/null 2>&1 && command -v openssl >/dev/null 2>&1; then
+    return 0
+  fi
+
+  echo "Certbot/OpenSSL support was not found. Attempting to install it with the system package manager..." >&2
+
+  if command -v apt-get >/dev/null 2>&1; then
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get update
+    run_as_root env DEBIAN_FRONTEND=noninteractive apt-get install -y certbot openssl
+  elif command -v dnf >/dev/null 2>&1; then
+    run_as_root dnf install -y certbot openssl
+  elif command -v yum >/dev/null 2>&1; then
+    run_as_root yum install -y certbot openssl
+  elif command -v zypper >/dev/null 2>&1; then
+    run_as_root zypper --non-interactive install certbot openssl
+  elif command -v pacman >/dev/null 2>&1; then
+    run_as_root pacman -Sy --noconfirm certbot openssl
+  elif command -v apk >/dev/null 2>&1; then
+    run_as_root apk add --no-cache certbot openssl
+  else
+    echo "Certbot and OpenSSL are required for Let's Encrypt certificates, and no supported package manager was found. Install certbot and openssl manually." >&2
+    exit 1
+  fi
+}
+
+ensure_nginx_running() {
+  if [[ "${OSTYPE:-}" != linux* ]]; then
+    return 0
+  fi
+
+  if command -v systemctl >/dev/null 2>&1; then
+    run_as_root systemctl start nginx || true
+  else
+    run_as_root nginx || true
+  fi
+}
+
+cert_expires_within() {
+  local cert_file="$1"
+  local days="$2"
+  local seconds=$((days * 24 * 60 * 60))
+
+  [[ ! -f "$cert_file" ]] && return 0
+  ! openssl x509 -checkend "$seconds" -noout -in "$cert_file" >/dev/null 2>&1
+}
+
+ensure_letsencrypt_certificate() {
+  if [[ "${OSTYPE:-}" != linux* ]]; then
+    return 0
+  fi
+
+  if [[ -z "${TLS_DOMAIN:-}" ]]; then
+    echo "No tls_domain configured; skipping Let's Encrypt certificate check."
+    return 0
+  fi
+
+  if [[ "$TLS_DOMAIN" == *"/"* || "$TLS_DOMAIN" == *" "* ]]; then
+    echo "tls_domain must be a DNS name, not a path or value with spaces: $TLS_DOMAIN" >&2
+    exit 1
+  fi
+
+  install_certbot
+
+  local cert_dir="${TLS_CERT_DIR:-/etc/letsencrypt/live/$TLS_DOMAIN}"
+  local acme_webroot="${ACME_WEBROOT:-/var/www/letsencrypt}"
+  local renewal_days="${LETSENCRYPT_RENEWAL_DAYS:-30}"
+  local fullchain="$cert_dir/fullchain.pem"
+  local certbot_args=(certonly --webroot -w "$acme_webroot" -d "$TLS_DOMAIN" --non-interactive --agree-tos --keep-until-expiring)
+
+  if [[ -n "${LETSENCRYPT_EMAIL:-}" ]]; then
+    certbot_args+=(--email "$LETSENCRYPT_EMAIL" --no-eff-email)
+  else
+    echo "No letsencrypt_email configured; requesting the certificate without an email address." >&2
+    certbot_args+=(--register-unsafely-without-email)
+  fi
+
+  if [[ -n "${LETSENCRYPT_SERVER:-}" ]]; then
+    certbot_args+=(--server "$LETSENCRYPT_SERVER")
+  fi
+
+  if cert_expires_within "$fullchain" "$renewal_days"; then
+    if [[ -f "$fullchain" ]]; then
+      echo "Let's Encrypt certificate for $TLS_DOMAIN expires within $renewal_days days; requesting a replacement."
+      certbot_args+=(--force-renewal)
+    else
+      echo "No Let's Encrypt certificate found for $TLS_DOMAIN; requesting one."
+    fi
+
+    echo "Installing HTTP Nginx config so Let's Encrypt can validate $TLS_DOMAIN..."
+    run_as_root mkdir -p "$acme_webroot/.well-known/acme-challenge"
+    "$NGINX_INSTALL_SCRIPT" --acme-webroot "$acme_webroot"
+    ensure_nginx_running
+
+    run_as_root certbot "${certbot_args[@]}"
+  else
+    echo "Let's Encrypt certificate for $TLS_DOMAIN is present and valid for more than $renewal_days days."
+  fi
+
+  echo "Installing TLS Nginx config for $TLS_DOMAIN..."
+  "$NGINX_INSTALL_SCRIPT" --tls-domain "$TLS_DOMAIN" --cert-dir "$cert_dir" --acme-webroot "$acme_webroot"
+  ensure_nginx_running
+}
+
 
 install_python_package_support() {
   echo "Python packaging support was not found. Attempting to install pip and venv support with the system package manager..." >&2
@@ -192,6 +301,12 @@ keys = [
     'password_seed',
     'flask_ip',
     'flask_port',
+    'tls_domain',
+    'tls_cert_dir',
+    'letsencrypt_email',
+    'letsencrypt_renewal_days',
+    'letsencrypt_server',
+    'acme_webroot',
 ]
 
 for key in keys:
@@ -213,6 +328,12 @@ FLASK_SECRET="${FLASK_SECRET:-dev-secret-change-me}"
 PASSWORD_SEED="${PASSWORD_SEED:-dev-password-seed-change-me}"
 FLASK_IP="${FLASK_IP:-127.0.0.1}"
 FLASK_PORT="${FLASK_PORT:-5000}"
+TLS_DOMAIN="${TLS_DOMAIN:-}"
+TLS_CERT_DIR="${TLS_CERT_DIR:-}"
+LETSENCRYPT_EMAIL="${LETSENCRYPT_EMAIL:-}"
+LETSENCRYPT_RENEWAL_DAYS="${LETSENCRYPT_RENEWAL_DAYS:-30}"
+LETSENCRYPT_SERVER="${LETSENCRYPT_SERVER:-}"
+ACME_WEBROOT="${ACME_WEBROOT:-/var/www/letsencrypt}"
 
 cd "$SCRIPT_DIR"
 
@@ -221,6 +342,8 @@ export PASSWORD_SEED
 export FLASK_SECRET
 export FLASK_RUN_HOST="$FLASK_IP"
 export FLASK_RUN_PORT="$FLASK_PORT"
+
+ensure_letsencrypt_certificate
 
 TIMESTAMP="$(date +%Y%m%d%H%M%S)"
 


### PR DESCRIPTION
### Motivation
- Automatically obtain and renew TLS certificates at startup when a production `tls_domain` is configured so a deployed instance can enable HTTPS with minimal manual steps.
- Ensure the HTTP ACME challenge endpoint remains available while certificates are requested and make the Nginx installer robust on first-time installs.

### Description
- Add Let's Encrypt support to `start-server.sh` including new functions `install_certbot`, `ensure_nginx_running`, `cert_expires_within`, and `ensure_letsencrypt_certificate`, and parse new config keys such as `tls_domain`, `tls_cert_dir`, `letsencrypt_email`, `letsencrypt_renewal_days`, `letsencrypt_server`, and `acme_webroot` from `config.yaml`.
- Wire `ensure_letsencrypt_certificate` into startup so the script will install Certbot/OpenSSL if needed, request or force-renew certificates with `certbot --webroot`, and then install the TLS Nginx config via the existing installer script using the `NGINX_INSTALL_SCRIPT` helper.
- Update `nginx/walter.conf` to expose the ACME `/.well-known/acme-challenge/` location using a rendered webroot placeholder, and make `scripts/install_nginx_config.sh` render `__WALTER_ACME_WEBROOT__` and accept `--acme-webroot` when installing configs.
- Improve `scripts/install_nginx_config.sh` reload behavior to attempt a service restart if a reload fails and document the new `tls_*` options in `README.md` and commented examples in `config.yaml`.

### Testing
- Ran a syntax check on the modified scripts with `bash -n start-server.sh scripts/install_nginx_config.sh`, which succeeded.
- Exercised the Nginx installer in dry-run mode with `./scripts/install_nginx_config.sh --dry-run --no-reload --acme-webroot /tmp/acme-test`, which succeeded and rendered the ACME webroot path.
- Exercised the TLS rendering path in dry-run mode with `./scripts/install_nginx_config.sh --dry-run --no-reload --tls-domain example.com --cert-dir /tmp/certs --acme-webroot /tmp/acme-test`, which succeeded and produced the expected rendered config files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ce52c75788320ae433c47570cd0e7)

## Summary by Sourcery

Automate Let's Encrypt certificate management during server startup and integrate it with Nginx configuration rendering.

New Features:
- Add startup handling to automatically obtain and renew Let's Encrypt TLS certificates when a tls_domain is configured.
- Introduce configurable TLS and ACME settings (tls_domain, tls_cert_dir, letsencrypt_email, letsencrypt_renewal_days, letsencrypt_server, acme_webroot) loaded from config.yaml.

Enhancements:
- Extend the Nginx install script to render ACME webroot placeholders, support an --acme-webroot option, and reuse a unified config rendering step for HTTP and HTTPS.
- Improve Nginx reload behavior to fall back to restart when a reload fails.
- Expose the ACME HTTP-01 challenge path in the default Nginx config to support certificate issuance before enabling HTTPS.

Documentation:
- Document automated Let's Encrypt/TLS startup behavior and tls_* configuration options in README.md and the example config.yaml.