### PR TITLE
Add bulk tournament management, venue visibility limits, and decklist UI

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -198,6 +198,12 @@ def create_app():
             if 'venue_id' not in columns:
                 db.session.execute(text('ALTER TABLE tournament ADD COLUMN venue_id INTEGER'))
                 db.session.commit()
+            if 'started_at' not in columns:
+                db.session.execute(text('ALTER TABLE tournament ADD COLUMN started_at DATETIME'))
+                db.session.commit()
+            if 'ended_at' not in columns:
+                db.session.execute(text('ALTER TABLE tournament ADD COLUMN ended_at DATETIME'))
+                db.session.commit()
         if 'user' in inspector.get_table_names():
             columns = [c['name'] for c in inspector.get_columns('user')]
             if 'break_end' not in columns:
@@ -394,6 +400,8 @@ def create_app():
     def tournament_is_complete(tournament):
         players = list(getattr(tournament, 'players', []) or [])
         rounds = sorted(list(getattr(tournament, 'rounds', []) or []), key=lambda r: r.number)
+        if getattr(tournament, 'ended_at', None):
+            return True
         if not rounds:
             return False
         round_limit = tournament.rounds_override or recommended_rounds(len(players))
@@ -478,8 +486,9 @@ def create_app():
         tournaments = db.session.query(Tournament).order_by(Tournament.created_at.desc()).all()
         visible_tournaments = [t for t in tournaments if not tournament_is_complete(t)]
         player_counts = {t.id: len(t.players) for t in visible_tournaments}
+        venues = db.session.query(Venue).order_by(Venue.name).all() if current_user.is_authenticated and current_user.has_permission('tournaments.bulk_manage') else []
         return render_template('index.html', tournaments=visible_tournaments, player_counts=player_counts,
-                               server_now=datetime.utcnow())
+                               venues=venues, server_now=datetime.utcnow())
 
     def _send_mailgun_email(to_email, subject, text):
         api_key = app.config.get('MAILGUN_API_KEY')
@@ -1448,6 +1457,28 @@ def create_app():
 
     def require_admin():
         require_permission('admin.panel')
