### PR TITLE
Add account lockout, login auditing, IP blacklist, and password reset controls

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -91,6 +91,9 @@ def create_app():
     app.config['MAILGUN_FROM_EMAIL'] = os.environ.get('MAILGUN_FROM_EMAIL', '')
     app.config['ACCOUNT_CREATION_INVITE_ONLY'] = os.environ.get('ACCOUNT_CREATION_INVITE_ONLY', '').strip().lower() in {'1', 'true', 'yes', 'on'}
     app.config['REGISTRATION_PIN_TTL_MINUTES'] = int(os.environ.get('REGISTRATION_PIN_TTL_MINUTES', '15'))
+    app.config['ACCOUNT_LOCKOUT_ATTEMPTS'] = int(os.environ.get('ACCOUNT_LOCKOUT_ATTEMPTS', '3') or '3')
+    app.config['IP_BLACKLIST_ATTEMPTS'] = int(os.environ.get('IP_BLACKLIST_ATTEMPTS', '10') or '10')
+    app.config['PASSWORD_RESET_TTL_MINUTES'] = int(os.environ.get('PASSWORD_RESET_TTL_MINUTES', '60') or '60')
 
     last_table_env = os.environ.get('MTG_LAST_TABLE_NUMBER', '').strip()
     if last_table_env:
@@ -197,7 +200,31 @@ def create_app():
                     {'level': level, 'name': role_name},
                 )
             db.session.commit()
-        from .models import Report, TournamentJoinRequest, PendingRegistration  # lazy import to avoid circular reference
+        from .models import (
+            Report,
+            TournamentJoinRequest,
+            PendingRegistration,
+            BadLoginAttempt,
+            BlacklistedIP,
+            PasswordResetToken,
+        )  # lazy import to avoid circular reference
+
+        if 'user' in inspector.get_table_names():
+            columns = [c['name'] for c in inspector.get_columns('user')]
+            if 'failed_login_count' not in columns:
+                db.session.execute(text('ALTER TABLE user ADD COLUMN failed_login_count INTEGER DEFAULT 0'))
+                db.session.execute(text('UPDATE user SET failed_login_count=0 WHERE failed_login_count IS NULL'))
+                db.session.commit()
+            if 'locked_at' not in columns:
+                db.session.execute(text('ALTER TABLE user ADD COLUMN locked_at DATETIME'))
+                db.session.commit()
+            if 'lock_reason' not in columns:
+                db.session.execute(text('ALTER TABLE user ADD COLUMN lock_reason TEXT'))
+                db.session.commit()
+
+        BadLoginAttempt.__table__.create(bind=db.engine, checkfirst=True)
+        BlacklistedIP.__table__.create(bind=db.engine, checkfirst=True)
+        PasswordResetToken.__table__.create(bind=db.engine, checkfirst=True)
 
         if 'report' not in inspector.get_table_names():
             Report.__table__.create(bind=db.engine)
@@ -255,6 +282,9 @@ def create_app():
         League,
         LeaguePlayer,
         LeagueResult,
+        BadLoginAttempt,
+        BlacklistedIP,
+        PasswordResetToken,
         all_permission_keys,
     )
     from .pairing import pair_round, recommended_rounds, compute_standings, player_points
@@ -363,6 +393,14 @@ def create_app():
                 r = Role(name=name, permissions=json.dumps(perms), level=level)
                 db.session.add(r)
             else:
+                current_perms = existing.permissions_dict()
+                changed = False
+                for key, allowed in perms.items():
+                    if key not in current_perms:
+                        current_perms[key] = allowed
+                        changed = True
+                if changed:
+                    existing.permissions = json.dumps(current_perms)
                 if existing.level != level:
                     existing.level = level
         db.session.commit()
@@ -438,6 +476,71 @@ def create_app():
             'Your Walter verification PIN',
             f'Use this one-time PIN to verify your Walter account: {pin}\n\nThis PIN expires in {app.config.get("REGISTRATION_PIN_TTL_MINUTES", 15)} minutes.',
         )
