### PR TITLE
Harden image upload path handling and fix bulk tournament processing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -38,11 +38,12 @@ import urllib.request
 from collections import OrderedDict
 from urllib.parse import urlparse
 from sqlalchemy import inspect, text, or_
+from sqlalchemy.exc import SQLAlchemyError
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
-from werkzeug.utils import secure_filename
+from werkzeug.utils import safe_join, secure_filename
 from PIL import Image, ImageOps
 
 from . import card_db
@@ -1535,6 +1536,7 @@ def create_app():
         storage_dir = app.config.get('MEDIA_STORAGE_DIR')
         if not storage_dir:
             return None
+        storage_dir = os.path.realpath(storage_dir)
         try:
             file_storage.stream.seek(0)
             image = Image.open(file_storage.stream)
@@ -1549,10 +1551,19 @@ def create_app():
         except Exception:
             return None
         buffer.seek(0)
-        safe_prefix = ''.join(ch for ch in prefix if ch.isalnum()) or 'deck'
-        filename = f"{safe_prefix}_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}_{secrets.token_hex(4)}.png"
+        safe_prefix = ''.join(ch for ch in str(prefix) if ch.isalnum()) or 'deck'
+        filename = secure_filename(
+            f"{safe_prefix}_{datetime.utcnow().strftime('%Y%m%d%H%M%S')}_{secrets.token_hex(4)}.png"
+        )
+        if not filename:
+            return None
         os.makedirs(storage_dir, exist_ok=True)
-        path = os.path.join(storage_dir, filename)
+        path = safe_join(storage_dir, filename)
+        if not path:
+            return None
+        path = os.path.realpath(path)
+        if os.path.commonpath([storage_dir, path]) != storage_dir:
+            return None
         with open(path, 'wb') as handle:
             handle.write(buffer.read())
         return filename
@@ -3330,11 +3341,16 @@ def create_app():
         require_permission('tournaments.bulk_manage')
         raw_ids = request.form.getlist('tournament_ids')
         tournament_ids = []
+        seen_tournament_ids = set()
         for raw_id in raw_ids:
             try:
-                tournament_ids.append(int(raw_id))
+                tournament_id = int(raw_id)
             except (TypeError, ValueError):
                 continue
+            if tournament_id in seen_tournament_ids:
+                continue
+            seen_tournament_ids.add(tournament_id)
+            tournament_ids.append(tournament_id)
         action = (request.form.get('bulk_action') or '').strip()
         if not tournament_ids:
             flash('Select at least one tournament.', 'error')
@@ -3356,20 +3372,43 @@ def create_app():
                 return redirect(url_for('index'))
             for tournament in ordered_tournaments:
                 tournament.venue_id = venue_id
-                db.session.flush()
-                db.session.add(TournamentLog(tournament_id=tournament.id, action='bulk_set_venue', result='success', error=f'venue_id={venue_id}', user_id=current_user.id))
-                db.session.add(SiteLog(action='bulk_set_tournament_venue', result='success', error=f'tournament_id={tournament.id}; venue_id={venue_id}', user_id=current_user.id))
+                db.session.add(TournamentLog(
+                    tournament_id=tournament.id,
+                    action='bulk_set_venue',
+                    result='success',
+                    error=f'venue_id={venue_id}',
+                    user_id=current_user.id,
+                ))
+                db.session.add(SiteLog(
+                    action='bulk_set_tournament_venue',
+                    result='success',
+                    error=f'tournament_id={tournament.id}; venue_id={venue_id}',
+                    user_id=current_user.id,
+                ))
                 count += 1
         elif action == 'start':
             for tournament in ordered_tournaments:
                 tournament.started_at = now
                 if not tournament.start_time:
                     tournament.start_time = now
-                    tournament.name = format_tournament_name(tournament.format, tournament.start_time, extract_provided_tournament_name(tournament.name))
+                    tournament.name = format_tournament_name(
+                        tournament.format,
+                        tournament.start_time,
+                        extract_provided_tournament_name(tournament.name),
+                    )
                 tournament.ended_at = None
-                db.session.flush()
-                db.session.add(TournamentLog(tournament_id=tournament.id, action='bulk_start', result='success', user_id=current_user.id))
-                db.session.add(SiteLog(action='bulk_start_tournament', result='success', error=f'tournament_id={tournament.id}', user_id=current_user.id))
+                db.session.add(TournamentLog(
+                    tournament_id=tournament.id,
+                    action='bulk_start',
+                    result='success',
+                    user_id=current_user.id,
+                ))
+                db.session.add(SiteLog(
+                    action='bulk_start_tournament',
+                    result='success',
+                    error=f'tournament_id={tournament.id}',
+                    user_id=current_user.id,
+                ))
                 count += 1
         elif action == 'end':
             for tournament in ordered_tournaments:
