### PR TITLE
Add Mailgun-backed email verification and invite-only registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,20 @@ You can still manage the Nginx config manually:
 
 The TLS template lives at `nginx/walter-tls.conf`. It serves HTTPS on port 443, redirects normal HTTP traffic to HTTPS, leaves `/.well-known/acme-challenge/` available on port 80 for Let's Encrypt renewals, only enables TLS 1.3, and restricts TLS 1.3 cipher suites to the FIPS-suitable AES-GCM suites `TLS_AES_256_GCM_SHA384` and `TLS_AES_128_GCM_SHA256`. If your certificate lives somewhere other than `/etc/letsencrypt/live/<domain>`, pass `--cert-dir /path/to/live/certdir`; if your ACME challenge webroot differs, pass `--acme-webroot /path/to/webroot`.
 
+## Account verification and invites
+
+Public account registration sends a one-time 6-digit verification PIN through Mailgun before creating the user account. Set these values in `config.yaml` before enabling public self-service registration:
+
+```yaml
+mailgun_api_key: key-your-mailgun-api-key
+mailgun_domain: mg.example.com
+mailgun_from_email: Walter <noreply@example.com>
+registration_pin_ttl_minutes: 15
+account_creation_invite_only: false
+```
+
+When `account_creation_invite_only` is `true`, new users must register with a valid tournament invite/passcode.
+
 ## Features
    - Player & Admin login
    - Tournaments: Commander, Draft, Constructed

--- a/app/app.py
+++ b/app/app.py
@@ -33,6 +33,8 @@ import io
 import glob
 import secrets
 import csv
+import urllib.parse
+import urllib.request
 from collections import OrderedDict
 from urllib.parse import urlparse
 from sqlalchemy import inspect, text, or_
@@ -84,6 +86,11 @@ def create_app():
     app.config['CARD_DB_URL'] = os.environ.get('MTG_CARD_DB_URL', card_db.ATOMIC_CARDS_URL)
     app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
     app.config['SECRET_KEY'] = os.environ.get('FLASK_SECRET', 'dev-secret-change-me')
+    app.config['MAILGUN_API_KEY'] = os.environ.get('MAILGUN_API_KEY', '')
+    app.config['MAILGUN_DOMAIN'] = os.environ.get('MAILGUN_DOMAIN', '')
+    app.config['MAILGUN_FROM_EMAIL'] = os.environ.get('MAILGUN_FROM_EMAIL', '')
+    app.config['ACCOUNT_CREATION_INVITE_ONLY'] = os.environ.get('ACCOUNT_CREATION_INVITE_ONLY', '').strip().lower() in {'1', 'true', 'yes', 'on'}
+    app.config['REGISTRATION_PIN_TTL_MINUTES'] = int(os.environ.get('REGISTRATION_PIN_TTL_MINUTES', '15'))
 
     last_table_env = os.environ.get('MTG_LAST_TABLE_NUMBER', '').strip()
     if last_table_env:
@@ -190,7 +197,7 @@ def create_app():
                     {'level': level, 'name': role_name},
                 )
             db.session.commit()
-        from .models import Report, TournamentJoinRequest  # lazy import to avoid circular reference
+        from .models import Report, TournamentJoinRequest, PendingRegistration  # lazy import to avoid circular reference
 
         if 'report' not in inspector.get_table_names():
             Report.__table__.create(bind=db.engine)
@@ -207,6 +214,7 @@ def create_app():
                 db.session.execute(text('ALTER TABLE report ADD COLUMN actions_taken TEXT'))
                 db.session.commit()
         TournamentJoinRequest.__table__.create(bind=db.engine, checkfirst=True)
+        PendingRegistration.__table__.create(bind=db.engine, checkfirst=True)
         from .models import LostFoundItem, TournamentPlayerDeck, League, LeaguePlayer, LeagueResult
 
         League.__table__.create(bind=db.engine, checkfirst=True)
