### PR TITLE
Move tournament venue bulk-add into per-venue workspace and harden password/token handling

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -25,7 +25,6 @@ import math
 import os
 import random
 import click
-import hashlib
 import psutil
 import json
 import base64
@@ -43,6 +42,8 @@ from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.asymmetric import padding
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives import hmac as crypto_hmac
 from werkzeug.utils import safe_join, secure_filename
 from PIL import Image, ImageOps
 
@@ -143,7 +144,12 @@ def create_app():
         seed_bytes = seed_env.encode()
         seed_display = seed_env
     global PASSWORD_KEY, PASSWORD_SEED
-    PASSWORD_KEY = hashlib.sha256(seed_bytes).digest()
+    PASSWORD_KEY = HKDF(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=None,
+        info=b'walter password seed key',
+    ).derive(seed_bytes)
     PASSWORD_SEED = seed_display
 
     db.init_app(app)
@@ -500,9 +506,8 @@ def create_app():
                 or current_user.has_permission('tournaments.manage')
             )
         )
-        venues = db.session.query(Venue).order_by(Venue.name).all() if can_bulk_edit_tournaments else []
         return render_template('index.html', tournaments=visible_tournaments, player_counts=player_counts,
-                               venues=venues, server_now=datetime.utcnow())
+                               server_now=datetime.utcnow())
 
     def _send_mailgun_email(to_email, subject, text):
         api_key = app.config.get('MAILGUN_API_KEY')
@@ -543,7 +548,10 @@ def create_app():
         return request.remote_addr or 'unknown'
 
     def _hash_reset_token(token):
-        return hashlib.sha256(token.encode()).hexdigest()
+        key_material = app.config['SECRET_KEY'].encode()
+        hmac_ctx = crypto_hmac.HMAC(key_material, hashes.SHA256())
+        hmac_ctx.update(token.encode())
+        return hmac_ctx.finalize().hex()
 
     def _send_password_reset_email(user, token):
         reset_url = url_for('password_reset_token', token=token, _external=True)
@@ -2689,6 +2697,113 @@ def create_app():
             flash('Venue updated.', 'success')
         return redirect(url_for('venue_management'))
 