@@ -3377,22 +3416,47 @@ def create_app():
                 tournament.round_timer_end = None
                 tournament.draft_timer_end = None
                 tournament.deck_timer_end = None
-                db.session.flush()
-                db.session.add(TournamentLog(tournament_id=tournament.id, action='bulk_end', result='success', user_id=current_user.id))
-                db.session.add(SiteLog(action='bulk_end_tournament', result='success', error=f'tournament_id={tournament.id}', user_id=current_user.id))
+                db.session.add(TournamentLog(
+                    tournament_id=tournament.id,
+                    action='bulk_end',
+                    result='success',
+                    user_id=current_user.id,
+                ))
+                db.session.add(SiteLog(
+                    action='bulk_end_tournament',
+                    result='success',
+                    error=f'tournament_id={tournament.id}',
+                    user_id=current_user.id,
+                ))
                 count += 1
         elif action == 'delete':
             for tournament in ordered_tournaments:
                 tid = tournament.id
                 name = tournament.name
-                db.session.add(TournamentLog(tournament_id=tid, action='bulk_delete', result='success', user_id=current_user.id))
-                db.session.add(SiteLog(action='bulk_delete_tournament', result='success', error=f'tournament_id={tid}; name={name}', user_id=current_user.id))
+                db.session.add(TournamentLog(
+                    tournament_id=tid,
+                    action='bulk_delete',
+                    result='success',
+                    user_id=current_user.id,
+                ))
+                db.session.add(SiteLog(
+                    action='bulk_delete_tournament',
+                    result='success',
+                    error=f'tournament_id={tid}; name={name}',
+                    user_id=current_user.id,
+                ))
                 db.session.delete(tournament)
                 count += 1
         else:
             flash('Choose a bulk action.', 'error')
             return redirect(url_for('index'))
-        db.session.commit()
+        try:
+            db.session.commit()
+        except SQLAlchemyError as exc:
+            db.session.rollback()
+            app.logger.exception('Bulk tournament action failed: %s', exc)
+            flash('Bulk action failed. Please try again or review the selected tournaments.', 'error')
+            return redirect(url_for('index'))
         flash(f'Bulk action applied to {count} tournament' + ('s' if count != 1 else '') + '.', 'success')
         return redirect(url_for('index'))
 

--- a/tests/test_decklists.py
+++ b/tests/test_decklists.py
@@ -126,6 +126,31 @@ def test_deck_image_upload_for_draft(client, session, user):
     assert other_tp.deck is None
 
 
+def test_deck_image_upload_sanitizes_generated_storage_path(client, session, user, app, tmp_path):
+    media_dir = tmp_path / 'media-root'
+    app.config['MEDIA_STORAGE_DIR'] = str(media_dir)
+    tournament = create_tournament(session, fmt='Draft')
+    tp = register_player(session, tournament, user)
+    login(client, user)
+
+    png_bytes = base64.b64decode(
+        'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO5lH2gAAAAASUVORK5CYII='
+    )
+    response = client.post(
+        f'/t/{tournament.id}/deck/image',
+        data={'deck_image': (io.BytesIO(png_bytes), '../../deck.png')},
+        content_type='multipart/form-data',
+    )
+
+    assert response.status_code == 302
+    session.refresh(tp)
+    assert tp.deck is not None and tp.deck.image_path
+    stored_path = os.path.realpath(os.path.join(app.config['MEDIA_STORAGE_DIR'], tp.deck.image_path))
+    expected_root = os.path.realpath(app.config['MEDIA_STORAGE_DIR'])
+    assert os.path.commonpath([expected_root, stored_path]) == expected_root
+    assert os.path.exists(stored_path)
+
+
 def test_deck_image_delete_removes_file(client, session, user, app):
     tournament = create_tournament(session, fmt='Draft')
     tp = register_player(session, tournament, user)

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -311,6 +311,68 @@ def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session
     assert session.get(Tournament, tournament.id).venue_id == venue.id
 
 