@@ -242,6 +250,7 @@ def create_app():
         Message,
         Report,
         TournamentJoinRequest,
+        PendingRegistration,
         LostFoundItem,
         League,
         LeaguePlayer,
@@ -398,17 +407,52 @@ def create_app():
         return render_template('index.html', tournaments=visible_tournaments, player_counts=player_counts,
                                server_now=datetime.utcnow())
 
+    def _send_mailgun_email(to_email, subject, text):
+        api_key = app.config.get('MAILGUN_API_KEY')
+        domain = app.config.get('MAILGUN_DOMAIN')
+        from_email = app.config.get('MAILGUN_FROM_EMAIL') or (f"Walter <mailgun@{domain}>" if domain else '')
+        if not api_key or not domain or not from_email:
+            raise RuntimeError('Mailgun is not configured. Set mailgun_api_key, mailgun_domain, and mailgun_from_email in config.yaml.')
+        data = urllib.parse.urlencode({
+            'from': from_email,
+            'to': to_email,
+            'subject': subject,
+            'text': text,
+        }).encode()
+        request_obj = urllib.request.Request(
+            f'https://api.mailgun.net/v3/{domain}/messages',
+            data=data,
+            headers={
+                'Authorization': 'Basic ' + base64.b64encode(f'api:{api_key}'.encode()).decode(),
+                'Content-Type': 'application/x-www-form-urlencoded',
+            },
+            method='POST',
+        )
+        with urllib.request.urlopen(request_obj, timeout=10) as response:
+            if response.status >= 400:
+                raise RuntimeError(f'Mailgun returned HTTP {response.status}')
+
+    def _send_registration_pin(email, pin):
+        _send_mailgun_email(
+            email,
+            'Your Walter verification PIN',
+            f'Use this one-time PIN to verify your Walter account: {pin}\n\nThis PIN expires in {app.config.get("REGISTRATION_PIN_TTL_MINUTES", 15)} minutes.',
+        )
+
     @app.route('/register', methods=['GET','POST'])
     def register():
-        from .models import User, Tournament, TournamentPlayer, Role
+        from .models import User, Tournament, TournamentPlayer, Role, PendingRegistration
         tournaments = db.session.query(Tournament).order_by(Tournament.created_at.desc()).all()
         prefill_tournament_id = request.args.get('tournament_id', '').strip()
         prefill_passcode = request.args.get('passcode', '').strip()
+        invite_only = app.config.get('ACCOUNT_CREATION_INVITE_ONLY', False)
         if request.method == 'POST':
             email = request.form['email'].strip().lower()
             name = request.form['name'].strip()
             password = request.form['password']
             confirm = request.form.get('password_confirm', '')
+            tournament_id = request.form.get('tournament_id')
+            tournament_passcode = request.form.get('passcode', '').strip()
             if password != confirm:
                 flash("Passwords do not match", "error")
                 log_site('register', 'failure', 'password mismatch')
@@ -417,31 +461,114 @@ def create_app():
                 flash("Email already registered", "error")
                 log_site('register', 'failure', 'email exists')
                 return redirect(url_for('register'))
-            role_user = db.session.query(Role).filter_by(name='user').first()
-            u = User(email=email, name=name, role=role_user)
-            u.set_password(password)
-            u.generate_keys(password)
-            db.session.add(u)
-            db.session.commit()
-            log_site('register', 'success')
-            tournament_id = request.form.get('tournament_id')
+
+            selected_tournament = None
             if tournament_id:
-                t = db.session.get(Tournament, int(tournament_id))
-                code = request.form.get('passcode', '')
-                if not t or code != t.passcode:
+                try:
+                    selected_tournament = db.session.get(Tournament, int(tournament_id))
+                except (TypeError, ValueError):
+                    selected_tournament = None
+                if not selected_tournament or tournament_passcode != selected_tournament.passcode:
                     flash("Invalid tournament passcode", "error")
