### PR TITLE
Add Let's Encrypt dry-run and validation to start-server.sh; document in README and config.yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ If you still see the default Nginx welcome page after installing, re-run `./scri
 
 For production, set `tls_domain` in `config.yaml` to your public DNS name before running `./start-server.sh`. The startup script then checks `/etc/letsencrypt/live/<domain>/fullchain.pem`; if the certificate is missing or expires within `letsencrypt_renewal_days` days (default: 30), it installs Certbot/OpenSSL if needed, installs the HTTP Nginx config for HTTP-01 validation, requests a Let's Encrypt certificate, and then installs the rendered HTTPS Nginx config. Do **not** add `fullchain.pem`, `privkey.pem`, `chain.pem`, or any other certificate/private-key material to this repository.
 
+The `tournaments.example.com` and `admin@example.com` values below are placeholders only. Replace them with a real public DNS name that points at your server and a real contact email address before enabling TLS; `./start-server.sh` stops early with a clear error if those reserved example values are still configured.
+
 Example `config.yaml` options:
 
 ```yaml
@@ -35,9 +37,12 @@ tls_domain: tournaments.example.com
 letsencrypt_email: admin@example.com
 # Optional overrides:
 # letsencrypt_renewal_days: 30
+# letsencrypt_dry_run: false
 # tls_cert_dir: /etc/letsencrypt/live/tournaments.example.com
 # acme_webroot: /var/www/letsencrypt
 ```
+
+To test the ACME/HTTP-01 validation flow without creating or replacing certificate files, set `letsencrypt_dry_run: true` in `config.yaml`. Dry-run mode still requires a real public DNS name that points at the server, installs the temporary HTTP Nginx config needed for validation, runs Certbot with `--dry-run`, and then skips installing the TLS Nginx config because Certbot does not write live certificate files during a dry run.
 
 You can still manage the Nginx config manually:
 

--- a/config.yaml
+++ b/config.yaml
@@ -12,4 +12,5 @@ last_table_number: 200
 # tls_domain: tournaments.example.com
 # letsencrypt_email: admin@example.com
 # letsencrypt_renewal_days: 30
+# letsencrypt_dry_run: false
 # acme_webroot: /var/www/letsencrypt

--- a/start-server.sh
+++ b/start-server.sh
@@ -139,6 +139,46 @@ cert_expires_within() {
   ! openssl x509 -checkend "$seconds" -noout -in "$cert_file" >/dev/null 2>&1
 }
 
