### PR TITLE
Fix tournament bulk venue assignment and bulk form markup

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -493,7 +493,14 @@ def create_app():
         tournaments = db.session.query(Tournament).order_by(Tournament.created_at.desc()).all()
         visible_tournaments = [t for t in tournaments if not tournament_is_complete(t)]
         player_counts = {t.id: len(t.players) for t in visible_tournaments}
-        venues = db.session.query(Venue).order_by(Venue.name).all() if current_user.is_authenticated and current_user.has_permission('tournaments.bulk_manage') else []
+        can_bulk_edit_tournaments = (
+            current_user.is_authenticated
+            and (
+                current_user.has_permission('tournaments.bulk_manage')
+                or current_user.has_permission('tournaments.manage')
+            )
+        )
+        venues = db.session.query(Venue).order_by(Venue.name).all() if can_bulk_edit_tournaments else []
         return render_template('index.html', tournaments=visible_tournaments, player_counts=player_counts,
                                venues=venues, server_now=datetime.utcnow())
 
@@ -3344,7 +3351,12 @@ def create_app():
     @app.route('/admin/tournaments/bulk', methods=['POST'])
     @login_required
     def bulk_edit_tournaments():
-        require_permission('tournaments.bulk_manage')
+        if not (
+            current_user.has_permission('tournaments.bulk_manage')
+            or current_user.has_permission('tournaments.manage')
+        ):
+            log_site('unauthorized_access', 'failure', 'tournaments.bulk_manage')
+            abort(403)
         raw_ids = request.form.getlist('tournament_ids')
         tournament_ids = []
         seen_tournament_ids = set()

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -12,13 +12,19 @@
   {% endif %}
 </section>
 
