### PR TITLE
Render Nginx upstream from `config.yaml` and auto-install HTTP site when TLS not configured

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,17 +12,17 @@
 
 ## Nginx reverse proxy (Linux)
 
-This repository includes a sample Nginx reverse-proxy config for running the app behind Nginx on port 80. The config proxies traffic to Waitress at `127.0.0.1:5000`; update `nginx/walter.conf` if your `config.yaml` uses a different `flask_port` or if you want to set a real `server_name`.
+This repository includes a sample Nginx reverse-proxy config for running the app behind Nginx on port 80. The config proxies traffic to the Waitress address rendered from `flask_ip` and `flask_port` in `config.yaml`; update `nginx/walter.conf` only if you want to set a real `server_name`.
 
 1) Start the app with Waitress:
    - `./start-server.sh`
 
-2) Install and enable the Nginx site config:
+2) Install and enable the Nginx site config if you are not using `start-server.sh`:
    - `./scripts/install_nginx_config.sh`
 
-The installer copies the config to `/etc/nginx/sites-available` and enables it via `/etc/nginx/sites-enabled` on Debian/Ubuntu-style systems. On systems that use `/etc/nginx/conf.d`, it installs `walter.conf` there instead. It also disables the packaged default Nginx site so requests to the server IP show Walter instead of the "Welcome to nginx!" page. Use `./scripts/install_nginx_config.sh --help` to see options such as `--dry-run`, `--config`, `--site-name`, `--no-reload`, and `--keep-default-site`.
+On Linux, `start-server.sh` installs the HTTP Nginx site automatically when `tls_domain` is blank so other computers on the LAN can browse to `http://<server-lan-ip>/` without connecting directly to the Waitress port. The installer copies the config to `/etc/nginx/sites-available` and enables it via `/etc/nginx/sites-enabled` on Debian/Ubuntu-style systems. On systems that use `/etc/nginx/conf.d`, it installs `walter.conf` there instead. It also disables the packaged default Nginx site so requests to the server IP show Walter instead of the "Welcome to nginx!" page. Use `./scripts/install_nginx_config.sh --help` to see options such as `--dry-run`, `--config`, `--site-name`, `--no-reload`, and `--keep-default-site`.
 
-If you still see the default Nginx welcome page after installing, re-run `./scripts/install_nginx_config.sh` and confirm that Nginx reloaded successfully. If you see a `502 Bad Gateway` page instead, make sure the Waitress host and port in `config.yaml` match the upstream address in `nginx/walter.conf`; the included config expects Waitress at `127.0.0.1:5000`.
+If LAN clients still cannot reach the app, browse to the server's LAN address on port 80 (for example, `http://192.168.1.25/`) and make sure host firewall rules allow inbound HTTP. If you see the default Nginx welcome page after installing, re-run `./scripts/install_nginx_config.sh` and confirm that Nginx reloaded successfully. If you see a `502 Bad Gateway` page instead, make sure the Waitress host and port in `config.yaml` match the upstream address in `nginx/walter.conf`; the rendered config expects Waitress at the `flask_ip` and `flask_port` values from `config.yaml`.
 
 ### HTTPS with TLS 1.3 and Let's Encrypt
 

--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ admin_email: admin@example.com
 admin_pass: admin123
 flask_secret: dev-secret-change-me
 password_seed: dev-password-seed-change-me
-flask_ip: 127.0.0.1
+flask_ip: 192.168.1.7
 flask_port: 5000
 last_table_number: 200
 # Optional production HTTPS settings. When tls_domain is set, start-server.sh

--- a/nginx/walter-tls.conf
+++ b/nginx/walter-tls.conf
@@ -1,11 +1,12 @@
 # Nginx reverse proxy for the Walter Flask/Waitress application with HTTPS.
 #
 # This file is a template used by scripts/install_nginx_config.sh --tls-domain.
