### PR TITLE
Improve venue tournament bulk-add logging and make audit logging non-fatal

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2809,59 +2809,130 @@ def create_app():
     @login_required
     def bulk_add_tournaments_to_venue(venue_id):
         require_permission('venues.manage')
+        user_id = current_user.id if current_user.is_authenticated else None
         if not (
             current_user.has_permission('tournaments.bulk_manage')
             or current_user.has_permission('tournaments.manage')
         ):
+            app.logger.warning(
+                'Venue bulk add denied: user_id=%s venue_id=%s required=%s',
+                user_id,
+                venue_id,
+                'venues.manage+(tournaments.bulk_manage|tournaments.manage)',
+            )
             log_site('unauthorized_access', 'failure', 'venues.manage+tournaments.bulk_manage')
             abort(403)
         venue = db.session.get(Venue, venue_id)
         if not venue:
+            app.logger.warning('Venue bulk add aborted: venue_id=%s was not found; user_id=%s', venue_id, user_id)
             abort(404)
         raw_ids = request.form.getlist('tournament_ids')
         tournament_ids = []
         seen_tournament_ids = set()
+        invalid_tournament_ids = []
+        duplicate_tournament_ids = []
         for raw_id in raw_ids:
             try:
                 tournament_id = int(raw_id)
             except (TypeError, ValueError):
+                invalid_tournament_ids.append(raw_id)
                 continue
             if tournament_id in seen_tournament_ids:
+                duplicate_tournament_ids.append(tournament_id)
                 continue
             seen_tournament_ids.add(tournament_id)
             tournament_ids.append(tournament_id)
+        app.logger.info(
+            'Venue bulk add requested: user_id=%s venue_id=%s raw_ids=%r parsed_ids=%s duplicates=%s invalid=%r',
+            user_id,
+            venue.id,
+            raw_ids,
+            tournament_ids,
+            duplicate_tournament_ids,
+            invalid_tournament_ids,
+        )
         if not tournament_ids:
+            app.logger.info('Venue bulk add rejected: no valid tournament ids for venue_id=%s user_id=%s', venue.id, user_id)
             flash('Select at least one tournament to add to this venue.', 'error')
             return redirect(url_for('venue_detail', venue_id=venue.id))
         tournaments = db.session.query(Tournament).filter(Tournament.id.in_(tournament_ids)).all()
         tournament_by_id = {t.id: t for t in tournaments}
         ordered_tournaments = [tournament_by_id[tid] for tid in tournament_ids if tid in tournament_by_id]
-        count = 0
+        missing_tournament_ids = [tid for tid in tournament_ids if tid not in tournament_by_id]
+        skipped_tournament_ids = []
+        moved_tournament_ids = []
         for tournament in ordered_tournaments:
             if tournament.venue_id == venue.id:
+                skipped_tournament_ids.append(tournament.id)
                 continue
+            previous_venue_id = tournament.venue_id
             tournament.venue_id = venue.id
-            db.session.add(TournamentLog(
-                tournament_id=tournament.id,
-                action='bulk_add_to_venue',
-                result='success',
-                error=f'venue_id={venue.id}',
-                user_id=current_user.id,
-            ))
-            db.session.add(SiteLog(
-                action='venue_bulk_add_tournaments',
-                result='success',
-                error=f'venue_id={venue.id}; tournament_id={tournament.id}',
-                user_id=current_user.id,
-            ))
-            count += 1
+            moved_tournament_ids.append(tournament.id)
+            app.logger.info(
+                'Venue bulk add staged: user_id=%s tournament_id=%s previous_venue_id=%s new_venue_id=%s',
+                user_id,
+                tournament.id,
+                previous_venue_id,
+                venue.id,
+            )
         try:
             db.session.commit()
-        except SQLAlchemyError as exc:
+        except Exception as exc:
             db.session.rollback()
-            app.logger.exception('Venue tournament bulk add failed: %s', exc)
+            app.logger.exception(
+                'Venue bulk add commit failed: user_id=%s venue_id=%s parsed_ids=%s moved_ids=%s missing_ids=%s skipped_ids=%s error=%s',
+                user_id,
+                venue.id,
+                tournament_ids,
+                moved_tournament_ids,
+                missing_tournament_ids,
+                skipped_tournament_ids,
+                exc,
+            )
             flash('Bulk add failed. Please try again or review the selected tournaments.', 'error')
             return redirect(url_for('venue_detail', venue_id=venue.id))