+                    log_site('register', 'failure', 'invalid tournament passcode')
                     return redirect(url_for('register'))
-                tp = TournamentPlayer(tournament_id=int(tournament_id), user_id=u.id)
-                db.session.add(tp)
-                db.session.commit()
-            flash("Registered. Please login.", "success")
-            return redirect(url_for('login', next=request.args.get('next')))
+            elif invite_only:
+                flash("Account creation is invite only. Use a tournament invite link or passcode to register.", "error")
+                log_site('register', 'failure', 'invite required')
+                return redirect(url_for('register'))
+
+            db.session.query(PendingRegistration).filter(PendingRegistration.expires_at < datetime.now(timezone.utc).replace(tzinfo=None)).delete()
+            existing_pending = db.session.query(PendingRegistration).filter_by(email=email).first()
+            if existing_pending:
+                db.session.delete(existing_pending)
+                db.session.flush()
+            pin = PendingRegistration.generate_pin()
+            pending = PendingRegistration(
+                email=email,
+                name=name,
+                verification_pin=pin,
+                tournament_id=selected_tournament.id if selected_tournament else None,
+                tournament_passcode=tournament_passcode if selected_tournament else None,
+                expires_at=datetime.now(timezone.utc).replace(tzinfo=None) + timedelta(minutes=app.config.get('REGISTRATION_PIN_TTL_MINUTES', 15)),
+            )
+            pending.set_password(password)
+            db.session.add(pending)
+            try:
+                _send_registration_pin(email, pin)
+            except Exception as exc:
+                db.session.rollback()
+                app.logger.warning('Unable to send registration PIN via Mailgun: %s', exc)
+                flash("We could not send your verification email. Please contact an administrator.", "error")
+                log_site('register', 'failure', 'mailgun send failed')
+                return redirect(url_for('register'))
+            db.session.commit()
+            log_site('register', 'pin_sent')
+            flash("Check your email for a 6-digit verification PIN to finish creating your account.", "success")
+            return redirect(url_for('verify_registration', email=email, next=request.args.get('next')))
         return render_template(
             'register.html',
             tournaments=tournaments,
             prefill_tournament_id=prefill_tournament_id,
             prefill_passcode=prefill_passcode,
+            invite_only=invite_only,
         )
+
+    @app.route('/register/verify', methods=['GET', 'POST'])
+    def verify_registration():
+        from .models import User, Tournament, TournamentPlayer, Role, PendingRegistration
+        email = (request.values.get('email') or '').strip().lower()
+        if request.method == 'POST':
+            email = request.form['email'].strip().lower()
+            pin = request.form.get('pin', '').strip()
+            password = request.form.get('password', '')
+            pending = db.session.query(PendingRegistration).filter_by(email=email).first()
+            if not pending or pending.expires_at < datetime.now(timezone.utc).replace(tzinfo=None):
+                if pending:
+                    db.session.delete(pending)
+                    db.session.commit()
+                flash("Verification PIN expired or was not found. Please register again.", "error")
+                log_site('register_verify', 'failure', 'missing or expired pin')
+                return redirect(url_for('register'))
+            if pending.verification_pin != pin or not pending.check_password(password):
+                flash("Invalid PIN or password.", "error")
+                log_site('register_verify', 'failure', 'invalid pin or password')
+                return redirect(url_for('verify_registration', email=email))
+            if db.session.query(User).filter_by(email=email).first():
+                db.session.delete(pending)
+                db.session.commit()
+                flash("Email already registered. Please login.", "error")
+                log_site('register_verify', 'failure', 'email exists')
+                return redirect(url_for('login'))
+
+            selected_tournament = None
+            if pending.tournament_id:
+                selected_tournament = db.session.get(Tournament, pending.tournament_id)
+                if not selected_tournament or pending.tournament_passcode != selected_tournament.passcode:
+                    db.session.delete(pending)
+                    db.session.commit()
+                    flash("Tournament invite expired or is no longer valid. Please register again.", "error")
+                    log_site('register_verify', 'failure', 'invalid pending tournament')
+                    return redirect(url_for('register'))
+
+            role_user = db.session.query(Role).filter_by(name='user').first()
+            u = User(email=email, name=pending.name, role=role_user)
+            u.set_password(password)
+            u.generate_keys(password)
+            db.session.add(u)
+            db.session.flush()
+            if selected_tournament:
+                already_joined = db.session.query(TournamentPlayer).filter_by(
+                    tournament_id=selected_tournament.id,
+                    user_id=u.id,
+                ).first()
+                if not already_joined:
+                    db.session.add(TournamentPlayer(tournament_id=selected_tournament.id, user_id=u.id))
+            db.session.delete(pending)
+            db.session.commit()
+            log_site('register_verify', 'success')
+            flash("Email verified and account created. Please login.", "success")
+            return redirect(url_for('login', next=request.args.get('next')))
+        return render_template('verify_registration.html', email=email)
 
     @app.route('/login', methods=['GET','POST'])
     def login():