+    def _get_visible_venue_or_404(venue_id):
+        venue = db.session.get(Venue, venue_id)
+        if not venue:
+            abort(404)
+        if current_user.has_permission('venues.manage'):
+            return venue
+        if venue.id not in venue_ids_for_user(current_user):
+            abort(403)
+        return venue
+
+    @app.route('/admin/venues/<int:venue_id>')
+    @login_required
+    def venue_detail(venue_id):
+        venue = _get_visible_venue_or_404(venue_id)
+        current_tournaments = (
+            db.session.query(Tournament)
+            .filter(Tournament.venue_id == venue.id)
+            .order_by(Tournament.start_time.desc().nullslast(), Tournament.created_at.desc())
+            .all()
+        )
+        available_tournaments = (
+            db.session.query(Tournament)
+            .filter(or_(Tournament.venue_id.is_(None), Tournament.venue_id != venue.id))
+            .order_by(Tournament.start_time.desc().nullslast(), Tournament.created_at.desc())
+            .all()
+        )
+        unassigned_tournaments = (
+            db.session.query(Tournament)
+            .filter(Tournament.venue_id.is_(None))
+            .order_by(Tournament.start_time.desc().nullslast(), Tournament.created_at.desc())
+            .all()
+        )
+        return render_template(
+            'admin/venue_detail.html',
+            venue=venue,
+            current_tournaments=current_tournaments,
+            available_tournaments=available_tournaments,
+            unassigned_tournaments=unassigned_tournaments,
+            can_bulk_add_tournaments=(
+                current_user.has_permission('venues.manage')
+                and (
+                    current_user.has_permission('tournaments.bulk_manage')
+                    or current_user.has_permission('tournaments.manage')
+                )
+            ),
+        )
+
+    @app.route('/admin/venues/<int:venue_id>/tournaments/bulk-add', methods=['POST'])
+    @login_required
+    def bulk_add_tournaments_to_venue(venue_id):
+        require_permission('venues.manage')
+        if not (
+            current_user.has_permission('tournaments.bulk_manage')
+            or current_user.has_permission('tournaments.manage')
+        ):
+            log_site('unauthorized_access', 'failure', 'venues.manage+tournaments.bulk_manage')
+            abort(403)
+        venue = db.session.get(Venue, venue_id)
+        if not venue:
+            abort(404)
+        raw_ids = request.form.getlist('tournament_ids')
+        tournament_ids = []
+        seen_tournament_ids = set()
+        for raw_id in raw_ids:
+            try:
+                tournament_id = int(raw_id)
+            except (TypeError, ValueError):
+                continue
+            if tournament_id in seen_tournament_ids:
+                continue
+            seen_tournament_ids.add(tournament_id)
+            tournament_ids.append(tournament_id)
+        if not tournament_ids:
+            flash('Select at least one tournament to add to this venue.', 'error')
+            return redirect(url_for('venue_detail', venue_id=venue.id))
+        tournaments = db.session.query(Tournament).filter(Tournament.id.in_(tournament_ids)).all()
+        tournament_by_id = {t.id: t for t in tournaments}
+        ordered_tournaments = [tournament_by_id[tid] for tid in tournament_ids if tid in tournament_by_id]
+        count = 0
+        for tournament in ordered_tournaments:
+            if tournament.venue_id == venue.id:
+                continue
+            tournament.venue_id = venue.id
+            db.session.add(TournamentLog(
+                tournament_id=tournament.id,
+                action='bulk_add_to_venue',
+                result='success',
+                error=f'venue_id={venue.id}',
+                user_id=current_user.id,
+            ))
+            db.session.add(SiteLog(
+                action='venue_bulk_add_tournaments',
+                result='success',
+                error=f'venue_id={venue.id}; tournament_id={tournament.id}',
+                user_id=current_user.id,
+            ))
+            count += 1
+        try:
+            db.session.commit()
+        except SQLAlchemyError as exc:
+            db.session.rollback()
+            app.logger.exception('Venue tournament bulk add failed: %s', exc)
+            flash('Bulk add failed. Please try again or review the selected tournaments.', 'error')
+            return redirect(url_for('venue_detail', venue_id=venue.id))
+        flash(f'Added {count} tournament' + ('s' if count != 1 else '') + f' to {venue.name}.', 'success')
+        return redirect(url_for('venue_detail', venue_id=venue.id))
+
     @app.route('/admin/venues/vendors', methods=['GET', 'POST'])
     @login_required
     def vendor_management():