+
+    def venue_ids_for_user(user):
+        if not user or not getattr(user, 'is_authenticated', False):
+            return set()
+        if hasattr(user, 'has_permission') and user.has_permission('venues.manage'):
+            return {venue.id for venue in db.session.query(Venue.id).all()}
+        rows = (
+            db.session.query(Tournament.venue_id)
+            .join(TournamentPlayer, TournamentPlayer.tournament_id == Tournament.id)
+            .filter(TournamentPlayer.user_id == user.id, Tournament.venue_id.isnot(None))
+            .distinct()
+            .all()
+        )
+        return {row[0] for row in rows}
+
+    def restrict_to_visible_venues(query, model):
+        visible_ids = venue_ids_for_user(current_user)
+        if current_user.has_permission('venues.manage'):
+            return query
+        if not visible_ids:
+            return query.filter(False)
+        return query.filter(model.venue_id.in_(visible_ids))
 
     def log_site(action, result, error=None):
         log = SiteLog(action=action, result=result, error=error,
@@ -2584,9 +2615,10 @@ def create_app():
         return render_template('admin/edit_tournament.html', **template_context)
 
     @app.route('/admin/venues', methods=['GET', 'POST'])
+    @login_required
     def venue_management():
-        require_permission('venues.manage')
         if request.method == 'POST':
+            require_permission('venues.manage')
             name = request.form.get('name', '').strip()
             if not name:
                 flash('Venue name is required.', 'error')
@@ -2602,10 +2634,19 @@ def create_app():
                 log_site('venue_create', 'success', f'venue_id={venue.id}')
                 flash('Venue created.', 'success')
                 return redirect(url_for('venue_management'))
-        venues = db.session.query(Venue).order_by(Venue.name).all()
-        return render_template('admin/venues.html', venues=venues)
+        venue_query = db.session.query(Venue).order_by(Venue.name)
+        if not current_user.has_permission('venues.manage'):
+            visible_ids = venue_ids_for_user(current_user)
+            venue_query = venue_query.filter(Venue.id.in_(visible_ids)) if visible_ids else venue_query.filter(False)
+        venues = venue_query.all()
+        return render_template(
+            'admin/venues.html',
+            venues=venues,
+            can_manage_venues=current_user.has_permission('venues.manage'),
+        )
 
     @app.route('/admin/venues/<int:venue_id>/update', methods=['POST'])
+    @login_required
     def update_venue(venue_id):
         require_permission('venues.manage')
         venue = db.session.get(Venue, venue_id)
@@ -2625,10 +2666,15 @@ def create_app():
         return redirect(url_for('venue_management'))
 
     @app.route('/admin/venues/vendors', methods=['GET', 'POST'])
+    @login_required
     def vendor_management():
-        require_permission('venues.manage')
-        venues = db.session.query(Venue).order_by(Venue.name).all()
+        venue_query = db.session.query(Venue).order_by(Venue.name)
+        if not current_user.has_permission('venues.manage'):
+            visible_ids = venue_ids_for_user(current_user)
+            venue_query = venue_query.filter(Venue.id.in_(visible_ids)) if visible_ids else venue_query.filter(False)
+        venues = venue_query.all()
         if request.method == 'POST':
+            require_permission('venues.manage')
             name = request.form.get('name', '').strip()
             if not name:
                 flash('Vendor name is required.', 'error')
@@ -2645,10 +2691,11 @@ def create_app():
                 log_site('vendor_create', 'success', f'vendor_id={vendor.id}')
                 flash('Vendor created.', 'success')
                 return redirect(url_for('vendor_management'))
-        vendors = db.session.query(Vendor).order_by(Vendor.name).all()
-        return render_template('admin/vendors.html', vendors=vendors, venues=venues)
+        vendors = restrict_to_visible_venues(db.session.query(Vendor), Vendor).order_by(Vendor.name).all()
+        return render_template('admin/vendors.html', vendors=vendors, venues=venues, can_manage_venues=current_user.has_permission('venues.manage'))
 
     @app.route('/admin/venues/vendors/<int:vendor_id>/update', methods=['POST'])
+    @login_required
     def update_vendor(vendor_id):
         require_permission('venues.manage')
         vendor = db.session.get(Vendor, vendor_id)
@@ -2669,10 +2716,15 @@ def create_app():
         return redirect(url_for('vendor_management'))
 
     @app.route('/admin/venues/artists', methods=['GET', 'POST'])
+    @login_required
     def artist_management():
-        require_permission('venues.manage')
-        venues = db.session.query(Venue).order_by(Venue.name).all()
+        venue_query = db.session.query(Venue).order_by(Venue.name)
+        if not current_user.has_permission('venues.manage'):
+            visible_ids = venue_ids_for_user(current_user)
+            venue_query = venue_query.filter(Venue.id.in_(visible_ids)) if visible_ids else venue_query.filter(False)
+        venues = venue_query.all()
         if request.method == 'POST':
+            require_permission('venues.manage')
             name = request.form.get('name', '').strip()
             if not name:
                 flash('Artist name is required.', 'error')
@@ -2689,10 +2741,11 @@ def create_app():
                 log_site('artist_create', 'success', f'artist_id={artist.id}')
                 flash('Artist profile created.', 'success')
                 return redirect(url_for('artist_management'))
-        artists = db.session.query(ArtistProfile).order_by(ArtistProfile.name).all()
-        return render_template('admin/artists.html', artists=artists, venues=venues)
+        artists = restrict_to_visible_venues(db.session.query(ArtistProfile), ArtistProfile).order_by(ArtistProfile.name).all()
+        return render_template('admin/artists.html', artists=artists, venues=venues, can_manage_venues=current_user.has_permission('venues.manage'))
 
     @app.route('/admin/venues/artists/<int:artist_id>/update', methods=['POST'])
+    @login_required
     def update_artist(artist_id):
         require_permission('venues.manage')
         artist = db.session.get(ArtistProfile, artist_id)
@@ -3271,6 +3324,75 @@ def create_app():
             headers={'Content-Disposition': 'attachment; filename=walter_bad_ips_iptables.sh'},
         )
 