+
+    def _client_ip():
+        forwarded = request.headers.get('X-Forwarded-For', '')
+        if forwarded:
+            return forwarded.split(',')[0].strip()
+        return request.remote_addr or 'unknown'
+
+    def _hash_reset_token(token):
+        return hashlib.sha256(token.encode()).hexdigest()
+
+    def _send_password_reset_email(user, token):
+        reset_url = url_for('password_reset_token', token=token, _external=True)
+        _send_mailgun_email(
+            user.email,
+            'Reset your Walter password',
+            (
+                'A password reset was requested for your Walter account. '
+                f'Use this link within {app.config.get("PASSWORD_RESET_TTL_MINUTES", 60)} minutes:\n\n'
+                f'{reset_url}\n\nIf you did not request this reset, ignore this email.'
+            ),
+        )
+
+    def _create_password_reset_token(user):
+        token = secrets.token_urlsafe(32)
+        reset = PasswordResetToken(
+            user=user,
+            token_hash=_hash_reset_token(token),
+            expires_at=datetime.utcnow() + timedelta(minutes=app.config.get('PASSWORD_RESET_TTL_MINUTES', 60)),
+        )
+        db.session.add(reset)
+        db.session.commit()
+        return token
+
+    def _record_bad_login(email, user, result):
+        ip_address = _client_ip()
+        attempt = BadLoginAttempt(
+            email=email or None,
+            user_id=user.id if user else None,
+            ip_address=ip_address,
+            user_agent=request.headers.get('User-Agent', ''),
+            result=result,
+        )
+        db.session.add(attempt)
+        if user and result == 'bad_password':
+            user.failed_login_count = (user.failed_login_count or 0) + 1
+            lockout_attempts = max(app.config.get('ACCOUNT_LOCKOUT_ATTEMPTS', 3), 1)
+            if user.failed_login_count >= lockout_attempts and not user.locked_at:
+                user.locked_at = datetime.utcnow()
+                user.lock_reason = f'{user.failed_login_count} incorrect password attempts'
+                app.logger.warning('Account locked for %s after %s bad login attempts', user.email, user.failed_login_count)
+                log_site('account_lock', 'success', f'user_id={user.id}; ip={ip_address}; attempts={user.failed_login_count}')
+        db.session.commit()
+        ip_attempts = db.session.query(BadLoginAttempt).filter_by(ip_address=ip_address).count()
+        threshold = max(app.config.get('IP_BLACKLIST_ATTEMPTS', 10), 1)
+        if ip_attempts >= threshold:
+            existing = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address).first()
+            if not existing:
+                existing = BlacklistedIP(ip_address=ip_address)
+                db.session.add(existing)
+            if not existing.is_active:
+                existing.is_active = True
+            existing.reason = f'{ip_attempts} bad login attempts'
+            db.session.commit()
+            app.logger.warning('IP address %s blacklisted after %s bad login attempts', ip_address, ip_attempts)
+            log_site('ip_blacklist', 'success', f'ip={ip_address}; attempts={ip_attempts}')
 
     @app.route('/register', methods=['GET','POST'])
     def register():
@@ -578,7 +681,15 @@ def create_app():
             password = request.form['password']
             from .models import User
             u = db.session.query(User).filter_by(email=email).first()
+            if u and u.locked_at:
+                flash("Account locked. Use password reset or contact an administrator.", "error")
+                _record_bad_login(email, u, 'account_locked')
+                log_site('login', 'failure', 'account locked')
+                return render_template('login.html')
             if u and u.check_password(password):
+                u.failed_login_count = 0
+                u.lock_reason = None
+                db.session.commit()
                 login_user(u)
                 try:
                     priv_pem = u.decrypt_private_key(password)
@@ -586,15 +697,61 @@ def create_app():
                         session['private_key'] = base64.b64encode(priv_pem).decode()
                 except Exception:
                     session['private_key'] = None
-                log_site('login', 'success')
+                log_site('login', 'success', f'ip={_client_ip()}')
                 if next_url:
                     parsed = urlparse(next_url)
                     if not parsed.netloc and parsed.path.startswith('/'):
                         return redirect(next_url)
                 return redirect(url_for('index'))
+            _record_bad_login(email, u, 'bad_password' if u else 'unknown_user')
             flash("Invalid credentials", "error")
-            log_site('login', 'failure', 'invalid credentials')
+            log_site('login', 'failure', f'invalid credentials; ip={_client_ip()}')
         return render_template('login.html')