-{% set can_bulk_edit = current_user.is_authenticated and current_user.has_permission('tournaments.bulk_manage') %}
+{% set can_manage_tournaments = current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+{% set can_bulk_edit = current_user.is_authenticated and (current_user.has_permission('tournaments.bulk_manage') or can_manage_tournaments) %}
+{% if can_manage_tournaments %}
+  {% for t in tournaments %}
+  <form id="delete-tournament-form-{{ t.id }}" method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');"></form>
+  {% endfor %}
+{% endif %}
 {% if can_bulk_edit %}
 <form id="bulk-tournament-form" method="post" action="{{ url_for('bulk_edit_tournaments') }}" class="bulk-tournament-form panel-card" onsubmit="return confirm('Apply this bulk action to selected tournaments?');">
   <div class="section-heading"><div><h3>Bulk Edit Tournaments</h3><p>Select tournaments below, then add them to a venue, start, end, or delete them.</p></div></div>
   <div class="form-grid two-column">
     <label>Action
-      <select name="bulk_action" form="bulk-tournament-form" required>
+      <select name="bulk_action" required>
         <option value="">Choose action</option>
         <option value="venue">Add to venue</option>
         <option value="start">Start</option>
@@ -27,19 +33,18 @@
       </select>
     </label>
     <label>Venue for Add to venue
-      <select name="bulk_venue_id" form="bulk-tournament-form">
+      <select name="bulk_venue_id">
         <option value="">No venue</option>
         {% for venue in venues or [] %}<option value="{{ venue.id }}">{{ venue.name }}</option>{% endfor %}
       </select>
     </label>
   </div>
   <div class="form-actions"><button class="btn" type="submit">Apply Bulk Action</button></div>
-</form>
 {% endif %}
 <ul class="cards">
   {% for t in tournaments %}
     <li class="card">
-      {% if can_bulk_edit %}<label class="bulk-select"><input type="checkbox" name="tournament_ids" value="{{ t.id }}" form="bulk-tournament-form"> Select for bulk edit</label>{% endif %}
+      {% if can_bulk_edit %}<label class="bulk-select"><input type="checkbox" name="tournament_ids" value="{{ t.id }}"> Select for bulk edit</label>{% endif %}
       <div class="card-header">
         <h3 class="card-title"><a href="{{ url_for('view_tournament', tid=t.id) }}">{{ t.name }}</a></h3>
       </div>
@@ -62,12 +67,10 @@
         <span><strong>Timer</strong><span class="timer" data-timer-end="{{ end.isoformat() }}Z" data-server-now="{{ server_now.isoformat() }}Z" data-tournament-id="{{ t.id }}" data-tournament-name="{{ t.name }}"{% if ttype %} data-timer-type="{{ ttype }}"{% endif %}></span></span>
         {% endif %}
       </div>
-      {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+      {% if can_manage_tournaments %}
       <div class="card-actions">
         <a class="btn secondary" href="{{ url_for('edit_tournament', tid=t.id) }}">Edit</a>
-        <form method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');">
-          <button class="btn danger" type="submit">Delete</button>
-        </form>
+        <button form="delete-tournament-form-{{ t.id }}" class="btn danger" type="submit">Delete</button>
       </div>
       {% endif %}
     </li>
@@ -77,4 +80,7 @@
     </li>
   {% endfor %}
 </ul>
+{% if can_bulk_edit %}
+</form>
+{% endif %}
 {% endblock %}

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -301,11 +301,42 @@ def test_bulk_edit_tournament_controls_stay_bound_to_bulk_form(client, session):
     html = response.get_data(as_text=True)
     assert response.status_code == 200
     assert 'id="bulk-tournament-form"' in html
-    assert 'name="bulk_action" form="bulk-tournament-form"' in html
-    assert 'name="bulk_venue_id" form="bulk-tournament-form"' in html
-    assert f'name="tournament_ids" value="{tournament.id}" form="bulk-tournament-form"' in html
-    assert html.index('</form>') < html.index('<ul class="cards">')
+    assert 'name="bulk_action" required' in html
+    assert 'name="bulk_venue_id"' in html
+    assert f'name="tournament_ids" value="{tournament.id}"' in html
+    assert html.index('<form id="bulk-tournament-form"') < html.index('<ul class="cards">')
+    assert html.index('<ul class="cards">') < html.index('</form>', html.index('<ul class="cards">'))
 
+
+
+def test_tournament_manager_can_bulk_add_tournament_to_venue(client, session):
+    manager_role = session.query(Role).filter_by(name='manager').one()
+    user = User(email='manager-bulk-venue@example.com', name='Manager Bulk Venue', role=manager_role)
+    user.set_password('secret')
+    tournament = Tournament(name='Manager Bulk Venue Event', format='Modern')
+    venue = Venue(name='Manager Bulk Venue')
+    session.add_all([user, tournament, venue])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+        page = client.get('/')
+        response = client.post(
+            '/admin/tournaments/bulk',
+            data={
+                'bulk_action': 'venue',
+                'bulk_venue_id': str(venue.id),
+                'tournament_ids': [str(tournament.id)],
+            },
+        )
+
+    html = page.get_data(as_text=True)
+    assert page.status_code == 200
+    assert 'id="bulk-tournament-form"' in html
+    assert response.status_code == 302
+    assert response.location == '/'
+    session.expire_all()
+    assert session.get(Tournament, tournament.id).venue_id == venue.id
 
 def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session):
     bulk_role = Role(


### PR DESCRIPTION
### Motivation
- Managers who can edit tournaments (`tournaments.manage`) should be able to perform bulk actions (for example, add tournaments to a venue) the same way admins with `tournaments.bulk_manage` can.
- The bulk form relied on detached `form` attributes which made checkbox submission fragile and prevented managers from using the bulk workflow in some browsers.
- Per-tournament delete controls were implemented as nested forms, which can cause issues with markup and submission behavior.

### Description
- Allow users with either `tournaments.bulk_manage` or `tournaments.manage` to access the bulk tournament endpoint by replacing `require_permission('tournaments.bulk_manage')` with an explicit permission check in `bulk_edit_tournaments` in `app/app.py`.
- Expose venue choices on the index page to users who can perform bulk actions by setting `can_bulk_edit_tournaments` and providing `venues` to the index template in `app/app.py`.
- Move the bulk checkboxes physically inside the bulk form and remove reliance on detached `form` attributes, and close the bulk form after the tournament list in `app/templates/index.html` to ensure checkboxes are submitted correctly.
- Move per-tournament delete forms out of the card markup and bind the delete button to external forms to avoid nested form conflicts in `app/templates/index.html`.
- Update `tests/test_tournament.py` to reflect the markup changes and add `test_tournament_manager_can_bulk_add_tournament_to_venue` to cover the manager permission path.

### Testing
- Ran the full test suite with `pytest -q`, and all tests passed (`54 passed`) with some deprecation warnings observed but not failing the suite.
- Ran focused tests around tournament bulk behavior (`tests/test_tournament.py`), which passed and include the new manager bulk-add regression test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f735465d48320ba05f27e9cbaec63)

## Summary by Sourcery

Allow tournament managers to use the bulk tournament actions and fix bulk form and delete controls markup so bulk operations and deletions submit reliably across browsers.

New Features:
- Enable users with standard tournament management permissions to perform bulk tournament actions previously restricted to bulk managers.

Bug Fixes:
- Ensure bulk tournament checkboxes and controls are properly enclosed within the bulk form so selected tournaments are correctly submitted.
- Resolve issues caused by nested delete forms in tournament cards by binding delete buttons to external forms.
- Expose venue options on the index page whenever a user is allowed to perform bulk tournament actions, avoiding missing data for bulk venue assignment.

Tests:
- Adjust existing tournament bulk-edit markup tests to reflect the new form structure and add coverage for managers bulk-assigning tournaments to venues.