+    @app.route('/admin/tournaments/bulk', methods=['POST'])
+    @login_required
+    def bulk_edit_tournaments():
+        require_permission('admin.panel')
+        require_permission('tournaments.bulk_manage')
+        raw_ids = request.form.getlist('tournament_ids')
+        tournament_ids = []
+        for raw_id in raw_ids:
+            try:
+                tournament_ids.append(int(raw_id))
+            except (TypeError, ValueError):
+                continue
+        action = (request.form.get('bulk_action') or '').strip()
+        if not tournament_ids:
+            flash('Select at least one tournament.', 'error')
+            return redirect(url_for('index'))
+        tournaments = db.session.query(Tournament).filter(Tournament.id.in_(tournament_ids)).all()
+        tournament_by_id = {t.id: t for t in tournaments}
+        ordered_tournaments = [tournament_by_id[tid] for tid in tournament_ids if tid in tournament_by_id]
+        count = 0
+        now = datetime.utcnow()
+        if action == 'venue':
+            venue_raw = request.form.get('bulk_venue_id')
+            venue_id = int(venue_raw) if venue_raw else None
+            if venue_id and not db.session.get(Venue, venue_id):
+                flash('Selected venue was not found.', 'error')
+                return redirect(url_for('index'))
+            for tournament in ordered_tournaments:
+                tournament.venue_id = venue_id
+                db.session.flush()
+                db.session.add(TournamentLog(tournament_id=tournament.id, action='bulk_set_venue', result='success', error=f'venue_id={venue_id}', user_id=current_user.id))
+                db.session.add(SiteLog(action='bulk_set_tournament_venue', result='success', error=f'tournament_id={tournament.id}; venue_id={venue_id}', user_id=current_user.id))
+                count += 1
+        elif action == 'start':
+            for tournament in ordered_tournaments:
+                tournament.started_at = now
+                if not tournament.start_time:
+                    tournament.start_time = now
+                    tournament.name = format_tournament_name(tournament.format, tournament.start_time, extract_provided_tournament_name(tournament.name))
+                tournament.ended_at = None
+                db.session.flush()
+                db.session.add(TournamentLog(tournament_id=tournament.id, action='bulk_start', result='success', user_id=current_user.id))
+                db.session.add(SiteLog(action='bulk_start_tournament', result='success', error=f'tournament_id={tournament.id}', user_id=current_user.id))
+                count += 1
+        elif action == 'end':
+            for tournament in ordered_tournaments:
+                tournament.ended_at = now
+                tournament.round_timer_end = None
+                tournament.draft_timer_end = None
+                tournament.deck_timer_end = None
+                db.session.flush()
+                db.session.add(TournamentLog(tournament_id=tournament.id, action='bulk_end', result='success', user_id=current_user.id))
+                db.session.add(SiteLog(action='bulk_end_tournament', result='success', error=f'tournament_id={tournament.id}', user_id=current_user.id))
+                count += 1
+        elif action == 'delete':
+            for tournament in ordered_tournaments:
+                tid = tournament.id
+                name = tournament.name
+                db.session.add(TournamentLog(tournament_id=tid, action='bulk_delete', result='success', user_id=current_user.id))
+                db.session.add(SiteLog(action='bulk_delete_tournament', result='success', error=f'tournament_id={tid}; name={name}', user_id=current_user.id))
+                db.session.delete(tournament)
+                count += 1
+        else:
+            flash('Choose a bulk action.', 'error')
+            return redirect(url_for('index'))
+        db.session.commit()
+        flash(f'Bulk action applied to {count} tournament' + ('s' if count != 1 else '') + '.', 'success')
+        return redirect(url_for('index'))
+
     @app.route('/admin/tournaments/<int:tid>/delete', methods=['POST'])
     def delete_tournament(tid):
         require_permission('tournaments.manage')
@@ -3402,6 +3524,30 @@ def create_app():
                                can_view_player_decks=can_view_player_decks,
                                available_users=available_users,
                                server_now=datetime.utcnow())
+
+    @app.route('/t/<int:tid>/decklists')
+    @login_required
+    def tournament_decklists(tid):
+        t = db.session.get(Tournament, tid)
+        if not t:
+            abort(404)
+        if not user_can_view_player_decks(current_user, t):
+            abort(403)
+        players = db.session.query(TournamentPlayer).filter_by(tournament_id=tid).order_by(TournamentPlayer.id).all()
+        deck_rows = []
+        for player in players:
+            deck = player.deck
+            main_cards = deck.mainboard_cards() if deck else []
+            side_cards = deck.sideboard_cards() if deck else []
+            max_len = max(len(main_cards), len(side_cards), 1)
+            rows = []
+            for index in range(max_len):
+                rows.append({
+                    'main': main_cards[index] if index < len(main_cards) else None,
+                    'side': side_cards[index] if index < len(side_cards) else None,
+                })
+            deck_rows.append({'player': player, 'deck': deck, 'rows': rows})
+        return render_template('tournament/decklists.html', t=t, deck_rows=deck_rows)
 
     @app.route('/t/<int:tid>/players/<int:player_id>/deck')
     @login_required

--- a/app/models.py
+++ b/app/models.py
@@ -19,6 +19,7 @@ PERMISSION_GROUPS = {
         'manage': 'Create and manage tournaments',
         'join': 'Join tournaments',
         'approve_join': 'Approve tournament join requests',
+        'bulk_manage': 'Bulk edit tournaments',
     },
     'venues': {
         'manage': 'Create and manage venues, vendors, and artists',
@@ -303,6 +304,8 @@ class Tournament(db.Model):
     deck_build_time = db.Column(db.Integer, nullable=True)
     # Optional scheduled start time for tournament
     start_time = db.Column(db.DateTime, nullable=True)
+    started_at = db.Column(db.DateTime, nullable=True)
+    ended_at = db.Column(db.DateTime, nullable=True)
     # Judge assignments
     head_judge_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
     floor_judges = db.Column(db.Text, default='[]')  # store list of user ids as JSON

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1813,3 +1813,38 @@ ul.flashes {
     width: 100%;
   }
 }