+
+    @app.route('/password-reset', methods=['GET', 'POST'])
+    def password_reset_request():
+        if request.method == 'POST':
+            email = request.form.get('email', '').strip().lower()
+            user = db.session.query(User).filter_by(email=email).first() if email else None
+            if user and user.email:
+                try:
+                    token = _create_password_reset_token(user)
+                    _send_password_reset_email(user, token)
+                    log_site('password_reset_request', 'success', f'user_id={user.id}; ip={_client_ip()}')
+                except Exception as exc:
+                    db.session.rollback()
+                    log_site('password_reset_request', 'failure', str(exc))
+                    flash('Password reset email could not be sent. Contact an administrator.', 'error')
+                    return redirect(url_for('password_reset_request'))
+            else:
+                log_site('password_reset_request', 'failure', f'unknown email; ip={_client_ip()}')
+            flash('If the email exists, a reset link has been sent.', 'success')
+            return redirect(url_for('login'))
+        return render_template('password_reset_request.html')
+
+    @app.route('/password-reset/<token>', methods=['GET', 'POST'])
+    def password_reset_token(token):
+        token_hash = _hash_reset_token(token)
+        reset = db.session.query(PasswordResetToken).filter_by(token_hash=token_hash).first()
+        valid = reset and not reset.used_at and reset.expires_at and reset.expires_at >= datetime.utcnow()
+        if not valid:
+            log_site('password_reset', 'failure', f'invalid or expired token; ip={_client_ip()}')
+            flash('Password reset link is invalid or expired.', 'error')
+            return redirect(url_for('password_reset_request'))
+        if request.method == 'POST':
+            password = request.form.get('password', '')
+            password_confirm = request.form.get('password_confirm', '')
+            if password != password_confirm:
+                flash('Passwords do not match.', 'error')
+                return render_template('password_reset_form.html', token=token)
+            reset.user.set_password(password)
+            reset.user.generate_keys(password)
+            reset.used_at = datetime.utcnow()
+            db.session.commit()
+            log_site('password_reset', 'success', f'user_id={reset.user_id}; ip={_client_ip()}')
+            flash('Password reset successfully. Please login.', 'success')
+            return redirect(url_for('login'))
+        return render_template('password_reset_form.html', token=token)
 
     @app.route('/t/<int:tid>/join-link')
     def tournament_join_link(tid):
@@ -1267,6 +1424,15 @@ def create_app():
                              user_id=current_user.id if current_user.is_authenticated else None)
         db.session.add(log)
         db.session.commit()
+
+    @app.before_request
+    def block_blacklisted_ip():
+        ip_address = _client_ip()
+        blocked = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address, is_active=True).first()
+        if blocked:
+            app.logger.warning('Blocked blacklisted IP address %s from %s', ip_address, request.path)
+            log_site('blocked_blacklisted_ip', 'failure', f'ip={ip_address}; path={request.path}')
+            abort(403)
 
     def parse_datetime_local(value):
         if not value:
@@ -2784,6 +2950,45 @@ def create_app():
             l.user = db.session.get(User, l.user_id) if l.user_id else None
         return render_template('admin/site_logs.html', logs=logs)
 
+    @app.route('/admin/security/bad-logins')
+    def admin_bad_logins():
+        require_permission('admin.login_audit')
+        log_site('view_bad_login_audit', 'success')
+        attempts = db.session.query(BadLoginAttempt).order_by(BadLoginAttempt.created_at.desc()).all()
+        return render_template('admin/bad_logins.html', attempts=attempts)
+
+    @app.route('/admin/security/ip-blacklist')
+    def admin_ip_blacklist():
+        require_permission('admin.ip_blacklist')
+        log_site('view_ip_blacklist', 'success')
+        ips = db.session.query(BlacklistedIP).order_by(BlacklistedIP.created_at.desc()).all()
+        return render_template('admin/ip_blacklist.html', ips=ips)
+
+    @app.route('/admin/security/ip-blacklist/<int:ip_id>/toggle', methods=['POST'])
+    def admin_toggle_ip_blacklist(ip_id):
+        require_permission('admin.ip_blacklist')
+        item = db.session.get(BlacklistedIP, ip_id)
+        if not item:
+            abort(404)
+        item.is_active = not item.is_active
+        db.session.commit()
+        log_site('ip_blacklist_toggle', 'success', f'ip={item.ip_address}; active={item.is_active}')
+        flash('IP blacklist entry updated.', 'success')
+        return redirect(url_for('admin_ip_blacklist'))
+
+    @app.route('/admin/security/ip-blacklist/export')
+    def admin_export_ip_blacklist():
+        require_permission('admin.ip_blacklist')
+        log_site('export_ip_blacklist', 'success')
+        ips = db.session.query(BlacklistedIP).filter_by(is_active=True).order_by(BlacklistedIP.ip_address).all()
+        lines = [f'iptables -A INPUT -s {item.ip_address} -j DROP' for item in ips]
+        output = '\n'.join(lines) + ('\n' if lines else '')
+        return Response(
+            output,
+            mimetype='text/plain',
+            headers={'Content-Disposition': 'attachment; filename=walter_bad_ips_iptables.sh'},
+        )
+
     @app.route('/admin/tournaments/<int:tid>/delete', methods=['POST'])
     def delete_tournament(tid):
         require_permission('tournaments.manage')
