### PR TITLE
Fix bulk tournament venue assignment

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -244,6 +244,8 @@ def create_app():
             Venue,
             Vendor,
             ArtistProfile,
+            SiteLog,
+            TournamentLog,
         )  # lazy import to avoid circular reference
 
         if 'user' in inspector.get_table_names():
@@ -265,6 +267,10 @@ def create_app():
         Venue.__table__.create(bind=db.engine, checkfirst=True)
         Vendor.__table__.create(bind=db.engine, checkfirst=True)
         ArtistProfile.__table__.create(bind=db.engine, checkfirst=True)
+
+        logs_engine = db.engines['logs']
+        SiteLog.__table__.create(bind=logs_engine, checkfirst=True)
+        TournamentLog.__table__.create(bind=logs_engine, checkfirst=True)
 
         if 'report' not in inspector.get_table_names():
             Report.__table__.create(bind=db.engine)

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,11 +14,11 @@
 
 {% set can_bulk_edit = current_user.is_authenticated and current_user.has_permission('tournaments.bulk_manage') %}
 {% if can_bulk_edit %}
-<form method="post" action="{{ url_for('bulk_edit_tournaments') }}" class="bulk-tournament-form panel-card" onsubmit="return confirm('Apply this bulk action to selected tournaments?');">
+<form id="bulk-tournament-form" method="post" action="{{ url_for('bulk_edit_tournaments') }}" class="bulk-tournament-form panel-card" onsubmit="return confirm('Apply this bulk action to selected tournaments?');">
   <div class="section-heading"><div><h3>Bulk Edit Tournaments</h3><p>Select tournaments below, then add them to a venue, start, end, or delete them.</p></div></div>
   <div class="form-grid two-column">
     <label>Action
-      <select name="bulk_action" required>
+      <select name="bulk_action" form="bulk-tournament-form" required>
         <option value="">Choose action</option>
         <option value="venue">Add to venue</option>
         <option value="start">Start</option>
@@ -27,18 +27,19 @@
       </select>
     </label>
     <label>Venue for Add to venue
-      <select name="bulk_venue_id">
+      <select name="bulk_venue_id" form="bulk-tournament-form">
         <option value="">No venue</option>
         {% for venue in venues or [] %}<option value="{{ venue.id }}">{{ venue.name }}</option>{% endfor %}
       </select>
     </label>
   </div>
   <div class="form-actions"><button class="btn" type="submit">Apply Bulk Action</button></div>
+</form>
 {% endif %}
 <ul class="cards">
   {% for t in tournaments %}
     <li class="card">
-      {% if can_bulk_edit %}<label class="bulk-select"><input type="checkbox" name="tournament_ids" value="{{ t.id }}"> Select for bulk edit</label>{% endif %}
+      {% if can_bulk_edit %}<label class="bulk-select"><input type="checkbox" name="tournament_ids" value="{{ t.id }}" form="bulk-tournament-form"> Select for bulk edit</label>{% endif %}
       <div class="card-header">
         <h3 class="card-title"><a href="{{ url_for('view_tournament', tid=t.id) }}">{{ t.name }}</a></h3>
       </div>
@@ -76,5 +77,4 @@
     </li>
   {% endfor %}
 </ul>
-{% if can_bulk_edit %}</form>{% endif %}
 {% endblock %}

--- a/tests/test_db_upgrade.py
+++ b/tests/test_db_upgrade.py
@@ -139,3 +139,20 @@ def test_role_level_column_added(tmp_path, monkeypatch):
         cols = [c['name'] for c in inspector.get_columns('role')]
         assert 'level' in cols
         db.session.remove()
+
+
+def test_log_tables_created_on_startup(tmp_path, monkeypatch):
+    db_path = tmp_path / "pre.db"
+    log_path = tmp_path / "logs.db"
+    sqlite3.connect(db_path).close()
+
+    monkeypatch.setenv("MTG_DB_PATH", str(db_path))
+    monkeypatch.setenv("MTG_LOG_DB_PATH", str(log_path))
+
+    app = create_app()
+    with app.app_context():
+        logs_inspector = inspect(db.engines['logs'])
+        tables = logs_inspector.get_table_names()
+        assert 'site_log' in tables
+        assert 'tournament_log' in tables
+        db.session.remove()

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -281,6 +281,32 @@ def test_bulk_register_adds_existing_users(client, session):
     assert new_user.id in tournament_player_ids
 
 
