### PR TITLE
Fix venue and tournament admin workflows

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -277,6 +277,18 @@ def create_app():
         logs_engine = db.engines['logs']
         SiteLog.__table__.create(bind=logs_engine, checkfirst=True)
         TournamentLog.__table__.create(bind=logs_engine, checkfirst=True)
+        logs_inspector = inspect(logs_engine)
+        log_tables = logs_inspector.get_table_names()
+        if 'site_log' in log_tables:
+            columns = [c['name'] for c in logs_inspector.get_columns('site_log')]
+            if 'user_id' not in columns:
+                with logs_engine.begin() as conn:
+                    conn.execute(text('ALTER TABLE site_log ADD COLUMN user_id INTEGER'))
+        if 'tournament_log' in log_tables:
+            columns = [c['name'] for c in logs_inspector.get_columns('tournament_log')]
+            if 'user_id' not in columns:
+                with logs_engine.begin() as conn:
+                    conn.execute(text('ALTER TABLE tournament_log ADD COLUMN user_id INTEGER'))
 
         if 'report' not in inspector.get_table_names():
             Report.__table__.create(bind=db.engine)
@@ -378,6 +390,31 @@ def create_app():
         if start == end:
             return str(start)
         return f"{start}-{end}"
+
+    def find_available_table_start(tournament):
+        _, _, tables_needed, _ = compute_table_allocation(tournament)
+        last_table = app.config.get('LAST_TABLE_NUMBER') or None
+        if tables_needed <= 1:
+            max_start = last_table or 1
+        elif last_table is not None:
+            max_start = last_table - tables_needed + 1
+            if max_start < 1:
+                return 1
+        else:
+            max_existing_end = 0
+            query = db.session.query(Tournament)
+            if getattr(tournament, 'id', None):
+                query = query.filter(Tournament.id != tournament.id)
+            for other in query.all():
+                _, other_end, other_tables, _ = compute_table_allocation(other)
+                if other_tables:
+                    max_existing_end = max(max_existing_end, other_end)
+            max_start = max(max_existing_end + 1, 1)
+        for candidate in range(1, max_start + 1):
+            errors, _, _, _, _ = validate_table_assignment(tournament, start_number=candidate)
+            if not errors:
+                return candidate
+        return max_start
 
     def validate_table_assignment(tournament, start_number=None):
         errors = []
@@ -2492,7 +2529,12 @@ def create_app():
         require_permission('tournaments.manage')
         leagues = db.session.query(League).order_by(League.name).all()
         venues = db.session.query(Venue).order_by(Venue.name).all()
-        template_context = {'leagues': leagues, 'venues': venues, 'formats': TOURNAMENT_FORMATS}
+        template_context = {
+            'leagues': leagues,
+            'venues': venues,
+            'formats': TOURNAMENT_FORMATS,
+            'suggested_start_table_number': 1,
+        }
         if request.method == 'POST':
             provided_name = request.form['name'].strip()
             fmt = request.form['format']
@@ -2518,12 +2560,15 @@ def create_app():
             if fmt != 'Draft':
                 is_cube = False
             join_requires_approval = request.form.get('join_requires_approval') == '1'