@@ -4090,6 +4295,12 @@ def create_app():
                     return redirect(redirect_target)
                 u.set_password(password)
                 u.generate_keys(password)
+                log_site('admin_password_reset', 'success', f'user_id={u.id}')
+            if request.form.get('unlock_account') == 'yes':
+                u.failed_login_count = 0
+                u.locked_at = None
+                u.lock_reason = None
+                log_site('admin_account_unlock', 'success', f'user_id={u.id}')
             u.email = email
             u.notes = request.form.get('notes', '').strip() or None
             role_id = request.form.get('role_id')

--- a/app/models.py
+++ b/app/models.py
@@ -27,6 +27,8 @@ PERMISSION_GROUPS = {
     'admin': {
         'panel': 'Access admin panel',
         'permissions': 'Manage roles and permissions',
+        'login_audit': 'Audit failed login attempts',
+        'ip_blacklist': 'Manage blacklisted IP addresses',
     },
 }
 
@@ -110,10 +112,16 @@ class User(db.Model, UserMixin):
     private_key_salt = db.Column(db.LargeBinary, nullable=True)
     private_key_nonce = db.Column(db.LargeBinary, nullable=True)
     permission_overrides = db.Column(db.Text, nullable=True)
+    failed_login_count = db.Column(db.Integer, nullable=False, default=0)
+    locked_at = db.Column(db.DateTime, nullable=True)
+    lock_reason = db.Column(db.Text, nullable=True)
 
     def set_password(self, pw):
         self.salt = os.urandom(16).hex()
         self.password_hash = hashlib.sha256((self.salt + pw).encode()).hexdigest()
+        self.failed_login_count = 0
+        self.locked_at = None
+        self.lock_reason = None
 
     def check_password(self, pw):
         if not self.password_hash or not self.salt:
@@ -172,6 +180,40 @@ class User(db.Model, UserMixin):
         if not self.role:
             return False
         return self.role.permissions_dict().get(key, False)
