### PR TITLE
Add restart-server scripts (sh + ps1) and README entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ This repository includes a sample Nginx reverse-proxy config for running the app
 2) Install and enable the Nginx site config if you are not using `start-server.sh`:
    - `./scripts/install_nginx_config.sh`
 
+After editing `config.yaml`, restart the app so the new settings are loaded:
+- Linux/macOS: `./restart-server.sh`
+- Windows PowerShell: `./restart-server.ps1`
+
 On Linux, `start-server.sh` installs the HTTP Nginx site automatically when `tls_domain` is blank so other computers on the LAN can browse to `http://<server-lan-ip>/` without connecting directly to the Waitress port. The installer copies the config to `/etc/nginx/sites-available` and enables it via `/etc/nginx/sites-enabled` on Debian/Ubuntu-style systems. On systems that use `/etc/nginx/conf.d`, it installs `walter.conf` there instead. It also disables the packaged default Nginx site so requests to the server IP show Walter instead of the "Welcome to nginx!" page. Use `./scripts/install_nginx_config.sh --help` to see options such as `--dry-run`, `--config`, `--site-name`, `--no-reload`, and `--keep-default-site`.
 
 If LAN clients still cannot reach the app, browse to the server's LAN address on port 80 (for example, `http://192.168.1.25/`) and make sure host firewall rules allow inbound HTTP. If you see the default Nginx welcome page after installing, re-run `./scripts/install_nginx_config.sh` and confirm that Nginx reloaded successfully. If you see a `502 Bad Gateway` page instead, make sure the Waitress host and port in `config.yaml` match the upstream address in `nginx/walter.conf`; the rendered config expects Waitress at the `flask_ip` and `flask_port` values from `config.yaml`.

--- a/restart-server.ps1
+++ b/restart-server.ps1
@@ -1,0 +1,27 @@
+# PowerShell script to restart the MTG Tournament Swiss App.
+# Stops the running server, then starts it again so config.yaml is reloaded.
+$ErrorActionPreference = "Stop"
+
+$configPath = Join-Path $PSScriptRoot "config.yaml"
+$stopScript = Join-Path $PSScriptRoot "stop-server.ps1"
+$startScript = Join-Path $PSScriptRoot "start-server.ps1"
+
+if (!(Test-Path $configPath)) {
+    Write-Error "Missing config.yaml"
+    exit 1
+}
+
+if (!(Test-Path $stopScript)) {
+    Write-Error "Missing stop-server.ps1"
+    exit 1
+}
+
+if (!(Test-Path $startScript)) {
+    Write-Error "Missing start-server.ps1"
+    exit 1
+}
+
+Write-Host "Restarting server to reload $configPath..."
+& $stopScript
+& $startScript
+Write-Host "Server restart complete; config.yaml has been reloaded."

--- a/restart-server.sh
+++ b/restart-server.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Bash script to restart the MTG Tournament Swiss App.
+# Stops the running server, then starts it again so config.yaml is reloaded.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STOP_SCRIPT="$SCRIPT_DIR/stop-server.sh"
+START_SCRIPT="$SCRIPT_DIR/start-server.sh"
+CONFIG_FILE="$SCRIPT_DIR/config.yaml"
+
+if [[ ! -f "$CONFIG_FILE" ]]; then
+  echo "Missing config.yaml" >&2
+  exit 1
+fi
+
+if [[ ! -x "$STOP_SCRIPT" ]]; then
+  echo "Missing or non-executable stop-server.sh" >&2
+  exit 1
+fi
+
+if [[ ! -x "$START_SCRIPT" ]]; then
+  echo "Missing or non-executable start-server.sh" >&2
+  exit 1
+fi
+
+printf 'Restarting server to reload %s...\n' "$CONFIG_FILE"
+"$STOP_SCRIPT"
+"$START_SCRIPT"
+printf 'Server restart complete; config.yaml has been reloaded.\n'


### PR DESCRIPTION
### Motivation
- Provide an easy, cross-platform way to restart the app so edits to `config.yaml` take effect without manual stop/start steps.
- Keep restart behavior consistent with existing `start-server`/`stop-server` scripts on both Linux/macOS and Windows PowerShell.

### Description
- Add `restart-server.sh`, a Bash script that validates `config.yaml` and the presence/executability of `stop-server.sh` and `start-server.sh`, then runs `stop-server.sh` followed by `start-server.sh` to reload the configuration.
- Add `restart-server.ps1`, the PowerShell equivalent that validates `config.yaml`, `stop-server.ps1`, and `start-server.ps1`, then invokes the stop and start scripts to reload the configuration.
- Update `README.md` to document the new restart commands for Linux/macOS (`./restart-server.sh`) and Windows PowerShell (`./restart-server.ps1`).

### Testing
- Ran shell syntax check `bash -n restart-server.sh`, which succeeded.
- Attempted to parse the PowerShell script with `pwsh` but `pwsh` was not installed in the environment, so PowerShell syntax validation was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e2520c9208320b08d79f48fe524de)

## Summary by Sourcery

Add cross-platform helper scripts to restart the server so configuration changes in config.yaml take effect and document their usage in the README.

New Features:
- Introduce restart-server.sh to stop and start the server on Linux/macOS using existing start/stop scripts.
- Introduce restart-server.ps1 to stop and start the server on Windows PowerShell using existing start/stop scripts.

Documentation:
- Document the new restart commands for Linux/macOS and Windows PowerShell in the README.