@@ -3206,7 +3321,7 @@ def create_app():
 
         return render_template(
             'admin/panel.html',
-            encryption_type='SHA256+salt',
+            encryption_type='Werkzeug password hashing',
             db_size=fmt_bytes(db_size),
             ram_usage=fmt_bytes(mem_usage),
             cpu_usage=cpu_usage,
@@ -3378,33 +3493,7 @@ def create_app():
         ordered_tournaments = [tournament_by_id[tid] for tid in tournament_ids if tid in tournament_by_id]
         count = 0
         now = datetime.utcnow()
-        if action == 'venue':
-            venue_raw = (request.form.get('bulk_venue_id') or '').strip()
-            try:
-                venue_id = int(venue_raw) if venue_raw else None
-            except ValueError:
-                flash('Selected venue was not found.', 'error')
-                return redirect(url_for('index'))
-            if venue_id is not None and not db.session.get(Venue, venue_id):
-                flash('Selected venue was not found.', 'error')
-                return redirect(url_for('index'))
-            for tournament in ordered_tournaments:
-                tournament.venue_id = venue_id
-                db.session.add(TournamentLog(
-                    tournament_id=tournament.id,
-                    action='bulk_set_venue',
-                    result='success',
-                    error=f'venue_id={venue_id}',
-                    user_id=current_user.id,
-                ))
-                db.session.add(SiteLog(
-                    action='bulk_set_tournament_venue',
-                    result='success',
-                    error=f'tournament_id={tournament.id}; venue_id={venue_id}',
-                    user_id=current_user.id,
-                ))
-                count += 1
-        elif action == 'start':
+        if action == 'start':
             for tournament in ordered_tournaments:
                 tournament.started_at = now
                 if not tournament.start_time:

--- a/app/models.py
+++ b/app/models.py
@@ -5,13 +5,13 @@ from sqlalchemy import UniqueConstraint
 import uuid
 import os
 import random
-import hashlib
 import json
 import secrets
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from werkzeug.security import check_password_hash, generate_password_hash
 
 # Permission groups and default role permissions
 PERMISSION_GROUPS = {
@@ -124,16 +124,16 @@ class User(db.Model, UserMixin):
     lock_reason = db.Column(db.Text, nullable=True)
 
     def set_password(self, pw):
-        self.salt = os.urandom(16).hex()
-        self.password_hash = hashlib.sha256((self.salt + pw).encode()).hexdigest()
+        self.salt = 'werkzeug'
+        self.password_hash = generate_password_hash(pw)
         self.failed_login_count = 0
         self.locked_at = None
         self.lock_reason = None
 
     def check_password(self, pw):
-        if not self.password_hash or not self.salt:
+        if not self.password_hash:
             return False
-        return self.password_hash == hashlib.sha256((self.salt + pw).encode()).hexdigest()
+        return check_password_hash(self.password_hash, pw)
 
     def generate_keys(self, password):
         private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
@@ -238,11 +238,11 @@ class PendingRegistration(db.Model):
     tournament = db.relationship('Tournament')
 
     def set_password(self, pw):
-        self.salt = os.urandom(16).hex()
-        self.password_hash = hashlib.sha256((self.salt + pw).encode()).hexdigest()
+        self.salt = 'werkzeug'
+        self.password_hash = generate_password_hash(pw)
 
     def check_password(self, pw):
-        return self.password_hash == hashlib.sha256((self.salt + pw).encode()).hexdigest()
+        return check_password_hash(self.password_hash, pw)
 
     @staticmethod
     def generate_pin():

--- a/app/templates/admin/venue_detail.html
+++ b/app/templates/admin/venue_detail.html
@@ -1,0 +1,100 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header">
+  <div class="page-header__title">
+    <span class="eyebrow">Venue Management</span>
+    <h2>{{ venue.name }}</h2>
+    <p class="page-description">Manage this venue's tournaments, artists, and vendors from one place.</p>
+  </div>
+  <div class="page-header__actions">
+    <a class="btn secondary" href="{{ url_for('venue_management') }}">All Venues</a>
+    <a class="btn secondary" href="{{ url_for('vendor_management') }}">Vendors</a>
+    <a class="btn secondary" href="{{ url_for('artist_management') }}">Artists</a>
+  </div>
+</section>
+
+<section class="panel-card">
+  <h3>Venue Details</h3>
+  <div class="card-meta">
+    <span><strong>Website</strong>{% if venue.website %}<a href="{{ venue.website }}" target="_blank" rel="noopener">{{ venue.website }}</a>{% else %}-{% endif %}</span>
+    <span><strong>Address</strong>{{ venue.address or '-' }}</span>
+    <span><strong>Notes</strong>{{ venue.notes or '-' }}</span>
+  </div>
+</section>
+
+<section class="panel-card">
+  <div class="section-heading">
+    <div>
+      <h3>Tournaments at {{ venue.name }}</h3>
+      <p>These tournaments are already assigned to this venue.</p>
+    </div>
+  </div>
+  {% if current_tournaments %}
+  <table class="table compact-table">
+    <thead><tr><th>Name</th><th>Format</th><th>Start Time</th><th>Players</th></tr></thead>
+    <tbody>
+      {% for tournament in current_tournaments %}
+      <tr>
+        <td><a href="{{ url_for('view_tournament', tid=tournament.id) }}">{{ tournament.name }}</a></td>
+        <td>{{ tournament.format }}</td>
+        <td>{{ tournament.start_time or '-' }}</td>
+        <td>{{ tournament.players|length }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-state compact-empty">No tournaments are assigned to this venue yet.</p>
+  {% endif %}
+</section>
+
+{% if can_bulk_add_tournaments %}
+<section class="panel-card">
+  <div class="section-heading">
+    <div>
+      <h3>Bulk Add Tournaments</h3>
+      <p>Populate this venue by selecting tournaments below, then add them in one action.</p>
+    </div>
+  </div>
+  {% if available_tournaments %}
+  <form method="post" action="{{ url_for('bulk_add_tournaments_to_venue', venue_id=venue.id) }}" onsubmit="return confirm('Add selected tournaments to this venue?');">
+    <table class="table compact-table">
+      <thead><tr><th>Select</th><th>Name</th><th>Current Venue</th><th>Format</th><th>Start Time</th></tr></thead>
+      <tbody>
+        {% for tournament in available_tournaments %}
+        <tr>
+          <td><input type="checkbox" name="tournament_ids" value="{{ tournament.id }}"{% if tournament in unassigned_tournaments %} checked{% endif %}></td>
+          <td><a href="{{ url_for('view_tournament', tid=tournament.id) }}">{{ tournament.name }}</a></td>
+          <td>{{ tournament.venue.name if tournament.venue else 'No venue' }}</td>
+          <td>{{ tournament.format }}</td>
+          <td>{{ tournament.start_time or '-' }}</td>
+        </tr>
+        {% endfor %}
+      </tbody>
+    </table>
+    <div class="form-actions"><button class="btn" type="submit">Add Selected to {{ venue.name }}</button></div>
+  </form>
+  {% else %}
+  <p class="empty-state compact-empty">No other tournaments are available to add.</p>
+  {% endif %}
+</section>
+{% endif %}
+
+<section class="panel-card">
+  <h3>Venue Assets</h3>
+  <div class="venue-assets-grid">
+    <div>
+      <h4>Artists</h4>
+      {% if venue.artists %}
+      <table class="table compact-table"><tbody>{% for artist in venue.artists %}<tr><td><a href="{{ url_for('artist_management') }}#artist-{{ artist.id }}">{{ artist.name }}</a></td><td>{{ artist.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
+      {% else %}<p class="empty-state compact-empty">No artists.</p>{% endif %}
+    </div>
+    <div>
+      <h4>Vendors</h4>
+      {% if venue.vendors %}
+      <table class="table compact-table"><tbody>{% for vendor in venue.vendors %}<tr><td><a href="{{ url_for('vendor_management') }}#vendor-{{ vendor.id }}">{{ vendor.name }}</a></td><td>{{ vendor.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
+      {% else %}<p class="empty-state compact-empty">No vendors.</p>{% endif %}
+    </div>
+  </div>
+</section>
+{% endblock %}

--- a/app/templates/admin/venues.html
+++ b/app/templates/admin/venues.html
@@ -4,7 +4,7 @@
   <div class="page-header__title">
     <span class="eyebrow">Admin</span>
     <h2>Venue Management</h2>
-    <p class="page-description">Create venues and view venue assets available through tournament membership.</p>
+    <p class="page-description">Create venues, open each venue workspace, and manage venue assets.</p>
   </div>
   <div class="page-header__actions">
     <a class="btn secondary" href="{{ url_for('vendor_management') }}">Vendor Management</a>
@@ -27,7 +27,7 @@
   <h3>Venues</h3>
   {% if venues %}
   <table class="table">
-    <thead><tr><th>Name</th><th>Website</th><th>Address</th><th>Notes</th>{% if can_manage_venues %}<th></th>{% endif %}</tr></thead>
+    <thead><tr><th>Name</th><th>Website</th><th>Address</th><th>Notes</th><th>Workspace</th>{% if can_manage_venues %}<th></th>{% endif %}</tr></thead>
     <tbody>
       {% for venue in venues %}
       <tr>
@@ -44,10 +44,10 @@
         </td>
         <td>{% if can_manage_venues %}<textarea form="venue-form-{{ venue.id }}" name="address" rows="2">{{ venue.address or '' }}</textarea>{% else %}{{ venue.address or '-' }}{% endif %}</td>
         <td>{% if can_manage_venues %}<textarea form="venue-form-{{ venue.id }}" name="notes" rows="2">{{ venue.notes or '' }}</textarea>{% else %}{{ venue.notes or '-' }}{% endif %}</td>
-        {% if can_manage_venues %}<td><button form="venue-form-{{ venue.id }}" class="btn" type="submit">Save</button></td>{% endif %}
+        <td><a class="btn secondary" href="{{ url_for('venue_detail', venue_id=venue.id) }}">Open Venue</a></td>{% if can_manage_venues %}<td><button form="venue-form-{{ venue.id }}" class="btn" type="submit">Save</button></td>{% endif %}
       </tr>
       <tr>
-        <td colspan="{{ 5 if can_manage_venues else 4 }}">
+        <td colspan="{{ 6 if can_manage_venues else 5 }}">
           <div class="venue-assets-grid">
             <div>
               <h4>Artists</h4>
@@ -64,7 +64,7 @@
             <div>
               <h4>Tournaments</h4>
               {% if venue.tournaments %}
-              <table class="table compact-table"><tbody>{% for tournament in venue.tournaments %}<tr><td><a href="{{ url_for('view_tournament', tid=tournament.id) }}">{{ tournament.name }}</a></td><td>{{ tournament.start_time or '-' }}</td></tr>{% endfor %}</tbody></table>
+              <table class="table compact-table"><tbody>{% for tournament in venue.tournaments %}<tr><td><a href="{{ url_for('view_tournament', tid=tournament.id) }}">{{ tournament.name }}</a></td><td>{{ tournament.start_time or '-' }}</td></tr>{% endfor %}</tbody></table><div class="form-actions"><a class="btn secondary" href="{{ url_for('venue_detail', venue_id=venue.id) }}">Manage tournament list</a></div>
               {% else %}<p class="empty-state compact-empty">No tournaments.</p>{% endif %}
             </div>
           </div>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -21,21 +21,14 @@
 {% endif %}
 {% if can_bulk_edit %}
 <form id="bulk-tournament-form" method="post" action="{{ url_for('bulk_edit_tournaments') }}" class="bulk-tournament-form panel-card" onsubmit="return confirm('Apply this bulk action to selected tournaments?');">
-  <div class="section-heading"><div><h3>Bulk Edit Tournaments</h3><p>Select tournaments below, then add them to a venue, start, end, or delete them.</p></div></div>
+  <div class="section-heading"><div><h3>Bulk Edit Tournaments</h3><p>Select tournaments below, then start, end, or delete them. Venue assignment is managed from each venue page.</p></div></div>
   <div class="form-grid two-column">
     <label>Action
       <select name="bulk_action" required>
         <option value="">Choose action</option>
-        <option value="venue">Add to venue</option>
         <option value="start">Start</option>
         <option value="end">End</option>
         <option value="delete">Delete</option>
-      </select>
-    </label>
-    <label>Venue for Add to venue
-      <select name="bulk_venue_id">
-        <option value="">No venue</option>
-        {% for venue in venues or [] %}<option value="{{ venue.id }}">{{ venue.name }}</option>{% endfor %}
       </select>
     </label>
   </div>

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -302,7 +302,8 @@ def test_bulk_edit_tournament_controls_stay_bound_to_bulk_form(client, session):
     assert response.status_code == 200
     assert 'id="bulk-tournament-form"' in html
     assert 'name="bulk_action" required' in html
-    assert 'name="bulk_venue_id"' in html
+    assert 'name="bulk_venue_id"' not in html
+    assert 'Venue assignment is managed from each venue page.' in html
     assert f'name="tournament_ids" value="{tournament.id}"' in html
     assert html.index('<form id="bulk-tournament-form"') < html.index('<ul class="cards">')
     assert html.index('<ul class="cards">') < html.index('</form>', html.index('<ul class="cards">'))
@@ -320,28 +321,27 @@ def test_tournament_manager_can_bulk_add_tournament_to_venue(client, session):
 
     with client:
         assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
-        page = client.get('/')
+        page = client.get(f'/admin/venues/{venue.id}')
         response = client.post(
-            '/admin/tournaments/bulk',
+            f'/admin/venues/{venue.id}/tournaments/bulk-add',
             data={
-                'bulk_action': 'venue',
-                'bulk_venue_id': str(venue.id),
                 'tournament_ids': [str(tournament.id)],
             },
         )
 
     html = page.get_data(as_text=True)
     assert page.status_code == 200
-    assert 'id="bulk-tournament-form"' in html
+    assert 'Bulk Add Tournaments' in html
+    assert f'name="tournament_ids" value="{tournament.id}"' in html
     assert response.status_code == 302
-    assert response.location == '/'
+    assert response.location == f'/admin/venues/{venue.id}'
     session.expire_all()
     assert session.get(Tournament, tournament.id).venue_id == venue.id
 
 def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session):
     bulk_role = Role(
         name='bulk venue manager',
-        permissions=json.dumps({'tournaments.bulk_manage': True}),
+        permissions=json.dumps({'tournaments.bulk_manage': True, 'venues.manage': True}),
         level=100,
     )
     user = User(email='bulk-venue-manager@example.com', name='Bulk Venue Manager', role=bulk_role)
@@ -354,16 +354,14 @@ def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session
     with client:
         assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
         response = client.post(
-            '/admin/tournaments/bulk',
+            f'/admin/venues/{venue.id}/tournaments/bulk-add',
             data={
-                'bulk_action': 'venue',
-                'bulk_venue_id': str(venue.id),
                 'tournament_ids': [str(tournament.id)],
             },
         )
 
     assert response.status_code == 302
-    assert response.location == '/'
+    assert response.location == f'/admin/venues/{venue.id}'
     session.expire_all()
     assert session.get(Tournament, tournament.id).venue_id == venue.id
 
@@ -371,7 +369,7 @@ def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session
 def test_bulk_edit_tournaments_adds_multiple_unique_tournaments_to_venue(client, session):
     bulk_role = Role(
         name='bulk multi venue manager',
-        permissions=json.dumps({'tournaments.bulk_manage': True}),
+        permissions=json.dumps({'tournaments.bulk_manage': True, 'venues.manage': True}),
         level=100,
     )
     user = User(email='bulk-multi-venue-manager@example.com', name='Bulk Multi Venue Manager', role=bulk_role)
@@ -385,16 +383,14 @@ def test_bulk_edit_tournaments_adds_multiple_unique_tournaments_to_venue(client,
     with client:
         assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
         response = client.post(
-            '/admin/tournaments/bulk',
+            f'/admin/venues/{venue.id}/tournaments/bulk-add',
             data={
-                'bulk_action': 'venue',
-                'bulk_venue_id': str(venue.id),
                 'tournament_ids': [str(first.id), str(second.id)],
             },
         )
 
     assert response.status_code == 302
-    assert response.location == '/'
+    assert response.location == f'/admin/venues/{venue.id}'
     session.expire_all()
     assert session.get(Tournament, first.id).venue_id == venue.id
     assert session.get(Tournament, second.id).venue_id == venue.id
@@ -403,7 +399,7 @@ def test_bulk_edit_tournaments_adds_multiple_unique_tournaments_to_venue(client,
 def test_bulk_edit_tournaments_ignores_duplicate_tournament_ids(client, session):
     bulk_role = Role(
         name='bulk duplicate venue manager',
-        permissions=json.dumps({'tournaments.bulk_manage': True}),
+        permissions=json.dumps({'tournaments.bulk_manage': True, 'venues.manage': True}),
         level=100,
     )
     user = User(email='bulk-duplicate-venue-manager@example.com', name='Bulk Duplicate Venue Manager', role=bulk_role)
@@ -416,21 +412,19 @@ def test_bulk_edit_tournaments_ignores_duplicate_tournament_ids(client, session)
     with client:
         assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
         response = client.post(
-            '/admin/tournaments/bulk',
+            f'/admin/venues/{venue.id}/tournaments/bulk-add',
             data={
-                'bulk_action': 'venue',
-                'bulk_venue_id': str(venue.id),
                 'tournament_ids': [str(tournament.id), str(tournament.id), str(tournament.id)],
             },
         )
 
     assert response.status_code == 302
-    assert response.location == '/'
+    assert response.location == f'/admin/venues/{venue.id}'
     session.expire_all()
     assert session.get(Tournament, tournament.id).venue_id == venue.id
 
 
-def test_bulk_edit_tournaments_rejects_invalid_venue_id(client, session):
+def test_venue_bulk_add_rejects_empty_tournament_selection(client, session):
     admin_role = session.query(Role).filter_by(name='admin').one()
     admin = User(
         email='bulk-invalid-venue-admin@example.com',
@@ -447,16 +441,14 @@ def test_bulk_edit_tournaments_rejects_invalid_venue_id(client, session):
     with client:
         assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
         response = client.post(
-            '/admin/tournaments/bulk',
+            f'/admin/venues/{venue.id}/tournaments/bulk-add',
             data={
-                'bulk_action': 'venue',
-                'bulk_venue_id': 'not-a-venue-id',
-                'tournament_ids': [str(tournament.id)],
+                'tournament_ids': [],
             },
         )
 
     assert response.status_code == 302
-    assert response.location == '/'
+    assert response.location == f'/admin/venues/{venue.id}'
     session.expire_all()
     assert session.get(Tournament, tournament.id).venue_id is None
 


### PR DESCRIPTION
### Motivation
- Make venue assignment for tournaments more discoverable and scoped by moving bulk venue assignment out of the global tournaments list and into a per-venue workspace.
- Remove use of ad-hoc SHA-256 usage for password/token operations and replace with stronger, standard primitives to fix cryptographic vulnerabilities.

### Description
- Removed the venue-assignment controls from the global bulk-edit form on the tournaments index and restricted that form to `start`, `end`, and `delete` actions only by updating `app/templates/index.html` and the index context rendering in `create_app()`.
- Added a per-venue workspace route and view `venue_detail` at `GET /admin/venues/<venue_id>` and a new bulk handler `POST /admin/venues/<venue_id>/tournaments/bulk-add` which lists available/unassigned tournaments, de-duplicates selected IDs, assigns selected tournaments to the venue, and logs actions to `TournamentLog` and `SiteLog` in `app/app.py` and a new template `app/templates/admin/venue_detail.html`.
- Updated the venue management table (`app/templates/admin/venues.html`) to provide an `Open Venue` workspace link and a shortcut to manage the venue's tournament list.
- Replaced weak custom SHA-256 password hashing with Werkzeug's `generate_password_hash` / `check_password_hash` for `User` and `PendingRegistration` in `app/models.py` and removed reliance on a custom `salt` field for hashing storage.
- Replaced the reset-token hashing with a keyed HMAC using the app `SECRET_KEY` (via `crypto_hmac.HMAC(..., hashes.SHA256())`) and derived the internal `PASSWORD_KEY` using `HKDF` (`cryptography.hazmat.primitives.kdf.hkdf.HKDF`) in `app/app.py` to strengthen key derivation and token HMACs.
- Updated tests to reflect the new venue-scoped bulk-add workflow and the change in the tournaments page UI (`tests/test_tournament.py`).

### Testing
- Compiled updated modules with `python -m py_compile app/app.py app/models.py` to catch syntax errors, which succeeded. 
- Ran the full test suite with `pytest -q`, producing `54 passed` (all tests passed) with warnings only about deprecated `utcnow` usage. 
- Also exercised targeted tests during development (see earlier `pytest` runs for `tests/test_tournament.py` and `tests/test_users.py`) which passed after updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f7d583ab083208fbff38ed0ecaa3d)

## Summary by Sourcery

Scope tournament venue assignment into a per-venue workspace and replace custom SHA-256-based password and token handling with stronger, standard cryptographic primitives.

New Features:
- Introduce a per-venue admin workspace page that lists a venue’s tournaments and supports bulk-adding tournaments to that venue.

Bug Fixes:
- Strengthen password hashing and reset-token generation by replacing ad-hoc SHA-256 usage with vetted library mechanisms and keyed HMACs.

Enhancements:
- Restrict the global tournaments bulk-edit form to start, end, and delete actions and direct venue assignment to venue-specific pages.
- Expose venue workspaces and tournament management shortcuts from the venue management table and venue detail page.
- Improve admin panel encryption-type display to reflect the new password hashing approach.

Tests:
- Update tournament tests to cover the new venue-scoped bulk-add workflow, permissions, and the simplified tournaments bulk-edit UI.