+
+
+class BadLoginAttempt(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    email = db.Column(db.String(255), nullable=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    ip_address = db.Column(db.String(64), nullable=False)
+    user_agent = db.Column(db.Text, nullable=True)
+    result = db.Column(db.String(50), nullable=False, default='bad_password')
+    created_at = db.Column(db.DateTime, default=utc_now)
+
+    user = db.relationship('User')
+
+
+class BlacklistedIP(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    ip_address = db.Column(db.String(64), unique=True, nullable=False)
+    reason = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    created_by_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+
+    created_by = db.relationship('User')
+
+
+class PasswordResetToken(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    token_hash = db.Column(db.String(64), unique=True, nullable=False)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    expires_at = db.Column(db.DateTime, nullable=False)
+    used_at = db.Column(db.DateTime, nullable=True)
+
+    user = db.relationship('User')
 
 
 class PendingRegistration(db.Model):

--- a/app/templates/admin/bad_logins.html
+++ b/app/templates/admin/bad_logins.html
@@ -1,0 +1,25 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header">
+  <div class="page-header__title">
+    <span class="eyebrow">Security</span>
+    <h2>Bad Login Audit</h2>
+    <p class="page-description">Review failed password attempts, locked-account attempts, unknown users, source IP addresses, and user agents.</p>
+  </div>
+</section>
+<table>
+  <tr><th>Time</th><th>Email</th><th>User</th><th>IP Address</th><th>Result</th><th>User Agent</th></tr>
+  {% for attempt in attempts %}
+  <tr>
+    <td>{{ attempt.created_at }}</td>
+    <td>{{ attempt.email or '' }}</td>
+    <td>{{ attempt.user.name if attempt.user else '' }}</td>
+    <td>{{ attempt.ip_address }}</td>
+    <td>{{ attempt.result }}</td>
+    <td>{{ attempt.user_agent or '' }}</td>
+  </tr>
+  {% else %}
+  <tr><td colspan="6">No bad login attempts recorded.</td></tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/admin/ip_blacklist.html
+++ b/app/templates/admin/ip_blacklist.html
@@ -1,0 +1,30 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header">
+  <div class="page-header__title">
+    <span class="eyebrow">Security</span>
+    <h2>IP Blacklist</h2>
+    <p class="page-description">IPs are automatically blacklisted after the configured number of bad login attempts.</p>
+  </div>
+  <div class="form-actions"><a class="btn" href="{{ url_for('admin_export_ip_blacklist') }}">Export iptables Rules</a></div>
+</section>
+<table>
+  <tr><th>IP Address</th><th>Status</th><th>Reason</th><th>Created</th><th>Created By</th><th>Actions</th></tr>
+  {% for item in ips %}
+  <tr>
+    <td>{{ item.ip_address }}</td>
+    <td>{{ 'Active' if item.is_active else 'Inactive' }}</td>
+    <td>{{ item.reason or '' }}</td>
+    <td>{{ item.created_at }}</td>
+    <td>{{ item.created_by.name if item.created_by else '' }}</td>
+    <td>
+      <form method="post" action="{{ url_for('admin_toggle_ip_blacklist', ip_id=item.id) }}" class="inline-form">
+        <button class="btn" type="submit">{{ 'Disable' if item.is_active else 'Enable' }}</button>
+      </form>
+    </td>
+  </tr>
+  {% else %}
+  <tr><td colspan="6">No blacklisted IP addresses.</td></tr>
+  {% endfor %}
+</table>
+{% endblock %}

--- a/app/templates/admin/panel.html
+++ b/app/templates/admin/panel.html
@@ -24,4 +24,11 @@
   <p>Create a private JSON backup for moving data between WaLTER instances or restoring a backup.</p>
   <div class="form-actions"><a class="btn" href="{{ url_for('admin_backup') }}">Open Backup &amp; Transfer</a></div>
 </section>
+<section class="panel-card">
+  <div class="section-heading"><div><h3>Security Controls</h3><p>Audit bad logins and manage IP lockouts.</p></div></div>
+  <div class="form-actions">
+    <a class="btn" href="{{ url_for('admin_bad_logins') }}">Bad Login Audit</a>
+    <a class="btn" href="{{ url_for('admin_ip_blacklist') }}">IP Blacklist</a>
+  </div>
+</section>
 {% endblock %}

--- a/app/templates/admin/user_detail.html
+++ b/app/templates/admin/user_detail.html
@@ -28,6 +28,13 @@
         {% endfor %}
       </select>
     </div>
+    {% if user.locked_at %}
+    <div class="form-row">
+      <label>Account Lock</label>
+      <div>Locked at {{ user.locked_at }}{% if user.lock_reason %}: {{ user.lock_reason }}{% endif %}</div>
+      <label><input type="checkbox" name="unlock_account" value="yes"> Unlock account</label>
+    </div>
+    {% endif %}
     <div class="form-row">
       <label for="user-password">Set Password</label>
       <input id="user-password" type="password" name="password" placeholder="New password">

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -42,7 +42,7 @@
             </div>
           </li>
           {% endif %}
-          {% if current_user.has_permission('users.manage') or current_user.has_permission('admin.panel') or current_user.has_permission('admin.permissions') %}
+          {% if current_user.has_permission('users.manage') or current_user.has_permission('admin.panel') or current_user.has_permission('admin.permissions') or current_user.has_permission('admin.login_audit') or current_user.has_permission('admin.ip_blacklist') %}
           <li class="nav-item has-dropdown">
             <button class="nav-link" type="button" data-dropdown-toggle aria-expanded="false">Admin</button>
             <div class="dropdown-menu" role="menu">
@@ -54,6 +54,12 @@
               <a class="dropdown-item" href="{{ url_for('site_logs') }}">Site Logs</a>
               <a class="dropdown-item" href="{{ url_for('admin_backup') }}">Backup &amp; Transfer</a>
               <a class="dropdown-item" href="{{ url_for('admin_reports') }}">Reports <span id="nav-reports-count" class="nav-badge{% if not nav_open_reports %} hidden{% endif %}">{{ nav_open_reports }}</span></a>
+              {% endif %}
+              {% if current_user.has_permission('admin.login_audit') %}
+              <a class="dropdown-item" href="{{ url_for('admin_bad_logins') }}">Bad Login Audit</a>
+              {% endif %}
+              {% if current_user.has_permission('admin.ip_blacklist') %}
+              <a class="dropdown-item" href="{{ url_for('admin_ip_blacklist') }}">IP Blacklist</a>
               {% endif %}
               {% if current_user.has_permission('admin.permissions') %}
               <a class="dropdown-item" href="{{ url_for('permissions') }}">Permissions</a>

--- a/app/templates/login.html
+++ b/app/templates/login.html
@@ -16,5 +16,6 @@
       <button class="btn" type="submit">Login</button>
     </div>
   </form>
+<p><a href="{{ url_for('password_reset_request') }}">Forgot your password?</a></p>
 </section>
 {% endblock %}

--- a/app/templates/password_reset_form.html
+++ b/app/templates/password_reset_form.html
@@ -1,0 +1,15 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="auth-card">
+  <h2>Choose a New Password</h2>
+  <form method="post" class="stacked-form">
+    <label>New password
+      <input type="password" name="password" required autocomplete="new-password">
+    </label>
+    <label>Confirm password
+      <input type="password" name="password_confirm" required autocomplete="new-password">
+    </label>
+    <div class="form-actions"><button class="btn" type="submit">Reset Password</button></div>
+  </form>
+</section>
+{% endblock %}

--- a/app/templates/password_reset_request.html
+++ b/app/templates/password_reset_request.html
@@ -1,0 +1,13 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="auth-card">
+  <h2>Reset Password</h2>
+  <p>Enter your account email and we will send a password reset link if the address exists.</p>
+  <form method="post" class="stacked-form">
+    <label>Email
+      <input type="email" name="email" required autocomplete="email">
+    </label>
+    <div class="form-actions"><button class="btn" type="submit">Send Reset Link</button></div>
+  </form>
+</section>
+{% endblock %}

--- a/config.yaml
+++ b/config.yaml
@@ -22,3 +22,11 @@ last_table_number: 200
 # registration_pin_ttl_minutes: 15
 # When true, public registration requires a valid tournament invite/passcode.
 account_creation_invite_only: false
+
+# Account security controls.
+# Lock user accounts after this many bad password attempts.
+account_lockout_attempts: 3
+# Blacklist an IP after this many total bad login attempts.
+ip_blacklist_attempts: 10
+# Password reset links expire after this many minutes.
+password_reset_ttl_minutes: 60

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -58,6 +58,9 @@ $MailgunDomain = $cfg.mailgun_domain
 $MailgunFromEmail = $cfg.mailgun_from_email
 $RegistrationPinTtlMinutes = $cfg.registration_pin_ttl_minutes
 $AccountCreationInviteOnly = $cfg.account_creation_invite_only
+$AccountLockoutAttempts = $cfg.account_lockout_attempts
+$IpBlacklistAttempts = $cfg.ip_blacklist_attempts
+$PasswordResetTtlMinutes = $cfg.password_reset_ttl_minutes
 $newadmin = New-Object System.Management.Automation.PSCredential($cfg.admin_email, (ConvertTo-SecureString $cfg.admin_pass -AsPlainText -Force))
 
 ######enable testing###########
@@ -72,6 +75,9 @@ if([string]::IsNullOrEmpty($FlaskIP)){ $FlaskIP = "127.0.0.1" }
 if([string]::IsNullOrEmpty($FlaskPort)){ $FlaskPort = 5000 }
 if([string]::IsNullOrEmpty($RegistrationPinTtlMinutes)){ $RegistrationPinTtlMinutes = 15 }
 if($null -eq $AccountCreationInviteOnly){ $AccountCreationInviteOnly = $false }
+if([string]::IsNullOrEmpty($AccountLockoutAttempts)){ $AccountLockoutAttempts = 3 }
+if([string]::IsNullOrEmpty($IpBlacklistAttempts)){ $IpBlacklistAttempts = 10 }
+if([string]::IsNullOrEmpty($PasswordResetTtlMinutes)){ $PasswordResetTtlMinutes = 60 }
 
 #check if Flask/Waitress is already running and stop it if necessary
 $flaskpid = try{
@@ -103,6 +109,9 @@ $env:MAILGUN_DOMAIN = $MailgunDomain
 $env:MAILGUN_FROM_EMAIL = $MailgunFromEmail
 $env:REGISTRATION_PIN_TTL_MINUTES = $RegistrationPinTtlMinutes
 $env:ACCOUNT_CREATION_INVITE_ONLY = $AccountCreationInviteOnly
+$env:ACCOUNT_LOCKOUT_ATTEMPTS = $AccountLockoutAttempts
+$env:IP_BLACKLIST_ATTEMPTS = $IpBlacklistAttempts
+$env:PASSWORD_RESET_TTL_MINUTES = $PasswordResetTtlMinutes
 
 $timestamp = Get-Date -Format "yyyyMMddHHmmss"
 

--- a/start-server.sh
+++ b/start-server.sh
@@ -377,6 +377,9 @@ keys = [
     'mailgun_from_email',
     'registration_pin_ttl_minutes',
     'account_creation_invite_only',
+    'account_lockout_attempts',
+    'ip_blacklist_attempts',
+    'password_reset_ttl_minutes',
 ]
 
 for key in keys:
@@ -410,6 +413,9 @@ MAILGUN_DOMAIN="${MAILGUN_DOMAIN:-}"
 MAILGUN_FROM_EMAIL="${MAILGUN_FROM_EMAIL:-}"
 REGISTRATION_PIN_TTL_MINUTES="${REGISTRATION_PIN_TTL_MINUTES:-15}"
 ACCOUNT_CREATION_INVITE_ONLY="${ACCOUNT_CREATION_INVITE_ONLY:-false}"
+ACCOUNT_LOCKOUT_ATTEMPTS="${ACCOUNT_LOCKOUT_ATTEMPTS:-3}"
+IP_BLACKLIST_ATTEMPTS="${IP_BLACKLIST_ATTEMPTS:-10}"
+PASSWORD_RESET_TTL_MINUTES="${PASSWORD_RESET_TTL_MINUTES:-60}"
 
 cd "$SCRIPT_DIR"
 
@@ -423,6 +429,9 @@ export MAILGUN_DOMAIN
 export MAILGUN_FROM_EMAIL
 export REGISTRATION_PIN_TTL_MINUTES
 export ACCOUNT_CREATION_INVITE_ONLY
+export ACCOUNT_LOCKOUT_ATTEMPTS
+export IP_BLACKLIST_ATTEMPTS
+export PASSWORD_RESET_TTL_MINUTES
 
 ensure_letsencrypt_certificate
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -193,3 +193,58 @@ def test_invite_only_registration_requires_tournament_passcode(client, session, 
 
     assert response.status_code == 302
     assert response.headers['Location'].endswith('/register/verify?email=invited@example.com')
+
+
+def test_account_locks_after_three_bad_passwords(client, session, app):
+    app.config['ACCOUNT_LOCKOUT_ATTEMPTS'] = 3
+    user_role = session.query(Role).filter_by(name='user').one()
+    user = User(email='lock@example.com', name='Lock User', role=user_role)
+    user.set_password('secret')
+    session.add(user)
+    session.commit()
+
+    for _ in range(3):
+        response = client.post('/login', data={'email': user.email, 'password': 'wrong'})
+        assert response.status_code == 200
+
+    session.refresh(user)
+    assert user.locked_at is not None
+    assert user.failed_login_count == 3
+
+    response = client.post('/login', data={'email': user.email, 'password': 'secret'})
+    assert response.status_code == 200
+    assert b'Account locked' in response.data
+
+
+def test_ip_blacklisted_after_ten_bad_logins(client, session, app):
+    app.config['IP_BLACKLIST_ATTEMPTS'] = 10
+    for _ in range(10):
+        response = client.post('/login', data={'email': 'missing@example.com', 'password': 'wrong'})
+        assert response.status_code == 200
+
+    from app.models import BlacklistedIP
+    entry = session.query(BlacklistedIP).filter_by(ip_address='127.0.0.1').one()
+    assert entry.is_active
+
+    response = client.get('/')
+    assert response.status_code == 403
+
+
+def test_admin_can_view_bad_login_audit_and_export_blacklist(client, session):
+    from app.models import BadLoginAttempt, BlacklistedIP
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(email='security-admin@example.com', name='Security Admin', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    session.add(admin)
+    session.add(BadLoginAttempt(email='bad@example.com', ip_address='203.0.113.8', result='bad_password'))
+    session.add(BlacklistedIP(ip_address='203.0.113.8', reason='test'))
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.get('/admin/security/bad-logins')
+        assert response.status_code == 200
+        assert b'bad@example.com' in response.data
+        export = client.get('/admin/security/ip-blacklist/export')
+        assert export.status_code == 200
+        assert b'iptables -A INPUT -s 203.0.113.8 -j DROP' in export.data


### PR DESCRIPTION
### Motivation
- Improve site security by locking accounts after repeated failed logins and providing a secure password reset path.
- Provide administrators with audit tools to investigate failed logins and manage suspicious IPs.
- Make lockout and blacklist thresholds configurable via `config.yaml` and startup scripts for flexible deployment.
- Ensure security events are logged for operational visibility and incident response.

### Description
- Added new data models `BadLoginAttempt`, `BlacklistedIP`, and `PasswordResetToken`, and added user fields `failed_login_count`, `locked_at`, and `lock_reason` to `app/models.py`.
- Introduced config-driven thresholds `ACCOUNT_LOCKOUT_ATTEMPTS`, `IP_BLACKLIST_ATTEMPTS`, and `PASSWORD_RESET_TTL_MINUTES` in `app/app.py` and wired them through `config.yaml`, `start-server.sh`, and `start-server.ps1`.
- Implemented bad-login recording and enforcement in `app/app.py` including `_client_ip()`, `_record_bad_login()`, automatic per-user lock after failed attempts, automatic IP blacklisting after threshold, and a `@app.before_request` hook to block blacklisted IPs.
- Added password reset request and token flow with routes `GET/POST /password-reset` and `GET/POST /password-reset/<token>` and email sending via the existing mailgun helper.
- Added admin UI and routes for audit and management: `GET /admin/security/bad-logins`, `GET /admin/security/ip-blacklist`, `POST /admin/security/ip-blacklist/<id>/toggle`, and `GET /admin/security/ip-blacklist/export` (exports iptables rules); added templates under `app/templates/admin/` and navigation links protected by new permissions `admin.login_audit` and `admin.ip_blacklist`.
- Added an account-unlock control and admin password-reset logging on the user detail admin page and updated default role permission handling to include the new admin permissions.

### Testing
- Added tests exercising account lockout, IP blacklisting, bad-login audit visibility, and blacklist export under `tests/test_users.py`, and ran the test suite; result: `pytest` completed with all tests passing (`44 passed`, several warnings related to datetime usage).
- Verified templates render and new routes respond in test client flows and ran `python -m compileall app` to ensure modules compile successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f57d3e57c8320909a06e199aa1b9a)

## Summary by Sourcery

Add configurable account security controls including login lockout, IP blacklisting, and password reset flow, along with admin auditing and management UI.

New Features:
- Introduce account lockout and IP blacklist thresholds configurable via environment variables, startup scripts, and config.yaml.
- Add password reset request and token-based reset flow with email delivery and token expiry controls.
- Expose admin security pages for bad login auditing and IP blacklist management, including an export of iptables rules.

Enhancements:
- Extend user model and migration logic to track failed login counts, lock status, and add new security-related tables for login attempts, blacklisted IPs, and password reset tokens.
- Update admin user detail page to display lock status, allow manual account unlock, and log admin-triggered password resets and unlocks.
- Expand admin navigation and panel to surface new security controls while preserving permission-based access.

Build:
- Wire new security configuration options through start-server.sh and start-server.ps1 so they are available as environment variables at runtime.

Documentation:
- Document new security-related configuration options in config.yaml for account lockout, IP blacklisting, and password reset TTL.

Tests:
- Add tests covering account lockout behavior, IP blacklisting and request blocking, and admin visibility/export of security data.