--- a/app/models.py
+++ b/app/models.py
@@ -7,6 +7,7 @@ import os
 import random
 import hashlib
 import json
+import secrets
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -171,6 +172,32 @@ class User(db.Model, UserMixin):
         if not self.role:
             return False
         return self.role.permissions_dict().get(key, False)
+
+
+class PendingRegistration(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), unique=True, nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    password_hash = db.Column(db.Text, nullable=False)
+    salt = db.Column(db.String(32), nullable=False)
+    verification_pin = db.Column(db.String(6), nullable=False)
+    tournament_id = db.Column(db.Integer, db.ForeignKey('tournament.id'), nullable=True)
+    tournament_passcode = db.Column(db.String(4), nullable=True)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    expires_at = db.Column(db.DateTime, nullable=False)
+
+    tournament = db.relationship('Tournament')
+
+    def set_password(self, pw):
+        self.salt = os.urandom(16).hex()
+        self.password_hash = hashlib.sha256((self.salt + pw).encode()).hexdigest()
+
+    def check_password(self, pw):
+        return self.password_hash == hashlib.sha256((self.salt + pw).encode()).hexdigest()
+
+    @staticmethod
+    def generate_pin():
+        return f"{secrets.randbelow(1000000):06d}"
 
 
 class Message(db.Model):

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -2,7 +2,10 @@
 {% block content %}
 <section class="auth-card">
   <h2 class="auth-card__title">Create your account</h2>
-  <p class="auth-card__subtitle">Register once to manage decks, join tournaments, and stay connected with staff.</p>
+  <p class="auth-card__subtitle">Register once to manage decks, join tournaments, and stay connected with staff. We will email you a one-time 6-digit PIN to verify your account.</p>
+  {% if invite_only %}
+  <p class="auth-card__subtitle">Account creation is currently invite only. Select your invited tournament and enter its passcode to continue.</p>
+  {% endif %}
   <form method="post" class="form-stacked">
     <div class="form-field">
       <label for="name">Name</label>

--- a/app/templates/verify_registration.html
+++ b/app/templates/verify_registration.html
@@ -1,0 +1,24 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="auth-card">
+  <h2 class="auth-card__title">Verify your email</h2>
+  <p class="auth-card__subtitle">Enter the 6-digit one-time PIN sent to your email address to finish creating your account.</p>
+  <form method="post" class="form-stacked">
+    <div class="form-field">
+      <label for="email">Email</label>
+      <input id="email" name="email" type="email" value="{{ email }}" required>
+    </div>
+    <div class="form-field">
+      <label for="pin">Verification PIN</label>
+      <input id="pin" name="pin" inputmode="numeric" pattern="[0-9]{6}" maxlength="6" autocomplete="one-time-code" required>
+    </div>
+    <div class="form-field">
+      <label for="password">Password</label>
+      <input id="password" name="password" type="password" autocomplete="current-password" required>
+    </div>
+    <div class="form-actions">
+      <button class="btn" type="submit">Verify Email</button>
+    </div>
+  </form>
+</section>
+{% endblock %}