+is_truthy() {
+  local value="${1,,}"
+  case "$value" in
+    1|true|yes|y|on)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+validate_letsencrypt_settings() {
+  local domain_lower email_lower email_domain
+  domain_lower="${TLS_DOMAIN,,}"
+
+  case "$domain_lower" in
+    example.com|*.example.com|example.net|*.example.net|example.org|*.example.org|localhost|*.localhost|*.test|*.invalid)
+      echo "tls_domain is set to a reserved/example name ($TLS_DOMAIN). Set tls_domain in config.yaml to your real public DNS name before requesting a Let's Encrypt certificate." >&2
+      exit 1
+      ;;
+  esac
+
+  if [[ -n "${LETSENCRYPT_EMAIL:-}" ]]; then
+    email_lower="${LETSENCRYPT_EMAIL,,}"
+    email_domain="${email_lower##*@}"
+    if [[ "$email_lower" != *@* || -z "$email_domain" || "$email_domain" == "$email_lower" ]]; then
+      echo "letsencrypt_email must be a valid email address, not: $LETSENCRYPT_EMAIL" >&2
+      exit 1
+    fi
+
+    case "$email_domain" in
+      example.com|*.example.com|example.net|*.example.net|example.org|*.example.org|localhost|*.localhost|*.test|*.invalid)
+        echo "letsencrypt_email uses a reserved/example domain ($LETSENCRYPT_EMAIL). Set letsencrypt_email in config.yaml to a real email address, or leave it blank to request without email." >&2
+        exit 1
+        ;;
+    esac
+  fi
+}
+
 ensure_letsencrypt_certificate() {
   if [[ "${OSTYPE:-}" != linux* ]]; then
     return 0
@@ -154,13 +194,20 @@ ensure_letsencrypt_certificate() {
     exit 1
   fi
 
+  validate_letsencrypt_settings
   install_certbot
 
   local cert_dir="${TLS_CERT_DIR:-/etc/letsencrypt/live/$TLS_DOMAIN}"
   local acme_webroot="${ACME_WEBROOT:-/var/www/letsencrypt}"
   local renewal_days="${LETSENCRYPT_RENEWAL_DAYS:-30}"
+  local dry_run=0
   local fullchain="$cert_dir/fullchain.pem"
   local certbot_args=(certonly --webroot -w "$acme_webroot" -d "$TLS_DOMAIN" --non-interactive --agree-tos --keep-until-expiring)
+
+  if is_truthy "${LETSENCRYPT_DRY_RUN:-false}"; then
+    dry_run=1
+    certbot_args+=(--dry-run)
+  fi
 
   if [[ -n "${LETSENCRYPT_EMAIL:-}" ]]; then
     certbot_args+=(--email "$LETSENCRYPT_EMAIL" --no-eff-email)
@@ -173,8 +220,10 @@ ensure_letsencrypt_certificate() {
     certbot_args+=(--server "$LETSENCRYPT_SERVER")
   fi
 
-  if cert_expires_within "$fullchain" "$renewal_days"; then
-    if [[ -f "$fullchain" ]]; then
+  if [[ "$dry_run" -eq 1 ]] || cert_expires_within "$fullchain" "$renewal_days"; then
+    if [[ "$dry_run" -eq 1 ]]; then
+      echo "Running Let's Encrypt dry run for $TLS_DOMAIN; no certificate files will be created or replaced."
+    elif [[ -f "$fullchain" ]]; then
       echo "Let's Encrypt certificate for $TLS_DOMAIN expires within $renewal_days days; requesting a replacement."
       certbot_args+=(--force-renewal)
     else
@@ -189,6 +238,11 @@ ensure_letsencrypt_certificate() {
     run_as_root certbot "${certbot_args[@]}"
   else
     echo "Let's Encrypt certificate for $TLS_DOMAIN is present and valid for more than $renewal_days days."
+  fi
+
+  if [[ "$dry_run" -eq 1 ]]; then
+    echo "Skipping TLS Nginx config install because letsencrypt_dry_run does not create or renew certificate files."
+    return 0
   fi
 
   echo "Installing TLS Nginx config for $TLS_DOMAIN..."
@@ -305,6 +359,7 @@ keys = [
     'tls_cert_dir',
     'letsencrypt_email',
     'letsencrypt_renewal_days',
+    'letsencrypt_dry_run',
     'letsencrypt_server',
     'acme_webroot',
 ]
@@ -332,6 +387,7 @@ TLS_DOMAIN="${TLS_DOMAIN:-}"
 TLS_CERT_DIR="${TLS_CERT_DIR:-}"
 LETSENCRYPT_EMAIL="${LETSENCRYPT_EMAIL:-}"
 LETSENCRYPT_RENEWAL_DAYS="${LETSENCRYPT_RENEWAL_DAYS:-30}"
+LETSENCRYPT_DRY_RUN="${LETSENCRYPT_DRY_RUN:-false}"
 LETSENCRYPT_SERVER="${LETSENCRYPT_SERVER:-}"
 ACME_WEBROOT="${ACME_WEBROOT:-/var/www/letsencrypt}"
 


### PR DESCRIPTION
### Motivation

- Improve TLS provisioning safety by adding a dry-run mode and preventing accidental use of example/reserved values for `tls_domain` and `letsencrypt_email`.
- Provide clear documentation in `README.md` and `config.yaml` for the dry-run option and placeholder values.

### Description

- Added `is_truthy()` helper and `validate_letsencrypt_settings()` to `start-server.sh` to parse boolean-like values and to reject reserved/example domain or email inputs for ACME operations.
- Implemented `letsencrypt_dry_run` support by adding `LETSENCRYPT_DRY_RUN` to the config loader and wiring dry-run behavior into `ensure_letsencrypt_certificate()` so Certbot runs with `--dry-run` and the TLS Nginx install is skipped after a dry run.
- Enhanced certificate renewal logic to run when dry-run is requested or when the certificate expires within the configured window, and added informative logging for dry-run and validation outcomes.
- Updated `README.md` and `config.yaml` with guidance about replacing placeholder `tournaments.example.com` / `admin@example.com` values and how to enable `letsencrypt_dry_run`; added example snippet showing `letsencrypt_dry_run: false`.

### Testing

- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ce75fa27483209c3ade5b90aa0386)

## Summary by Sourcery

Add support for Let's Encrypt dry-run mode and stricter validation of TLS configuration, and document these behaviors in the setup guides.

New Features:
- Introduce a configurable letsencrypt_dry_run option that runs Certbot in dry-run mode and skips installing the TLS Nginx configuration.
- Add validation of tls_domain and letsencrypt_email to prevent using reserved or example domains and invalid email addresses before requesting Let's Encrypt certificates.

Enhancements:
- Extend certificate renewal logic to consider dry-run requests and improve logging around certificate checks and ACME operations.

Documentation:
- Update README and example config.yaml with guidance on replacing placeholder TLS values and instructions for using letsencrypt_dry_run.