-            start_table_raw = (request.form.get('start_table_number') or '1').strip()
-            try:
-                start_table_number = int(start_table_raw)
-            except ValueError:
-                flash('Starting table number must be a whole number.', 'error')
-                return render_template('admin/new_tournament.html', **template_context)
+            start_table_raw = (request.form.get('start_table_number') or '').strip()
+            if start_table_raw:
+                try:
+                    start_table_number = int(start_table_raw)
+                except ValueError:
+                    flash('Starting table number must be a whole number.', 'error')
+                    return render_template('admin/new_tournament.html', **template_context)
+            else:
+                start_table_number = None
             name = format_tournament_name(fmt, start_time, provided_name)
             t = Tournament(name=name, format=fmt, cut=cut, structure=structure,
                            pairing_type=pairing_type,
@@ -2542,6 +2587,9 @@ def create_app():
             venue_id = request.form.get('venue_id')
             if venue_id:
                 t.venue_id = int(venue_id)
+            if start_table_number is None:
+                start_table_number = find_available_table_start(t)
+                t.start_table_number = start_table_number
             errors, _, _, _, _ = validate_table_assignment(t, start_number=start_table_number)
             if errors:
                 for message in errors:
@@ -2578,7 +2626,14 @@ def create_app():
         if not t:
             abort(404)
         venues = db.session.query(Venue).order_by(Venue.name).all()
-        template_context = {'t': t, 'venues': venues, 'formats': TOURNAMENT_FORMATS, 'provided_name': extract_provided_tournament_name(t.name)}
+        suggested_start_table_number = find_available_table_start(t)
+        template_context = {
+            't': t,
+            'venues': venues,
+            'formats': TOURNAMENT_FORMATS,
+            'provided_name': extract_provided_tournament_name(t.name),
+            'suggested_start_table_number': suggested_start_table_number,
+        }
         if request.method == 'POST':
             provided_name = request.form['name'].strip()
             new_format = request.form['format']
@@ -2599,12 +2654,15 @@ def create_app():
             rel = request.form.get('rules_enforcement_level', 'None') or 'None'
             is_cube = request.form.get('is_cube') == '1'
             join_requires_approval = request.form.get('join_requires_approval') == '1'
-            start_table_raw = (request.form.get('start_table_number') or str(t.start_table_number or 1)).strip()
-            try:
-                start_table_number = int(start_table_raw)
-            except ValueError:
-                flash('Starting table number must be a whole number.', 'error')
-                return render_template('admin/edit_tournament.html', **template_context)
+            start_table_raw = (request.form.get('start_table_number') or '').strip()
+            if start_table_raw:
+                try:
+                    start_table_number = int(start_table_raw)
+                except ValueError:
+                    flash('Starting table number must be a whole number.', 'error')
+                    return render_template('admin/edit_tournament.html', **template_context)
+            else:
+                start_table_number = None
 
             class _Preview:
                 pass
@@ -2612,9 +2670,12 @@ def create_app():
             preview = _Preview()
             preview.id = t.id
             preview.format = new_format
-            preview.start_table_number = start_table_number
+            preview.start_table_number = start_table_number or t.start_table_number or 1
             preview.players = t.players
             preview.name = provided_name or t.name
+            if start_table_number is None:
+                start_table_number = find_available_table_start(preview)
+                preview.start_table_number = start_table_number
             errors, _, _, _, _ = validate_table_assignment(preview, start_number=start_table_number)
             if errors:
                 for message in errors:
@@ -2804,6 +2865,30 @@ def create_app():
         flash(f'Added {count} tournament' + ('s' if count != 1 else '') + f' to {venue.name}.', 'success')
         return redirect(url_for('venue_detail', venue_id=venue.id))
 
+    def booth_number_conflict(venue_id, booth_number, *, vendor_id=None, artist_id=None):
+        booth = (booth_number or '').strip()
+        if not venue_id or not booth:
+            return None
+        vendor_query = db.session.query(Vendor).filter(
+            Vendor.venue_id == venue_id,
+            db.func.lower(Vendor.booth_number) == booth.lower(),
+        )
+        if vendor_id is not None:
+            vendor_query = vendor_query.filter(Vendor.id != vendor_id)
+        vendor = vendor_query.first()
+        if vendor:
+            return f'Booth {booth} is already assigned to vendor {vendor.name}.'
+        artist_query = db.session.query(ArtistProfile).filter(
+            ArtistProfile.venue_id == venue_id,
+            db.func.lower(ArtistProfile.booth_number) == booth.lower(),
+        )
+        if artist_id is not None:
+            artist_query = artist_query.filter(ArtistProfile.id != artist_id)
+        artist = artist_query.first()
+        if artist:
+            return f'Booth {booth} is already assigned to artist {artist.name}.'
+        return None
+
     @app.route('/admin/venues/vendors', methods=['GET', 'POST'])
     @login_required
     def vendor_management():
@@ -2818,18 +2903,24 @@ def create_app():
             if not name:
                 flash('Vendor name is required.', 'error')
             else:
-                vendor = Vendor(
-                    name=name,
-                    venue_id=int(request.form['venue_id']) if request.form.get('venue_id') else None,
-                    website=request.form.get('website', '').strip() or None,
-                    booth_number=request.form.get('booth_number', '').strip() or None,
-                    services_provided=request.form.get('services_provided', '').strip() or None,
-                )
-                db.session.add(vendor)
-                db.session.commit()
-                log_site('vendor_create', 'success', f'vendor_id={vendor.id}')
-                flash('Vendor created.', 'success')
-                return redirect(url_for('vendor_management'))
+                venue_id = int(request.form['venue_id']) if request.form.get('venue_id') else None
+                booth_number = request.form.get('booth_number', '').strip() or None
+                conflict = booth_number_conflict(venue_id, booth_number)
+                if conflict:
+                    flash(conflict, 'error')
+                else:
+                    vendor = Vendor(
+                        name=name,
+                        venue_id=venue_id,
+                        website=request.form.get('website', '').strip() or None,
+                        booth_number=booth_number,
+                        services_provided=request.form.get('services_provided', '').strip() or None,
+                    )
+                    db.session.add(vendor)
+                    db.session.commit()
+                    log_site('vendor_create', 'success', f'vendor_id={vendor.id}')
+                    flash('Vendor created.', 'success')
+                    return redirect(url_for('vendor_management'))
         vendors = restrict_to_visible_venues(db.session.query(Vendor), Vendor).order_by(Vendor.name).all()
         return render_template('admin/vendors.html', vendors=vendors, venues=venues, can_manage_venues=current_user.has_permission('venues.manage'))
 
@@ -2844,14 +2935,20 @@ def create_app():
         if not name:
             flash('Vendor name is required.', 'error')
         else:
-            vendor.name = name
-            vendor.venue_id = int(request.form['venue_id']) if request.form.get('venue_id') else None
-            vendor.website = request.form.get('website', '').strip() or None
-            vendor.booth_number = request.form.get('booth_number', '').strip() or None
-            vendor.services_provided = request.form.get('services_provided', '').strip() or None
-            db.session.commit()
-            log_site('vendor_update', 'success', f'vendor_id={vendor.id}')
-            flash('Vendor updated.', 'success')
+            venue_id = int(request.form['venue_id']) if request.form.get('venue_id') else None
+            booth_number = request.form.get('booth_number', '').strip() or None
+            conflict = booth_number_conflict(venue_id, booth_number, vendor_id=vendor.id)
+            if conflict:
+                flash(conflict, 'error')
+            else:
+                vendor.name = name
+                vendor.venue_id = venue_id
+                vendor.website = request.form.get('website', '').strip() or None
+                vendor.booth_number = booth_number
+                vendor.services_provided = request.form.get('services_provided', '').strip() or None
+                db.session.commit()
+                log_site('vendor_update', 'success', f'vendor_id={vendor.id}')
+                flash('Vendor updated.', 'success')
         return redirect(url_for('vendor_management'))
 
     @app.route('/admin/venues/artists', methods=['GET', 'POST'])
@@ -2868,18 +2965,24 @@ def create_app():
             if not name:
                 flash('Artist name is required.', 'error')
             else:
-                artist = ArtistProfile(
-                    name=name,
-                    venue_id=int(request.form['venue_id']) if request.form.get('venue_id') else None,
-                    website=request.form.get('website', '').strip() or None,
-                    booth_number=request.form.get('booth_number', '').strip() or None,
-                    services_provided=request.form.get('services_provided', '').strip() or None,
-                )
-                db.session.add(artist)
-                db.session.commit()
-                log_site('artist_create', 'success', f'artist_id={artist.id}')
-                flash('Artist profile created.', 'success')
-                return redirect(url_for('artist_management'))
+                venue_id = int(request.form['venue_id']) if request.form.get('venue_id') else None
+                booth_number = request.form.get('booth_number', '').strip() or None
+                conflict = booth_number_conflict(venue_id, booth_number)
+                if conflict:
+                    flash(conflict, 'error')
+                else:
+                    artist = ArtistProfile(
+                        name=name,
+                        venue_id=venue_id,
+                        website=request.form.get('website', '').strip() or None,
+                        booth_number=booth_number,
+                        services_provided=request.form.get('services_provided', '').strip() or None,
+                    )
+                    db.session.add(artist)
+                    db.session.commit()
+                    log_site('artist_create', 'success', f'artist_id={artist.id}')
+                    flash('Artist profile created.', 'success')
+                    return redirect(url_for('artist_management'))
         artists = restrict_to_visible_venues(db.session.query(ArtistProfile), ArtistProfile).order_by(ArtistProfile.name).all()
         return render_template('admin/artists.html', artists=artists, venues=venues, can_manage_venues=current_user.has_permission('venues.manage'))
 
@@ -2894,14 +2997,20 @@ def create_app():
         if not name:
             flash('Artist name is required.', 'error')
         else:
-            artist.name = name
-            artist.venue_id = int(request.form['venue_id']) if request.form.get('venue_id') else None
-            artist.website = request.form.get('website', '').strip() or None
-            artist.booth_number = request.form.get('booth_number', '').strip() or None
-            artist.services_provided = request.form.get('services_provided', '').strip() or None
-            db.session.commit()
-            log_site('artist_update', 'success', f'artist_id={artist.id}')
-            flash('Artist profile updated.', 'success')
+            venue_id = int(request.form['venue_id']) if request.form.get('venue_id') else None
+            booth_number = request.form.get('booth_number', '').strip() or None
+            conflict = booth_number_conflict(venue_id, booth_number, artist_id=artist.id)
+            if conflict:
+                flash(conflict, 'error')
+            else:
+                artist.name = name
+                artist.venue_id = venue_id
+                artist.website = request.form.get('website', '').strip() or None
+                artist.booth_number = booth_number
+                artist.services_provided = request.form.get('services_provided', '').strip() or None
+                db.session.commit()
+                log_site('artist_update', 'success', f'artist_id={artist.id}')
+                flash('Artist profile updated.', 'success')
         return redirect(url_for('artist_management'))
 
     @app.route('/admin/tournaments/<int:tid>/judges', methods=['GET','POST'])
@@ -4895,7 +5004,7 @@ def create_app():
                     flash('Passwords do not match.', 'error')
                     log_site('user_update', 'failure', 'password mismatch')
                     return redirect(redirect_target)
-                u.set_password(password)
+                u.set_password(password, unlock=False)
                 u.generate_keys(password)
                 log_site('admin_password_reset', 'success', f'user_id={u.id}')
             lock_action = request.form.get('account_lock_action')

--- a/app/models.py
+++ b/app/models.py
@@ -123,12 +123,13 @@ class User(db.Model, UserMixin):
     locked_at = db.Column(db.DateTime, nullable=True)
     lock_reason = db.Column(db.Text, nullable=True)
 
-    def set_password(self, pw):
+    def set_password(self, pw, *, unlock=True):
         self.salt = 'werkzeug'
         self.password_hash = generate_password_hash(pw)
         self.failed_login_count = 0
-        self.locked_at = None
-        self.lock_reason = None
+        if unlock:
+            self.locked_at = None
+            self.lock_reason = None
 
     def check_password(self, pw):
         if not self.password_hash:

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1848,3 +1848,32 @@ ul.flashes {
 .decklist-xy-table td {
   vertical-align: top;
 }
+
+.responsive-table {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.venue-management-table {
+  table-layout: fixed;
+  min-width: 900px;
+}
+
+.venue-management-table th:nth-child(5),
+.venue-management-table td:nth-child(5),
+.venue-management-table th:nth-child(6),
+.venue-management-table td:nth-child(6) {
+  width: 120px;
+}
+
+.venue-management-table input,
+.venue-management-table textarea {
+  width: 100%;
+  min-width: 0;
+}
+
+.venue-management-table .btn {
+  width: 100%;
+  justify-content: center;
+  white-space: normal;
+}

--- a/app/templates/admin/edit_tournament.html
+++ b/app/templates/admin/edit_tournament.html
@@ -83,7 +83,7 @@
       </tr>
       <tr>
         <td>Starting Table Number</td>
-        <td><input type="number" name="start_table_number" min="1" value="{{ request.form.get('start_table_number', t.start_table_number or 1) }}"></td>
+        <td><input type="number" name="start_table_number" min="1" value="{{ request.form.get('start_table_number', suggested_start_table_number) }}"></td>
       </tr>
       <tr>
         <td>Start Time</td>

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -77,7 +77,7 @@
       </tr>
       <tr>
         <td>Starting Table Number</td>
-        <td><input type="number" name="start_table_number" min="1" value="{{ request.form.get('start_table_number', 1) }}"></td>
+        <td><input type="number" name="start_table_number" min="1" value="{{ request.form.get('start_table_number', suggested_start_table_number) }}"></td>
       </tr>
       <tr>
         <td>Start Time</td>

--- a/app/templates/admin/venues.html
+++ b/app/templates/admin/venues.html
@@ -26,7 +26,7 @@
 <section class="panel-card">
   <h3>Venues</h3>
   {% if venues %}
-  <table class="table">
+  <div class="responsive-table"><table class="table venue-management-table">
     <thead><tr><th>Name</th><th>Website</th><th>Address</th><th>Notes</th><th>Workspace</th>{% if can_manage_venues %}<th></th>{% endif %}</tr></thead>
     <tbody>
       {% for venue in venues %}
@@ -72,7 +72,7 @@
       </tr>
       {% endfor %}
     </tbody>
-  </table>
+  </table></div>
   {% else %}
   <p>No venues available.</p>
   {% endif %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,8 @@
-Flask==3.0.3
+Flask==3.1.3
 Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
-cryptography==42.0.7
+cryptography==48.0.0
 psutil==5.9.8
 PyYAML==6.0.1
-Pillow==10.3.0
+Pillow==12.2.0
 waitress==3.0.2

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -484,3 +484,69 @@ def test_tournament_name_uses_format_timestamp_and_venue(client, session):
     tournament = session.query(Tournament).filter_by(format='Modern').one()
     assert tournament.name == 'Modern - 20260602 - 1930 - Store Championship'
     assert tournament.venue_id == venue.id
+
+
+def test_tournament_edit_auto_fills_lowest_contiguous_table_range(client, session, app):
+    app.config['LAST_TABLE_NUMBER'] = 20
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    user_role = session.query(Role).filter_by(name='user').one()
+    admin = User(email='admin-table-fill@example.com', name='Table Admin', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    blocker_one = Tournament(name='Blocker One', format='Modern', start_table_number=1)
+    blocker_two = Tournament(name='Blocker Two', format='Modern', start_table_number=4)
+    target = Tournament(name='Target Tables', format='Modern', start_table_number=10)
+    session.add_all([admin, blocker_one, blocker_two, target])
+    session.commit()
+    for tournament in (blocker_one, blocker_two, target):
+        for i in range(4):
+            user = User(email=f'table-{tournament.id}-{i}@example.com', name=f'Table {tournament.id} {i}', role=user_role)
+            session.add(user)
+            session.flush()
+            session.add(TournamentPlayer(tournament_id=tournament.id, user_id=user.id))
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            f'/admin/tournaments/{target.id}/edit',
+            data={
+                'name': 'Target Tables',
+                'format': 'Modern',
+                'structure': 'swiss',
+                'cut': 'none',
+                'round_length': '50',
+                'start_table_number': '',
+            },
+        )
+
+    assert response.status_code == 302
+    session.refresh(target)
+    assert target.start_table_number == 6
+
+
+def test_duplicate_booth_numbers_are_blocked_across_artists_and_vendors(client, session):
+    from app.models import ArtistProfile, Vendor
+
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(email='admin-booth@example.com', name='Booth Admin', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    venue = Venue(name='Booth Venue')
+    vendor = Vendor(name='Existing Vendor', venue=venue, booth_number='12')
+    session.add_all([admin, venue, vendor])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/admin/venues/artists',
+            data={
+                'name': 'Duplicate Artist',
+                'venue_id': str(venue.id),
+                'booth_number': '12',
+            },
+            follow_redirects=True,
+        )
+
+    assert response.status_code == 200
+    assert b'already assigned to vendor Existing Vendor' in response.data
+    assert session.query(ArtistProfile).filter_by(name='Duplicate Artist').first() is None

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -294,3 +294,36 @@ def test_admin_can_manually_lock_and_unlock_user(client, session):
     session.refresh(target)
     assert target.locked_at is None
     assert target.lock_reason is None
+
+
+def test_admin_password_change_rekeys_user_and_preserves_lock_without_unlock_action(client, session):
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    user_role = session.query(Role).filter_by(name='user').one()
+    admin = User(email='admin-rekey@example.com', name='Rekey Admin', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    target = User(email='rekey-target@example.com', name='Rekey Target', role=user_role)
+    target.set_password('old-secret')
+    target.generate_keys('old-secret')
+    target.locked_at = __import__('datetime').datetime.utcnow()
+    target.lock_reason = 'manual review'
+    session.add_all([admin, target])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            f'/admin/users/{target.id}/update',
+            data={
+                'email': target.email,
+                'password': 'new-secret',
+                'password_confirm': 'new-secret',
+                'account_lock_action': '',
+            },
+        )
+
+    assert response.status_code == 302
+    session.refresh(target)
+    assert target.check_password('new-secret')
+    assert target.decrypt_private_key('new-secret').startswith(b'-----BEGIN PRIVATE KEY-----')
+    assert target.locked_at is not None
+    assert target.lock_reason == 'manual review'


### PR DESCRIPTION
### Motivation
- Address several admin UX and correctness issues: layout overflow in venue management, broken bulk-adding of tournaments to venues on older installs, incorrect behaviour when admins change user passwords after the crypto/key changes, and duplicate booth assignments for artists/vendors.
- Remove known dependency vulnerabilities by upgrading packages to secure versions.
- Auto-fill a sensible starting table number for tournaments when the field is left blank, choosing the lowest contiguous range that fits the event.

### Description
- Updated dependency pins in `requirements.txt` to `Flask==3.1.3`, `cryptography==48.0.0`, and `Pillow==12.2.0` to resolve known vulnerabilities.
- Added a logs schema backfill for the logs DB to add missing `user_id` columns if present so older installs do not fail when bulk operations write `SiteLog`/`TournamentLog` entries (`app/app.py`).
- Implemented `find_available_table_start(...)` and wired blank `start_table_number` submissions to auto-fill the lowest contiguous range that fits the tournament, and surfaced a `suggested_start_table_number` into the new/edit tournament templates (`app/app.py`, `app/templates/admin/new_tournament.html`, `app/templates/admin/edit_tournament.html`).
- Preserved explicit account locks when an admin resets a user password by adding an `unlock` flag to `User.set_password(...)` and calling it with `unlock=False` during admin password changes so locks remain unless explicitly changed (`app/models.py`, `app/app.py`).
- Prevented duplicate booth numbers across vendors and artists within the same venue by adding `booth_number_conflict(...)` and checking it on create/update flows for vendors and artists (`app/app.py`).
- Fixed venue list layout overflow by wrapping the venues table in a responsive container and adding targeted table styles so action buttons and rows stay inside the panel (`app/templates/admin/venues.html`, `app/static/style.css`).
- Added regression tests for the new behaviours and fixes (`tests/test_tournament.py`, `tests/test_users.py`).

### Testing
- Dependency and vulnerability checks: ran `python -m pip install -r requirements.txt` and `python -m pip_audit -r requirements.txt`, the initial audit flagged a Flask CVE which was resolved by upgrading to `Flask==3.1.3`, after which `pip_audit` reported no known vulnerabilities.
- Unit test suite: ran `python -m pytest -q` and the full test suite passed (`57 passed`, with warnings reported), and targeted tests for the new fixes also passed (`test_tournament_edit_auto_fills_lowest_contiguous_table_range`, `test_duplicate_booth_numbers_are_blocked_across_artists_and_vendors`, `test_tournament_manager_can_bulk_add_tournament_to_venue`, `test_admin_password_change_rekeys_user_and_preserves_lock_without_unlock_action`, `test_admin_can_manually_lock_and_unlock_user`).
- Additional checks: code compiled (`python -m py_compile`) and `git diff --check` showed no whitespace or diff-check errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa75174008320b11533bc3cd71935)

## Summary by Sourcery

Improve admin workflows for tournaments, venues, users, and booths while updating dependencies to secure versions.

New Features:
- Automatically suggest and apply the lowest available contiguous starting table range when creating or editing tournaments.
- Enforce unique booth numbers per venue across vendors and artists with user-facing conflict messages.

Bug Fixes:
- Backfill missing user_id columns in logs tables on older installs so bulk logging operations do not fail.
- Preserve explicit account locks when admins reset user passwords so accounts remain locked unless explicitly unlocked.
- Prevent layout overflow in the venue management page by making the venues table responsive.

Enhancements:
- Refine tournament start table handling to accept blank values and derive a valid starting table number when omitted.

Build:
- Update Flask, cryptography, and Pillow dependency pins to patched versions addressing known vulnerabilities.

Tests:
- Add regression tests covering automatic table range selection, booth conflict handling, and admin password reset/lock behaviour.