--- a/config.yaml
+++ b/config.yaml
@@ -14,3 +14,11 @@ last_table_number: 200
 # letsencrypt_renewal_days: 30
 # letsencrypt_dry_run: false
 # acme_webroot: /var/www/letsencrypt
+
+# Mailgun settings for account verification email.
+# mailgun_api_key: key-your-mailgun-api-key
+# mailgun_domain: mg.example.com
+# mailgun_from_email: Walter <noreply@example.com>
+# registration_pin_ttl_minutes: 15
+# When true, public registration requires a valid tournament invite/passcode.
+account_creation_invite_only: false

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -53,6 +53,11 @@ $FlaskSecret = $cfg.flask_secret
 $PasswordSeed = $cfg.password_seed
 $FlaskIP = $cfg.flask_ip
 $FlaskPort = $cfg.flask_port
+$MailgunApiKey = $cfg.mailgun_api_key
+$MailgunDomain = $cfg.mailgun_domain
+$MailgunFromEmail = $cfg.mailgun_from_email
+$RegistrationPinTtlMinutes = $cfg.registration_pin_ttl_minutes
+$AccountCreationInviteOnly = $cfg.account_creation_invite_only
 $newadmin = New-Object System.Management.Automation.PSCredential($cfg.admin_email, (ConvertTo-SecureString $cfg.admin_pass -AsPlainText -Force))
 
 ######enable testing###########