+def test_bulk_edit_tournaments_adds_multiple_unique_tournaments_to_venue(client, session):
+    bulk_role = Role(
+        name='bulk multi venue manager',
+        permissions=json.dumps({'tournaments.bulk_manage': True}),
+        level=100,
+    )
+    user = User(email='bulk-multi-venue-manager@example.com', name='Bulk Multi Venue Manager', role=bulk_role)
+    user.set_password('secret')
+    first = Tournament(name='Bulk Venue Event One', format='Modern')
+    second = Tournament(name='Bulk Venue Event Two', format='Legacy')
+    venue = Venue(name='Bulk Multi Venue')
+    session.add_all([bulk_role, user, first, second, venue])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/admin/tournaments/bulk',
+            data={
+                'bulk_action': 'venue',
+                'bulk_venue_id': str(venue.id),
+                'tournament_ids': [str(first.id), str(second.id)],
+            },
+        )
+
+    assert response.status_code == 302
+    assert response.location == '/'
+    session.expire_all()
+    assert session.get(Tournament, first.id).venue_id == venue.id
+    assert session.get(Tournament, second.id).venue_id == venue.id
+
+
+def test_bulk_edit_tournaments_ignores_duplicate_tournament_ids(client, session):
+    bulk_role = Role(
+        name='bulk duplicate venue manager',
+        permissions=json.dumps({'tournaments.bulk_manage': True}),
+        level=100,
+    )
+    user = User(email='bulk-duplicate-venue-manager@example.com', name='Bulk Duplicate Venue Manager', role=bulk_role)
+    user.set_password('secret')
+    tournament = Tournament(name='Bulk Duplicate Venue Event', format='Modern')
+    venue = Venue(name='Bulk Duplicate Venue')
+    session.add_all([bulk_role, user, tournament, venue])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/admin/tournaments/bulk',
+            data={
+                'bulk_action': 'venue',
+                'bulk_venue_id': str(venue.id),
+                'tournament_ids': [str(tournament.id), str(tournament.id), str(tournament.id)],
+            },
+        )
+
+    assert response.status_code == 302
+    assert response.location == '/'
+    session.expire_all()
+    assert session.get(Tournament, tournament.id).venue_id == venue.id
+
+
 def test_bulk_edit_tournaments_rejects_invalid_venue_id(client, session):
     admin_role = session.query(Role).filter_by(name='admin').one()
     admin = User(


### PR DESCRIPTION
### Motivation
- Prevent path traversal and unsafe filenames when saving uploaded images by ensuring files are written inside the configured media root. 
- Fix broken behavior when submitting duplicate tournament IDs (or multiple tournaments at once) for bulk actions so the same tournament isn't processed multiple times. 
- Avoid raising a 500 on commit failures during bulk operations by handling DB errors and showing a friendly message.

### Description
- Hardened `sanitize_image_upload` to resolve `MEDIA_STORAGE_DIR` with `os.path.realpath`, generate a secured filename with `secure_filename`, use `safe_join` to build the target path, and verify the final path is inside the media root before writing. 
- Deduplicated incoming `tournament_ids` in the `bulk_edit_tournaments` endpoint while preserving order using a `seen_tournament_ids` set. 
- Wrapped the final `db.session.commit()` in the bulk action handler with a `try/except SQLAlchemyError` block that rolls back, logs the exception, and flashes an error to the user. 
- Imported `SQLAlchemyError` and `safe_join` where needed. 
- Added regression tests: `test_bulk_edit_tournaments_adds_multiple_unique_tournaments_to_venue`, `test_bulk_edit_tournaments_ignores_duplicate_tournament_ids`, and `test_deck_image_upload_sanitizes_generated_storage_path` to cover the fixes.

### Testing
- Added unit tests and ran the full test suite with `pytest -q`, which completed successfully with `51 passed` and warnings about `datetime.utcnow()` deprecation. 
- Also ran targeted tests exercising the new behavior; the new and related tests passed (`7 passed` for focused runs and `3 passed` for smaller subsets shown while iterating). 
- `git diff --check` was performed to ensure there are no whitespace or diff issues (no problems found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f6e0731408320a7477d901f868539)

## Summary by Sourcery

Harden image upload path handling and make bulk tournament actions more robust and predictable.

Bug Fixes:
- Prevent uploaded deck images from escaping the configured media storage directory via unsafe or traversal-based filenames.
- Ensure bulk tournament edits ignore duplicate tournament IDs so each tournament is processed at most once.
- Handle database errors during bulk tournament actions gracefully by rolling back, logging, and showing an error instead of returning a 500.

Enhancements:
- Tighten image upload filename sanitization by enforcing a safe prefix, using a secured filename, and validating the final storage path.
- Simplify bulk tournament logging by batching changes and committing once after all updates.

Tests:
- Add regression tests covering multi-tournament venue assignment, duplicate tournament ID handling in bulk edits, and safe deck image upload storage paths.