+
+        app.logger.info(
+            'Venue bulk add committed: user_id=%s venue_id=%s moved_ids=%s missing_ids=%s skipped_ids=%s duplicates=%s invalid=%r',
+            user_id,
+            venue.id,
+            moved_tournament_ids,
+            missing_tournament_ids,
+            skipped_tournament_ids,
+            duplicate_tournament_ids,
+            invalid_tournament_ids,
+        )
+
+        if moved_tournament_ids:
+            try:
+                for tournament_id in moved_tournament_ids:
+                    db.session.add(TournamentLog(
+                        tournament_id=tournament_id,
+                        action='bulk_add_to_venue',
+                        result='success',
+                        error=f'venue_id={venue.id}',
+                        user_id=user_id,
+                    ))
+                    db.session.add(SiteLog(
+                        action='venue_bulk_add_tournaments',
+                        result='success',
+                        error=f'venue_id={venue.id}; tournament_id={tournament_id}',
+                        user_id=user_id,
+                    ))
+                db.session.commit()
+            except Exception as exc:
+                db.session.rollback()
+                app.logger.exception(
+                    'Venue bulk add audit logging failed after assignment commit: user_id=%s venue_id=%s moved_ids=%s error=%s',
+                    user_id,
+                    venue.id,
+                    moved_tournament_ids,
+                    exc,
+                )
+
+        if missing_tournament_ids:
+            flash(f'Some selected tournaments no longer exist: {missing_tournament_ids}.', 'warning')
+        count = len(moved_tournament_ids)
         flash(f'Added {count} tournament' + ('s' if count != 1 else '') + f' to {venue.name}.', 'success')
         return redirect(url_for('venue_detail', venue_id=venue.id))
 

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -3,7 +3,7 @@ import random
 from itertools import product
 
 from app.app import db
-from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult, Venue
+from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult, Venue, SiteLog, TournamentLog
 from app.pairing import pair_round, compute_standings
 from datetime import datetime
 
@@ -423,6 +423,43 @@ def test_bulk_edit_tournaments_ignores_duplicate_tournament_ids(client, session)
     session.expire_all()
     assert session.get(Tournament, tournament.id).venue_id == venue.id
 
+
+
+def test_venue_bulk_add_keeps_assignment_when_audit_logging_fails(client, session, monkeypatch):
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(
+        email='bulk-log-failure-admin@example.com',
+        name='Bulk Log Failure Admin',
+        role=admin_role,
+        is_admin=True,
+    )
+    admin.set_password('secret')
+    tournament = Tournament(name='Audit Failure Venue Event', format='Modern')
+    venue = Venue(name='Audit Failure Venue')
+    session.add_all([admin, tournament, venue])
+    session.commit()
+
+    original_add = db.session.add
+
+    def fail_on_audit_log(instance):
+        if isinstance(instance, (SiteLog, TournamentLog)):
+            raise RuntimeError('simulated audit log failure')
+        return original_add(instance)
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        monkeypatch.setattr(db.session, 'add', fail_on_audit_log)
+        response = client.post(
+            f'/admin/venues/{venue.id}/tournaments/bulk-add',
+            data={
+                'tournament_ids': [str(tournament.id)],
+            },
+        )
+
+    assert response.status_code == 302
+    assert response.location == f'/admin/venues/{venue.id}'
+    session.expire_all()
+    assert session.get(Tournament, tournament.id).venue_id == venue.id
 
 def test_venue_bulk_add_rejects_empty_tournament_selection(client, session):
     admin_role = session.query(Role).filter_by(name='admin').one()


### PR DESCRIPTION
### Motivation
- Add detailed, verbose logging around the venue bulk-add flow so failures when assigning tournaments to venues can be diagnosed. 
- Prevent failures in audit logging from rolling back a successful tournament-to-venue assignment so assignments are preserved even if logging/database issues occur. 

### Description
- Added structured request and parsing logs and collected `invalid_tournament_ids` and `duplicate_tournament_ids` during parsing in `bulk_add_tournaments_to_venue` in `app/app.py`. 
- Staged assignments into `moved_tournament_ids`/`skipped_tournament_ids`/`missing_tournament_ids`, committed venue assignments first, and then attempted to write `TournamentLog`/`SiteLog` records in a separate commit so audit logging failures do not undo assignments. 
- Added extensive `app.logger` calls for permission denials, missing venues, staged moves, commit failures, and audit logging failures in `app/app.py`. 
- Added a regression test `test_venue_bulk_add_keeps_assignment_when_audit_logging_fails` in `tests/test_tournament.py` that simulates audit-log write failures and verifies the tournament is still assigned to the venue. 

### Testing
- Ran targeted tests with `pytest -q tests/test_tournament.py::test_tournament_manager_can_bulk_add_tournament_to_venue tests/test_tournament.py::test_bulk_edit_tournaments_adds_selected_tournament_to_venue` and they passed. 
- Ran the new regression test `test_venue_bulk_add_keeps_assignment_when_audit_logging_fails` alongside related tests and it passed. 
- Ran the full test suite with `pytest -q` and all tests passed (`59 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a208271bd04832092451625fa92a5bc)

## Summary by Sourcery

Improve the venue tournament bulk-add flow with more robust behavior and observability, ensuring venue assignments succeed even when audit logging fails.

Bug Fixes:
- Prevent audit logging failures from rolling back successful tournament-to-venue assignments during venue bulk-add operations.

Enhancements:
- Add detailed structured logging around venue bulk-add requests, parsing, permission checks, commit outcomes, and audit logging attempts.
- Track and report invalid, duplicate, missing, skipped, and moved tournament IDs during venue bulk-add operations for easier diagnosis.

Tests:
- Add a regression test to verify that venue bulk-add still assigns tournaments when audit log writes fail.