@@ -65,6 +70,8 @@ if([string]::IsNullOrEmpty($FlaskSecret)){ $FlaskSecret = "dev-secret-change-me"
 if([string]::IsNullOrEmpty($PasswordSeed)){ $PasswordSeed = "dev-password-seed-change-me" }
 if([string]::IsNullOrEmpty($FlaskIP)){ $FlaskIP = "127.0.0.1" }
 if([string]::IsNullOrEmpty($FlaskPort)){ $FlaskPort = 5000 }
+if([string]::IsNullOrEmpty($RegistrationPinTtlMinutes)){ $RegistrationPinTtlMinutes = 15 }
+if($null -eq $AccountCreationInviteOnly){ $AccountCreationInviteOnly = $false }
 
 #check if Flask/Waitress is already running and stop it if necessary
 $flaskpid = try{
@@ -91,6 +98,11 @@ $env:FLASK_SECRET = $FlaskSecret
 
 $env:FLASK_RUN_HOST = $FlaskIP
 $env:FLASK_RUN_PORT = $FlaskPort
+$env:MAILGUN_API_KEY = $MailgunApiKey
+$env:MAILGUN_DOMAIN = $MailgunDomain
+$env:MAILGUN_FROM_EMAIL = $MailgunFromEmail
+$env:REGISTRATION_PIN_TTL_MINUTES = $RegistrationPinTtlMinutes
+$env:ACCOUNT_CREATION_INVITE_ONLY = $AccountCreationInviteOnly
 
 $timestamp = Get-Date -Format "yyyyMMddHHmmss"
 

--- a/start-server.sh
+++ b/start-server.sh
@@ -372,6 +372,11 @@ keys = [
     'letsencrypt_dry_run',
     'letsencrypt_server',
     'acme_webroot',
+    'mailgun_api_key',
+    'mailgun_domain',
+    'mailgun_from_email',
+    'registration_pin_ttl_minutes',
+    'account_creation_invite_only',
 ]
 
 for key in keys:
@@ -400,6 +405,11 @@ LETSENCRYPT_RENEWAL_DAYS="${LETSENCRYPT_RENEWAL_DAYS:-30}"
 LETSENCRYPT_DRY_RUN="${LETSENCRYPT_DRY_RUN:-false}"
 LETSENCRYPT_SERVER="${LETSENCRYPT_SERVER:-}"
 ACME_WEBROOT="${ACME_WEBROOT:-/var/www/letsencrypt}"
+MAILGUN_API_KEY="${MAILGUN_API_KEY:-}"
+MAILGUN_DOMAIN="${MAILGUN_DOMAIN:-}"
+MAILGUN_FROM_EMAIL="${MAILGUN_FROM_EMAIL:-}"
+REGISTRATION_PIN_TTL_MINUTES="${REGISTRATION_PIN_TTL_MINUTES:-15}"
+ACCOUNT_CREATION_INVITE_ONLY="${ACCOUNT_CREATION_INVITE_ONLY:-false}"
 
 cd "$SCRIPT_DIR"
 
@@ -408,6 +418,11 @@ export PASSWORD_SEED
 export FLASK_SECRET
 export FLASK_RUN_HOST="$FLASK_IP"
 export FLASK_RUN_PORT="$FLASK_PORT"
+export MAILGUN_API_KEY
+export MAILGUN_DOMAIN
+export MAILGUN_FROM_EMAIL
+export REGISTRATION_PIN_TTL_MINUTES
+export ACCOUNT_CREATION_INVITE_ONLY
 
 ensure_letsencrypt_certificate
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -93,3 +93,103 @@ def test_admin_bulk_delete_users(client, session):
     assert session.get(User, user_one.id) is None
     assert session.get(User, user_two.id) is None
     assert session.get(User, admin.id) is not None
+
+
+def test_registration_sends_mailgun_pin_and_requires_verification(client, session, app, monkeypatch):
+    from app.models import PendingRegistration
+
+    app.config['MAILGUN_API_KEY'] = 'key-test'
+    app.config['MAILGUN_DOMAIN'] = 'mg.example.com'
+    app.config['MAILGUN_FROM_EMAIL'] = 'Walter <noreply@example.com>'
+    sent = {}
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    def fake_urlopen(request_obj, timeout=10):
+        sent['url'] = request_obj.full_url
+        sent['body'] = request_obj.data.decode()
+        sent['auth'] = request_obj.headers.get('Authorization')
+        return FakeResponse()
+
+    monkeypatch.setattr('app.app.urllib.request.urlopen', fake_urlopen)
+
+    response = client.post('/register', data={
+        'email': 'new@example.com',
+        'name': 'New User',
+        'password': 'secret',
+        'password_confirm': 'secret',
+    })
+
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/register/verify?email=new@example.com')
+    pending = session.query(PendingRegistration).filter_by(email='new@example.com').one()
+    assert len(pending.verification_pin) == 6
+    assert sent['url'] == 'https://api.mailgun.net/v3/mg.example.com/messages'
+    assert 'new%40example.com' in sent['body']
+    assert pending.verification_pin in sent['body']
+    assert session.query(User).filter_by(email='new@example.com').first() is None
+
+    verify_response = client.post('/register/verify', data={
+        'email': 'new@example.com',
+        'pin': pending.verification_pin,
+        'password': 'secret',
+    })
+
+    assert verify_response.status_code == 302
+    created = session.query(User).filter_by(email='new@example.com').one()
+    assert created.check_password('secret')
+    assert session.query(PendingRegistration).filter_by(email='new@example.com').first() is None
+
+
+def test_invite_only_registration_requires_tournament_passcode(client, session, app, monkeypatch):
+    from app.models import Tournament
+
+    app.config['ACCOUNT_CREATION_INVITE_ONLY'] = True
+
+    response = client.post('/register', data={
+        'email': 'blocked@example.com',
+        'name': 'Blocked User',
+        'password': 'secret',
+        'password_confirm': 'secret',
+    })
+
+    assert response.status_code == 302
+    assert session.query(User).filter_by(email='blocked@example.com').first() is None
+
+    tournament = Tournament(name='Invite Event', format='Constructed', passcode='1234')
+    session.add(tournament)
+    session.commit()
+
+    app.config['MAILGUN_API_KEY'] = 'key-test'
+    app.config['MAILGUN_DOMAIN'] = 'mg.example.com'
+    app.config['MAILGUN_FROM_EMAIL'] = 'Walter <noreply@example.com>'
+
+    class FakeResponse:
+        status = 200
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr('app.app.urllib.request.urlopen', lambda request_obj, timeout=10: FakeResponse())
+
+    response = client.post('/register', data={
+        'email': 'invited@example.com',
+        'name': 'Invited User',
+        'password': 'secret',
+        'password_confirm': 'secret',
+        'tournament_id': str(tournament.id),
+        'passcode': '1234',
+    })
+
+    assert response.status_code == 302
+    assert response.headers['Location'].endswith('/register/verify?email=invited@example.com')


### PR DESCRIPTION
### Motivation
- Prevent immediate account creation without verifying email by introducing a one-time PIN verification step delivered via Mailgun.
- Support invite-only flows where public registration is disabled unless the requester provides a valid tournament invite/passcode.
- Keep unverified credentials out of the main `user` table while still allowing verification within a TTL window.

### Description
- Add `PendingRegistration` model to store hashed pending credentials, a one-time 6-digit `verification_pin`, optional `tournament_id` and `tournament_passcode`, and `expires_at` metadata in `app/models.py`.
- Wire Mailgun and registration options into the Flask app config (`MAILGUN_API_KEY`, `MAILGUN_DOMAIN`, `MAILGUN_FROM_EMAIL`, `ACCOUNT_CREATION_INVITE_ONLY`, `REGISTRATION_PIN_TTL_MINUTES`) and expose them via the `start-server.sh` / `start-server.ps1` startup scripts and `config.yaml` example.
- Implement Mailgun helpers `_send_mailgun_email` and `_send_registration_pin` plus replace the previous immediate `/register` behavior with a flow that creates a `PendingRegistration`, sends the PIN, and redirects to `/register/verify` in `app/app.py`.
- Add `/register/verify` route which validates the PIN and password, creates the actual `User`, optionally joins the invited `Tournament`, and removes the pending record after successful verification.
- Update templates to inform users about the PIN verification and add a `verify_registration.html` form; update README with configuration and feature notes.
- Add tests covering Mailgun PIN delivery, delayed account creation until verification, pending cleanup on successful verification, and invite-only enforcement under `tests/test_users.py`.

### Testing
- Added unit tests `test_registration_sends_mailgun_pin_and_requires_verification` and `test_invite_only_registration_requires_tournament_passcode` which mock `urllib.request.urlopen` to simulate Mailgun responses and exercise the new flows.
- Ran the full test suite with `pytest -q` and observed all tests passing: `41 passed` (with warnings) in CI-local run.
- Also ran `git diff --check` (no problems) and updated README and startup scripts to reflect new configuration options.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e14c8b648832084ce9e62a7cc4bbf)

## Summary by Sourcery

Introduce a Mailgun-backed, PIN-based email verification flow for user registration, with optional invite-only gating tied to tournament passcodes.

New Features:
- Add Mailgun integration and configuration for sending registration verification emails.
- Add a PendingRegistration model and /register/verify route to support PIN-based email verification before creating user accounts.
- Support invite-only account creation that requires a valid tournament invite/passcode during registration.

Enhancements:
- Update registration templates and README to describe the new verification and invite-only behavior.
- Extend startup scripts and config to surface Mailgun and registration-related settings as environment variables.

Tests:
- Add tests to ensure registration sends a Mailgun PIN, delays account creation until verification, and enforces invite-only registration with valid tournament passcodes.