+.venue-assets-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+.compact-table td {
+  padding: 0.35rem 0.5rem;
+}
+.bulk-select {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+  font-weight: 700;
+  margin-bottom: 0.75rem;
+}
+.inline-add-player summary {
+  cursor: pointer;
+  list-style: none;
+}
+.inline-add-player summary::-webkit-details-marker {
+  display: none;
+}
+.inline-add-player summary::after {
+  content: 'Expand';
+  align-self: center;
+  color: var(--accent, #2563eb);
+  font-weight: 700;
+}
+.inline-add-player[open] summary::after {
+  content: 'Collapse';
+}
+.decklist-xy-table th,
+.decklist-xy-table td {
+  vertical-align: top;
+}

--- a/app/templates/admin/artists.html
+++ b/app/templates/admin/artists.html
@@ -11,6 +11,7 @@
     <a class="btn secondary" href="{{ url_for('vendor_management') }}">Vendor Management</a>
   </div>
 </section>
+{% if can_manage_venues %}
 <section class="panel-card">
   <h3>Create Artist Profile</h3>
   <form method="post" class="compact-form">
@@ -25,29 +26,32 @@
     <button class="btn" type="submit">Create Artist</button>
   </form>
 </section>
+{% endif %}
 <section class="panel-card">
   <h3>Artists</h3>
   {% if artists %}
   <table class="table">
-    <thead><tr><th>Name</th><th>Website</th><th>Booth</th><th>Venue</th><th>Services</th><th></th></tr></thead>
+    <thead><tr><th>Name</th><th>Website</th><th>Booth</th><th>Venue</th><th>Services</th>{% if can_manage_venues %}<th></th>{% endif %}</tr></thead>
     <tbody>
       {% for artist in artists %}
-      <tr>
+      <tr id="artist-{{ artist.id }}">
         <td>
+          {% if can_manage_venues %}
           <form id="artist-form-{{ artist.id }}" method="post" action="{{ url_for('update_artist', artist_id=artist.id) }}"></form>
           <input form="artist-form-{{ artist.id }}" name="name" value="{{ artist.name }}" required>
+          {% else %}<strong>{{ artist.name }}</strong>{% endif %}
         </td>
-        <td><input form="artist-form-{{ artist.id }}" name="website" type="url" value="{{ artist.website or '' }}"></td>
-        <td><input form="artist-form-{{ artist.id }}" name="booth_number" value="{{ artist.booth_number or '' }}"></td>
-        <td><select form="artist-form-{{ artist.id }}" name="venue_id"><option value="">No venue</option>{% for venue in venues %}<option value="{{ venue.id }}"{% if artist.venue_id == venue.id %} selected{% endif %}>{{ venue.name }}</option>{% endfor %}</select></td>
-        <td><textarea form="artist-form-{{ artist.id }}" name="services_provided" rows="2">{{ artist.services_provided or '' }}</textarea></td>
-        <td><button form="artist-form-{{ artist.id }}" class="btn" type="submit">Save</button></td>
+        <td>{% if can_manage_venues %}<input form="artist-form-{{ artist.id }}" name="website" type="url" value="{{ artist.website or '' }}">{% elif artist.website %}<a href="{{ artist.website }}" target="_blank" rel="noopener">Website</a>{% else %}-{% endif %}</td>
+        <td>{% if can_manage_venues %}<input form="artist-form-{{ artist.id }}" name="booth_number" value="{{ artist.booth_number or '' }}">{% else %}{{ artist.booth_number or '-' }}{% endif %}</td>
+        <td>{% if can_manage_venues %}<select form="artist-form-{{ artist.id }}" name="venue_id"><option value="">No venue</option>{% for venue in venues %}<option value="{{ venue.id }}"{% if artist.venue_id == venue.id %} selected{% endif %}>{{ venue.name }}</option>{% endfor %}</select>{% else %}{{ artist.venue.name if artist.venue else 'No venue' }}{% endif %}</td>
+        <td>{% if can_manage_venues %}<textarea form="artist-form-{{ artist.id }}" name="services_provided" rows="2">{{ artist.services_provided or '' }}</textarea>{% else %}{{ artist.services_provided or '-' }}{% endif %}</td>
+        {% if can_manage_venues %}<td><button form="artist-form-{{ artist.id }}" class="btn" type="submit">Save</button></td>{% endif %}
       </tr>
       {% endfor %}
     </tbody>
   </table>
   {% else %}
-  <p>No artist profiles created yet.</p>
+  <p>No artists available.</p>
   {% endif %}
 </section>
 {% endblock %}

--- a/app/templates/admin/vendors.html
+++ b/app/templates/admin/vendors.html
@@ -11,6 +11,7 @@
     <a class="btn secondary" href="{{ url_for('artist_management') }}">Artist Profiles</a>
   </div>
 </section>
+{% if can_manage_venues %}
 <section class="panel-card">
   <h3>Create Vendor</h3>
   <form method="post" class="compact-form">
@@ -25,29 +26,32 @@
     <button class="btn" type="submit">Create Vendor</button>
   </form>
 </section>
+{% endif %}
 <section class="panel-card">
   <h3>Vendors</h3>
   {% if vendors %}
   <table class="table">
-    <thead><tr><th>Name</th><th>Website</th><th>Booth</th><th>Venue</th><th>Services</th><th></th></tr></thead>
+    <thead><tr><th>Name</th><th>Website</th><th>Booth</th><th>Venue</th><th>Services</th>{% if can_manage_venues %}<th></th>{% endif %}</tr></thead>
     <tbody>
       {% for vendor in vendors %}
-      <tr>
+      <tr id="vendor-{{ vendor.id }}">
         <td>
+          {% if can_manage_venues %}
           <form id="vendor-form-{{ vendor.id }}" method="post" action="{{ url_for('update_vendor', vendor_id=vendor.id) }}"></form>
           <input form="vendor-form-{{ vendor.id }}" name="name" value="{{ vendor.name }}" required>
+          {% else %}<strong>{{ vendor.name }}</strong>{% endif %}
         </td>
-        <td><input form="vendor-form-{{ vendor.id }}" name="website" type="url" value="{{ vendor.website or '' }}"></td>
-        <td><input form="vendor-form-{{ vendor.id }}" name="booth_number" value="{{ vendor.booth_number or '' }}"></td>
-        <td><select form="vendor-form-{{ vendor.id }}" name="venue_id"><option value="">No venue</option>{% for venue in venues %}<option value="{{ venue.id }}"{% if vendor.venue_id == venue.id %} selected{% endif %}>{{ venue.name }}</option>{% endfor %}</select></td>
-        <td><textarea form="vendor-form-{{ vendor.id }}" name="services_provided" rows="2">{{ vendor.services_provided or '' }}</textarea></td>
-        <td><button form="vendor-form-{{ vendor.id }}" class="btn" type="submit">Save</button></td>
+        <td>{% if can_manage_venues %}<input form="vendor-form-{{ vendor.id }}" name="website" type="url" value="{{ vendor.website or '' }}">{% elif vendor.website %}<a href="{{ vendor.website }}" target="_blank" rel="noopener">Website</a>{% else %}-{% endif %}</td>
+        <td>{% if can_manage_venues %}<input form="vendor-form-{{ vendor.id }}" name="booth_number" value="{{ vendor.booth_number or '' }}">{% else %}{{ vendor.booth_number or '-' }}{% endif %}</td>
+        <td>{% if can_manage_venues %}<select form="vendor-form-{{ vendor.id }}" name="venue_id"><option value="">No venue</option>{% for venue in venues %}<option value="{{ venue.id }}"{% if vendor.venue_id == venue.id %} selected{% endif %}>{{ venue.name }}</option>{% endfor %}</select>{% else %}{{ vendor.venue.name if vendor.venue else 'No venue' }}{% endif %}</td>
+        <td>{% if can_manage_venues %}<textarea form="vendor-form-{{ vendor.id }}" name="services_provided" rows="2">{{ vendor.services_provided or '' }}</textarea>{% else %}{{ vendor.services_provided or '-' }}{% endif %}</td>
+        {% if can_manage_venues %}<td><button form="vendor-form-{{ vendor.id }}" class="btn" type="submit">Save</button></td>{% endif %}
       </tr>
       {% endfor %}
     </tbody>
   </table>
   {% else %}
-  <p>No vendors created yet.</p>
+  <p>No vendors available.</p>
   {% endif %}
 </section>
 {% endblock %}

--- a/app/templates/admin/venues.html
+++ b/app/templates/admin/venues.html
@@ -4,13 +4,14 @@
   <div class="page-header__title">
     <span class="eyebrow">Admin</span>
     <h2>Venue Management</h2>
-    <p class="page-description">Create venues and manage the vendor and artist subpages for event locations.</p>
+    <p class="page-description">Create venues and view venue assets available through tournament membership.</p>
   </div>
   <div class="page-header__actions">
     <a class="btn secondary" href="{{ url_for('vendor_management') }}">Vendor Management</a>
     <a class="btn secondary" href="{{ url_for('artist_management') }}">Artist Profiles</a>
   </div>
 </section>
+{% if can_manage_venues %}
 <section class="panel-card">
   <h3>Create Venue</h3>
   <form method="post" class="compact-form">
@@ -21,28 +22,59 @@
     <button class="btn" type="submit">Create Venue</button>
   </form>
 </section>
+{% endif %}
 <section class="panel-card">
   <h3>Venues</h3>
   {% if venues %}
   <table class="table">
-    <thead><tr><th>Name</th><th>Website</th><th>Address</th><th>Notes</th><th></th></tr></thead>
+    <thead><tr><th>Name</th><th>Website</th><th>Address</th><th>Notes</th>{% if can_manage_venues %}<th></th>{% endif %}</tr></thead>
     <tbody>
       {% for venue in venues %}
       <tr>
         <td>
+          {% if can_manage_venues %}
           <form id="venue-form-{{ venue.id }}" method="post" action="{{ url_for('update_venue', venue_id=venue.id) }}"></form>
           <input form="venue-form-{{ venue.id }}" name="name" value="{{ venue.name }}" required>
+          {% else %}
+          <strong>{{ venue.name }}</strong>
+          {% endif %}
         </td>
-        <td><input form="venue-form-{{ venue.id }}" name="website" type="url" value="{{ venue.website or '' }}"></td>
-        <td><textarea form="venue-form-{{ venue.id }}" name="address" rows="2">{{ venue.address or '' }}</textarea></td>
-        <td><textarea form="venue-form-{{ venue.id }}" name="notes" rows="2">{{ venue.notes or '' }}</textarea></td>
-        <td><button form="venue-form-{{ venue.id }}" class="btn" type="submit">Save</button></td>
+        <td>
+          {% if can_manage_venues %}<input form="venue-form-{{ venue.id }}" name="website" type="url" value="{{ venue.website or '' }}">{% elif venue.website %}<a href="{{ venue.website }}" target="_blank" rel="noopener">Website</a>{% else %}-{% endif %}
+        </td>
+        <td>{% if can_manage_venues %}<textarea form="venue-form-{{ venue.id }}" name="address" rows="2">{{ venue.address or '' }}</textarea>{% else %}{{ venue.address or '-' }}{% endif %}</td>
+        <td>{% if can_manage_venues %}<textarea form="venue-form-{{ venue.id }}" name="notes" rows="2">{{ venue.notes or '' }}</textarea>{% else %}{{ venue.notes or '-' }}{% endif %}</td>
+        {% if can_manage_venues %}<td><button form="venue-form-{{ venue.id }}" class="btn" type="submit">Save</button></td>{% endif %}
+      </tr>
+      <tr>
+        <td colspan="{{ 5 if can_manage_venues else 4 }}">
+          <div class="venue-assets-grid">
+            <div>
+              <h4>Artists</h4>
+              {% if venue.artists %}
+              <table class="table compact-table"><tbody>{% for artist in venue.artists %}<tr><td><a href="{{ url_for('artist_management') }}#artist-{{ artist.id }}">{{ artist.name }}</a></td><td>{{ artist.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
+              {% else %}<p class="empty-state compact-empty">No artists.</p>{% endif %}
+            </div>
+            <div>
+              <h4>Vendors</h4>
+              {% if venue.vendors %}
+              <table class="table compact-table"><tbody>{% for vendor in venue.vendors %}<tr><td><a href="{{ url_for('vendor_management') }}#vendor-{{ vendor.id }}">{{ vendor.name }}</a></td><td>{{ vendor.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
+              {% else %}<p class="empty-state compact-empty">No vendors.</p>{% endif %}
+            </div>
+            <div>
+              <h4>Tournaments</h4>
+              {% if venue.tournaments %}
+              <table class="table compact-table"><tbody>{% for tournament in venue.tournaments %}<tr><td><a href="{{ url_for('view_tournament', tid=tournament.id) }}">{{ tournament.name }}</a></td><td>{{ tournament.start_time or '-' }}</td></tr>{% endfor %}</tbody></table>
+              {% else %}<p class="empty-state compact-empty">No tournaments.</p>{% endif %}
+            </div>
+          </div>
+        </td>
       </tr>
       {% endfor %}
     </tbody>
   </table>
   {% else %}
-  <p>No venues created yet.</p>
+  <p>No venues available.</p>
   {% endif %}
 </section>
 {% endblock %}

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -39,8 +39,8 @@
               <a class="dropdown-item" href="{{ url_for('leagues') }}">Leagues</a>
               <a class="dropdown-item" href="{{ url_for('staff_management') }}">Staff</a>
               <a class="dropdown-item" href="{{ url_for('schedule') }}">Schedule</a>
-              {% if current_user.has_permission('venues.manage') %}
-              <a class="dropdown-item" href="{{ url_for('venue_management') }}">Venue Management</a>
+              {% if current_user.has_permission('venues.manage') or current_user.is_authenticated %}
+              <a class="dropdown-item" href="{{ url_for('venue_management') }}">Venues</a>
               {% endif %}
             </div>
           </li>
@@ -49,8 +49,8 @@
           <li class="nav-item has-dropdown">
             <button class="nav-link" type="button" data-dropdown-toggle aria-expanded="false">Admin</button>
             <div class="dropdown-menu" role="menu">
-              {% if current_user.has_permission('venues.manage') %}
-              <a class="dropdown-item" href="{{ url_for('venue_management') }}">Venue Management</a>
+              {% if current_user.has_permission('venues.manage') or current_user.is_authenticated %}
+              <a class="dropdown-item" href="{{ url_for('venue_management') }}">Venues</a>
               {% endif %}
               {% if current_user.has_permission('users.manage') %}
               <a class="dropdown-item" href="{{ url_for('admin_users') }}">Manage Users</a>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,9 +12,33 @@
   {% endif %}
 </section>
 
+{% set can_bulk_edit = current_user.is_authenticated and current_user.has_permission('tournaments.bulk_manage') %}
+{% if can_bulk_edit %}
+<form method="post" action="{{ url_for('bulk_edit_tournaments') }}" class="bulk-tournament-form panel-card" onsubmit="return confirm('Apply this bulk action to selected tournaments?');">
+  <div class="section-heading"><div><h3>Bulk Edit Tournaments</h3><p>Select tournaments below, then add them to a venue, start, end, or delete them.</p></div></div>
+  <div class="form-grid two-column">
+    <label>Action
+      <select name="bulk_action" required>
+        <option value="">Choose action</option>
+        <option value="venue">Add to venue</option>
+        <option value="start">Start</option>
+        <option value="end">End</option>
+        <option value="delete">Delete</option>
+      </select>
+    </label>
+    <label>Venue for Add to venue
+      <select name="bulk_venue_id">
+        <option value="">No venue</option>
+        {% for venue in venues or [] %}<option value="{{ venue.id }}">{{ venue.name }}</option>{% endfor %}
+      </select>
+    </label>
+  </div>
+  <div class="form-actions"><button class="btn" type="submit">Apply Bulk Action</button></div>
+{% endif %}
 <ul class="cards">
   {% for t in tournaments %}
     <li class="card">
+      {% if can_bulk_edit %}<label class="bulk-select"><input type="checkbox" name="tournament_ids" value="{{ t.id }}"> Select for bulk edit</label>{% endif %}
       <div class="card-header">
         <h3 class="card-title"><a href="{{ url_for('view_tournament', tid=t.id) }}">{{ t.name }}</a></h3>
       </div>
@@ -52,4 +76,5 @@
     </li>
   {% endfor %}
 </ul>
+{% if can_bulk_edit %}</form>{% endif %}
 {% endblock %}

--- a/app/templates/tournament/decklists.html
+++ b/app/templates/tournament/decklists.html
@@ -1,0 +1,37 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header">
+  <div class="page-header__title">
+    <span class="eyebrow">Tournament Deck Lists</span>
+    <h2>{{ t.name }}</h2>
+    <p class="page-description">Player deck lists shown as x,y mainboard and sideboard tables.</p>
+  </div>
+  <div class="page-header__actions">
+    <a class="btn secondary" href="{{ url_for('view_tournament', tid=t.id) }}">Back to Tournament</a>
+  </div>
+</section>
+{% for row in deck_rows %}
+<section class="panel-card">
+  <div class="section-heading"><div><h3>{{ row.player.user.name }}</h3><p>{% if row.deck %}Main {{ row.deck.total_mainboard() }} · Side {{ row.deck.total_sideboard() }}{% if row.deck.is_submitted %} · Submitted{% else %} · Draft{% endif %}{% else %}No deck submitted{% endif %}</p></div></div>
+  {% if row.deck %}
+  <table class="table decklist-xy-table">
+    <thead><tr><th colspan="2">Mainboard (x,y)</th><th colspan="2">Sideboard (x,y)</th></tr><tr><th>x</th><th>y</th><th>x</th><th>y</th></tr></thead>
+    <tbody>
+      {% for card_row in row.rows %}
+      <tr>
+        <td>{{ card_row.main.count if card_row.main else '' }}</td>
+        <td>{{ card_row.main.name if card_row.main else '' }}</td>
+        <td>{{ card_row.side.count if card_row.side else '' }}</td>
+        <td>{{ card_row.side.name if card_row.side else '' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-state compact-empty">No deck submitted.</p>
+  {% endif %}
+</section>
+{% else %}
+<section class="panel-card"><p>No players registered.</p></section>
+{% endfor %}
+{% endblock %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -64,6 +64,7 @@
       <button class="btn ghost" type="submit">Set Rounds</button>
     </form>
     {% if t.format == 'Draft' %}<a class="btn ghost" href="{{ url_for('draft_seating', tid=t.id) }}">Draft Seating</a>{% endif %}
+    {% if can_view_player_decks %}<a class="btn ghost" href="{{ url_for('tournament_decklists', tid=t.id) }}">Player Deck Lists</a>{% endif %}
     <a class="btn ghost" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
   {% endif %}
 </section>
@@ -464,8 +465,8 @@ Sideboard
 {% endif %}
 
 {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
-<section class="inline-add-player panel-card">
-  <div class="section-heading"><div><h3>Add Players</h3><p>Add a single searched player, choose several existing people, or quick-create one new player.</p></div></div>
+<details class="inline-add-player panel-card">
+  <summary class="section-heading"><div><h3>Add Players</h3><p>Add a single searched player, choose several existing people, or quick-create one new player.</p></div></summary>
   <form method="post" action="{{ url_for('add_player_to_tournament', tid=t.id) }}" class="message-form add-player-form tournament-control-card">
     <div class="form-grid two-column">
       <div>
@@ -495,7 +496,7 @@ Sideboard
     </div>
     <div class="form-actions"><button class="btn" type="submit">Add Player(s)</button></div>
   </form>
-</section>
+</details>
 <script>
   document.addEventListener('DOMContentLoaded', function(){
     if(window.attachUserLookup){


### PR DESCRIPTION
### Motivation
- Implement bulk administration workflows so admins can add tournaments to venues, start, end, or delete many tournaments at once and have each action logged.  
- Restrict venue-related assets so users only see vendor/artist/tournament assets for venues they are part of via a tournament.  
- Surface player decklists as x,y tables and improve the tournament UI by making the Add Players pane collapsible and exposing a decklists subpage.  

### Description
- Persisted tournament lifecycle state by adding `started_at` and `ended_at` to the `Tournament` model and adding safe schema upgrades for those columns, and treat `ended_at` as finished in `tournament_is_complete`.  
- Added `tournaments.bulk_manage` permission and an admin bulk endpoint `POST /admin/tournaments/bulk` that supports actions `venue`, `start`, `end`, and `delete`, updates tournaments in the requested order, and logs each individual action to `TournamentLog` and `SiteLog`.  
- Enforced venue visibility: added `venue_ids_for_user` and `restrict_to_visible_venues` helpers and applied them to venue/vendor/artist listing routes so non-managers only see assets for venues they are associated with via tournaments.  
- UI and templates: added a bulk-edit form and selectable checkboxes on the tournaments index, a `tournament/decklists` subpage (`/t/<tid>/decklists`) that renders main/side lists as x,y tables, made the Add Players pane collapsible using `<details>`/`<summary>`, and updated `admin/venues`, `admin/vendors`, and `admin/artists` to show asset tables with links.  
- Minor: added supporting CSS for venue asset grids, bulk selection controls, collapsible summary UI, and decklist table styling.  

### Testing
- Ran the full test suite with `python -m pytest`; all tests passed (`46 passed`) with warnings only; no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f62c22c58832098f69d1cd3c81aea)

## Summary by Sourcery

Add tournament lifecycle tracking, bulk administration tools, venue-based visibility controls, and decklist/tournament UI improvements.

New Features:
- Track tournament lifecycle with started and ended timestamps that mark events as complete when finished.
- Provide a bulk tournament admin endpoint and UI to assign venues, start, end, or delete multiple tournaments at once with per-tournament logging.
- Expose a tournament decklists page that shows each player’s mainboard and sideboard as x,y tables and link it from the tournament view.

Enhancements:
- Restrict venue, vendor, and artist listings so non-managers only see assets for venues they participate in via tournaments, while still allowing authenticated users to browse their accessible venues.
- Update venue, vendor, and artist admin pages to support read-only views for non-managers and richer asset tables linking related entities.
- Make the Add Players section on the tournament page collapsible and add supporting styling for bulk selection, venue asset grids, and decklist tables.