-# The installer replaces __WALTER_DOMAIN__, __WALTER_CERT_DIR__, and
-# __WALTER_ACME_WEBROOT__. Do not commit certificate material to this repo.
+# The installer replaces __WALTER_DOMAIN__, __WALTER_CERT_DIR__,
+# __WALTER_ACME_WEBROOT__, __WALTER_FLASK_IP__, and
+# __WALTER_FLASK_PORT__. Do not commit certificate material to this repo.
 
 upstream walter_app {
-    server 127.0.0.1:5000;
+    server __WALTER_FLASK_IP__:__WALTER_FLASK_PORT__;
     keepalive 16;
 }
 

--- a/nginx/walter.conf
+++ b/nginx/walter.conf
@@ -1,19 +1,22 @@
 # Nginx reverse proxy for the Walter Flask/Waitress application.
 #
 # The application is expected to be running locally with start-server.sh.
-# If your config.yaml uses a different flask_port, update the port below.
+# The upstream address is rendered from flask_ip and flask_port in config.yaml.
 # For production HTTPS with TLS 1.3, FIPS-approved cipher suites, and
 # Let's Encrypt certificates, install nginx/walter-tls.conf via
 # scripts/install_nginx_config.sh --tls-domain your.domain.example.
 
 upstream walter_app {
-    server 127.0.0.1:5000;
+    server __WALTER_FLASK_IP__:__WALTER_FLASK_PORT__;
     keepalive 16;
 }
 
 server {
-    listen 80;
-    listen [::]:80;
+    # Bind as the default HTTP vhost on all IPv4/IPv6 interfaces so requests
+    # sent to the server's LAN IP reach Walter instead of any packaged
+    # default site.
+    listen 80 default_server;
+    listen [::]:80 default_server;
 
     # Replace _ with your domain name when one is available, for example:
     # server_name tournaments.example.com;

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -6,6 +6,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEFAULT_CONFIG="$REPO_DIR/nginx/walter.conf"
 DEFAULT_TLS_CONFIG="$REPO_DIR/nginx/walter-tls.conf"
+DEFAULT_APP_CONFIG="$REPO_DIR/config.yaml"
 
 CONFIG_FILE="$DEFAULT_CONFIG"
 SITE_NAME="walter"
@@ -15,6 +16,9 @@ DISABLE_DEFAULT_SITE=1
 TLS_DOMAIN=""
 CERT_DIR=""
 ACME_WEBROOT="/var/www/letsencrypt"
+APP_CONFIG="$DEFAULT_APP_CONFIG"
+FLASK_IP="127.0.0.1"
+FLASK_PORT="5000"
 GENERATED_CONFIG=""
 CONFIG_EXPLICIT=0
 
@@ -32,6 +36,7 @@ Options:
       --cert-dir PATH    Let's Encrypt live cert directory (default: /etc/letsencrypt/live/NAME)
       --acme-webroot PATH
                         Webroot for HTTP-01 challenges (default: $ACME_WEBROOT)
+      --app-config PATH Config file to read flask_ip/flask_port from (default: $DEFAULT_APP_CONFIG)
   -n, --site-name NAME  Installed site name (default: $SITE_NAME)
       --dry-run         Print actions without changing files
       --no-reload       Do not validate or reload Nginx after installing
@@ -111,6 +116,15 @@ while [[ $# -gt 0 ]]; do
       ACME_WEBROOT="$2"
       shift 2
       ;;
+    --app-config)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log "Missing value for $1" >&2
+        usage >&2
+        exit 1
+      fi
+      APP_CONFIG="$2"
+      shift 2
+      ;;
     --dry-run)
       DRY_RUN=1
       shift
@@ -176,22 +190,69 @@ if [[ ! -d /etc/nginx && "$DRY_RUN" -ne 1 ]]; then
 fi
 
 
+read_config_value() {
+  local key="$1"
+  local file="$2"
+
+  awk -v key="$key" '
+    $0 ~ "^[[:space:]]*" key "[[:space:]]*:" {
+      sub("^[[:space:]]*" key "[[:space:]]*:[[:space:]]*", "")
+      sub("[[:space:]]+#.*$", "")
+      sub("^[[:space:]]+", "")
+      sub("[[:space:]]+$", "")
+      if (($0 ~ /^".*"$/) || ($0 ~ /^'"'"'.*'"'"'$/)) {
+        print substr($0, 2, length($0) - 2)
+      } else {
+        print
+      }
+      exit
+    }
+  ' "$file"
+}
+
+load_app_config() {
+  if [[ ! -f "$APP_CONFIG" ]]; then
+    log "Application config not found: $APP_CONFIG" >&2
+    exit 1
+  fi
+
+  local configured_ip configured_port
+  configured_ip="$(read_config_value flask_ip "$APP_CONFIG")"
+  configured_port="$(read_config_value flask_port "$APP_CONFIG")"
+
+  FLASK_IP="${configured_ip:-$FLASK_IP}"
+  FLASK_PORT="${configured_port:-$FLASK_PORT}"
+
+  if [[ -z "$FLASK_IP" || "$FLASK_IP" == *[[:space:]]* || "$FLASK_IP" == *"/"* ]]; then
+    log "flask_ip in $APP_CONFIG must be a single IP address or hostname, not: $FLASK_IP" >&2
+    exit 1
+  fi
+
+  if [[ ! "$FLASK_PORT" =~ ^[0-9]+$ || "$FLASK_PORT" -lt 1 || "$FLASK_PORT" -gt 65535 ]]; then
+    log "flask_port in $APP_CONFIG must be a TCP port from 1 to 65535, not: $FLASK_PORT" >&2
+    exit 1
+  fi
+}
 
 escape_sed_replacement() {
   printf '%s' "$1" | sed -e 's/[\/&]/\\&/g'
 }
 
 render_config() {
-  local escaped_domain escaped_cert_dir escaped_acme_webroot
+  local escaped_domain escaped_cert_dir escaped_acme_webroot escaped_flask_ip escaped_flask_port
   escaped_domain="$(escape_sed_replacement "$TLS_DOMAIN")"
   escaped_cert_dir="$(escape_sed_replacement "$CERT_DIR")"
   escaped_acme_webroot="$(escape_sed_replacement "$ACME_WEBROOT")"
+  escaped_flask_ip="$(escape_sed_replacement "$FLASK_IP")"
+  escaped_flask_port="$(escape_sed_replacement "$FLASK_PORT")"
 
   GENERATED_CONFIG="$(mktemp)"
   sed \
     -e "s/__WALTER_DOMAIN__/$escaped_domain/g" \
     -e "s/__WALTER_CERT_DIR__/$escaped_cert_dir/g" \
     -e "s/__WALTER_ACME_WEBROOT__/$escaped_acme_webroot/g" \
+    -e "s/__WALTER_FLASK_IP__/$escaped_flask_ip/g" \
+    -e "s/__WALTER_FLASK_PORT__/$escaped_flask_port/g" \
     "$CONFIG_FILE" > "$GENERATED_CONFIG"
   CONFIG_FILE="$GENERATED_CONFIG"
 }
@@ -225,6 +286,7 @@ disable_packaged_default_site() {
   fi
 }
 
+load_app_config
 render_config
 
 if [[ -n "$TLS_DOMAIN" ]]; then

--- a/start-server.sh
+++ b/start-server.sh
@@ -179,13 +179,23 @@ validate_letsencrypt_settings() {
   fi
 }
 
+install_http_nginx_config() {
+  if [[ "${OSTYPE:-}" != linux* ]]; then
+    return 0
+  fi
+
+  echo "No tls_domain configured; installing HTTP Nginx config for LAN access."
+  "$NGINX_INSTALL_SCRIPT" --acme-webroot "${ACME_WEBROOT:-/var/www/letsencrypt}" --app-config "$CONFIG_FILE"
+  ensure_nginx_running
+}
+
 ensure_letsencrypt_certificate() {
   if [[ "${OSTYPE:-}" != linux* ]]; then
     return 0
   fi
 
   if [[ -z "${TLS_DOMAIN:-}" ]]; then
-    echo "No tls_domain configured; skipping Let's Encrypt certificate check."
+    install_http_nginx_config
     return 0
   fi
 
@@ -232,7 +242,7 @@ ensure_letsencrypt_certificate() {
 
     echo "Installing HTTP Nginx config so Let's Encrypt can validate $TLS_DOMAIN..."
     run_as_root mkdir -p "$acme_webroot/.well-known/acme-challenge"
-    "$NGINX_INSTALL_SCRIPT" --acme-webroot "$acme_webroot"
+    "$NGINX_INSTALL_SCRIPT" --acme-webroot "$acme_webroot" --app-config "$CONFIG_FILE"
     ensure_nginx_running
 
     run_as_root certbot "${certbot_args[@]}"
@@ -246,7 +256,7 @@ ensure_letsencrypt_certificate() {
   fi
 
   echo "Installing TLS Nginx config for $TLS_DOMAIN..."
-  "$NGINX_INSTALL_SCRIPT" --tls-domain "$TLS_DOMAIN" --cert-dir "$cert_dir" --acme-webroot "$acme_webroot"
+  "$NGINX_INSTALL_SCRIPT" --tls-domain "$TLS_DOMAIN" --cert-dir "$cert_dir" --acme-webroot "$acme_webroot" --app-config "$CONFIG_FILE"
   ensure_nginx_running
 }
 


### PR DESCRIPTION
### Motivation

- Allow the Nginx configs and install script to use the application `flask_ip` and `flask_port` values from `config.yaml` instead of hard-coded `127.0.0.1:5000`. 
- Make the startup flow easier for LAN use by automatically installing the HTTP Nginx site when `tls_domain` is blank so other hosts can reach the app at the server LAN IP. 
- Add safe parsing/validation of the app config so install scripts produce correct, validated Nginx upstream addresses.

### Description

- Updated `nginx/walter.conf` and `nginx/walter-tls.conf` to replace hard-coded upstream addresses with `__WALTER_FLASK_IP__` and `__WALTER_FLASK_PORT__` placeholders. 
- Extended `scripts/install_nginx_config.sh` with a new `--app-config` option, defaulting to `config.yaml`, and added `read_config_value` and `load_app_config` functions to extract and validate `flask_ip` and `flask_port`; the script now renders those placeholders into the generated config. 
- Modified `start-server.sh` to call the installer with `--app-config` and to automatically install the HTTP Nginx config when `tls_domain` is empty via a new `install_http_nginx_config` step so the app is reachable on the LAN without TLS. 
- Documentation updates in `README.md` and a sample change in `config.yaml` to reflect the new behavior and defaults.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ceadb06348320b96e13e78dd2fb64)

## Summary by Sourcery

Render Nginx upstream configuration from application settings and streamline HTTP site installation for non-TLS deployments.

New Features:
- Allow Nginx configs to derive the upstream Flask/Waitress IP and port from config.yaml instead of hard-coded values.
- Automatically install the HTTP Nginx site on Linux when no tls_domain is configured so the app is reachable over LAN without TLS.

Enhancements:
- Add safe parsing and validation of flask_ip and flask_port in the Nginx install script and propagate these values into rendered configs.
- Update Nginx templates to use placeholders for upstream settings and make the HTTP vhost the default server on port 80.
- Pass the application config path through start-server.sh to the Nginx installer for both HTTP and TLS setups.

Documentation:
- Document the new Nginx behavior, automatic HTTP site installation, and config-driven upstream settings in README.md and config.yaml.