### PR TITLE
Fix bulk tournament venue assignment

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3327,7 +3327,6 @@ def create_app():
     @app.route('/admin/tournaments/bulk', methods=['POST'])
     @login_required
     def bulk_edit_tournaments():
-        require_permission('admin.panel')
         require_permission('tournaments.bulk_manage')
         raw_ids = request.form.getlist('tournament_ids')
         tournament_ids = []
@@ -3346,9 +3345,13 @@ def create_app():
         count = 0
         now = datetime.utcnow()
         if action == 'venue':
-            venue_raw = request.form.get('bulk_venue_id')
-            venue_id = int(venue_raw) if venue_raw else None
-            if venue_id and not db.session.get(Venue, venue_id):
+            venue_raw = (request.form.get('bulk_venue_id') or '').strip()
+            try:
+                venue_id = int(venue_raw) if venue_raw else None
+            except ValueError:
+                flash('Selected venue was not found.', 'error')
+                return redirect(url_for('index'))
+            if venue_id is not None and not db.session.get(Venue, venue_id):
                 flash('Selected venue was not found.', 'error')
                 return redirect(url_for('index'))
             for tournament in ordered_tournaments:

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -1,8 +1,9 @@
+import json
 import random
 from itertools import product
 
 from app.app import db
-from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult
+from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult, Venue
 from app.pairing import pair_round, compute_standings
 from datetime import datetime
 
@@ -278,6 +279,67 @@ def test_bulk_register_adds_existing_users(client, session):
     assert existing_two.id in tournament_player_ids
     new_user = session.query(User).filter_by(name='New Person').one()
     assert new_user.id in tournament_player_ids
+
+
+def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session):
+    bulk_role = Role(
+        name='bulk venue manager',
+        permissions=json.dumps({'tournaments.bulk_manage': True}),
+        level=100,
+    )
+    user = User(email='bulk-venue-manager@example.com', name='Bulk Venue Manager', role=bulk_role)
+    user.set_password('secret')
+    tournament = Tournament(name='Bulk Venue Event', format='Modern')
+    venue = Venue(name='Bulk Venue')
+    session.add_all([bulk_role, user, tournament, venue])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/admin/tournaments/bulk',
+            data={
+                'bulk_action': 'venue',
+                'bulk_venue_id': str(venue.id),
+                'tournament_ids': [str(tournament.id)],
+            },
+        )
+
+    assert response.status_code == 302
+    assert response.location == '/'
+    session.expire_all()
+    assert session.get(Tournament, tournament.id).venue_id == venue.id
+
+
+def test_bulk_edit_tournaments_rejects_invalid_venue_id(client, session):
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(
+        email='bulk-invalid-venue-admin@example.com',
+        name='Bulk Invalid Admin',
+        role=admin_role,
+        is_admin=True,
+    )
+    admin.set_password('secret')
+    tournament = Tournament(name='Invalid Venue Event', format='Modern')
+    venue = Venue(name='Existing Venue')
+    session.add_all([admin, tournament, venue])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/admin/tournaments/bulk',
+            data={
+                'bulk_action': 'venue',
+                'bulk_venue_id': 'not-a-venue-id',
+                'tournament_ids': [str(tournament.id)],
+            },
+        )
+
+    assert response.status_code == 302
+    assert response.location == '/'
+    session.expire_all()
+    assert session.get(Tournament, tournament.id).venue_id is None
 
 
 def test_tournament_name_uses_format_timestamp_and_venue(client, session):


### PR DESCRIPTION
### Motivation
- The bulk "Add to venue" feature could raise on malformed venue IDs and unnecessarily required `admin.panel` access in addition to the intended `tournaments.bulk_manage` permission. 
- Make the endpoint robust for non-admin users permitted to perform bulk tournament operations and avoid internal errors for bad input.

### Description
- Remove the extra `require_permission('admin.panel')` check so the endpoint is gated by `require_permission('tournaments.bulk_manage')` only, matching the intended permission model in `app/app.py`.
- Add defensive parsing and validation of `bulk_venue_id` by trimming input, catching `ValueError` on `int()` conversion, and treating an empty value as `None`, and ensure existence checks only run for non-None IDs in `app/app.py`.
- Preserve the existing audit logging and venue assignment flow after validation succeeds in `app/app.py`.
- Add two regression tests in `tests/test_tournament.py` covering successful bulk venue assignment by a user with `tournaments.bulk_manage` and safe handling of an invalid `bulk_venue_id` value.

### Testing
- Added tests `test_bulk_edit_tournaments_adds_selected_tournament_to_venue` and `test_bulk_edit_tournaments_rejects_invalid_venue_id` and ran them with `pytest -q`, which passed.
- Ran the full test suite with `pytest -q` and observed `48 passed` (with warnings), confirming no regressions in existing behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f6afebffc8320a1ef98035db1dd8e)

## Summary by Sourcery

Relax bulk tournament venue assignment permissions and harden venue ID handling for bulk edits.

Bug Fixes:
- Allow users with only the tournaments.bulk_manage permission to perform bulk tournament venue assignments by removing the unnecessary admin.panel requirement.
- Prevent errors and invalid updates when a malformed or empty bulk_venue_id is submitted during bulk tournament edits by validating and safely rejecting bad input.

Tests:
- Add regression tests covering successful bulk venue assignment by a user with tournaments.bulk_manage and rejection of an invalid venue ID during bulk edits.