+def test_bulk_edit_tournament_controls_stay_bound_to_bulk_form(client, session):
+    bulk_role = Role(
+        name='bulk form manager',
+        permissions=json.dumps({'tournaments.bulk_manage': True, 'tournaments.manage': True}),
+        level=100,
+    )
+    user = User(email='bulk-form-manager@example.com', name='Bulk Form Manager', role=bulk_role)
+    user.set_password('secret')
+    tournament = Tournament(name='Bulk Form Event', format='Modern')
+    venue = Venue(name='Bulk Form Venue')
+    session.add_all([bulk_role, user, tournament, venue])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+        response = client.get('/')
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'id="bulk-tournament-form"' in html
+    assert 'name="bulk_action" form="bulk-tournament-form"' in html
+    assert 'name="bulk_venue_id" form="bulk-tournament-form"' in html
+    assert f'name="tournament_ids" value="{tournament.id}" form="bulk-tournament-form"' in html
+    assert html.index('</form>') < html.index('<ul class="cards">')
+
+
 def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session):
     bulk_role = Role(
         name='bulk venue manager',


### PR DESCRIPTION
### Motivation
- The bulk-add-to-venue flow could fail in-browser because per-card delete forms nested inside the tournament list could prevent selected tournament checkboxes and controls from submitting together. 
- Bulk venue updates write audit logs and can fail if the logs tables are not present on startup. 
- Add regression tests to prevent regressions in the bulk form binding and ensure log tables are created during app init.

### Description
- Update `app/templates/index.html` to give the bulk controls a stable `id` (`bulk-tournament-form`), close the bulk form before rendering the tournament cards, and bind the `bulk_action`, `bulk_venue_id`, and `tournament_ids` inputs to that form using the `form` attribute so nested per-card forms cannot break bulk submissions. 
- Update `create_app` in `app/app.py` to ensure `SiteLog` and `TournamentLog` tables are created on the `logs` bind (`db.engines['logs']`) at startup so logging from bulk actions can succeed. 
- Add regression tests in `tests/test_tournament.py` (`test_bulk_edit_tournament_controls_stay_bound_to_bulk_form`) and `tests/test_db_upgrade.py` (`test_log_tables_created_on_startup`) to validate the markup and startup behavior. 

### Testing
- Ran the added regression tests `pytest -q tests/test_tournament.py::test_bulk_edit_tournament_controls_stay_bound_to_bulk_form` and `pytest -q tests/test_db_upgrade.py::test_log_tables_created_on_startup`, which passed. 
- Ran the bulk-related tournament tests `pytest -q tests/test_tournament.py::test_bulk_edit_tournaments_adds_selected_tournament_to_venue tests/test_tournament.py::test_bulk_edit_tournaments_adds_multiple_unique_tournaments_to_venue tests/test_tournament.py::test_bulk_edit_tournaments_ignores_duplicate_tournament_ids tests/test_tournament.py::test_bulk_edit_tournaments_rejects_invalid_venue_id`, which passed. 
- Ran the full test suite with `pytest -q`, and all tests passed (`53 passed`) with a number of deprecation warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f705f00dc8320a452efb94a493b20)

## Summary by Sourcery

Fix bulk tournament venue assignment so bulk controls submit correctly and logging tables exist at startup.

Bug Fixes:
- Ensure bulk tournament action controls and checkboxes submit through a dedicated bulk form instead of being broken by nested per-tournament forms.
- Create site and tournament log tables on the logs database at application startup so bulk action logging does not fail when tables are missing.

Tests:
- Add a regression test to verify bulk edit controls remain bound to the bulk form in the tournaments index page.
- Add a regression test to verify log tables are created on startup against the logs database bind.