### PR TITLE
Enable TLS 1.2/1.3 with FIPS-safe AES-GCM ciphers and update docs/scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ On Linux, `start-server.sh` installs the HTTP Nginx site automatically when `tls
 
 If LAN clients still cannot reach the app, browse to the server's LAN address on port 80 (for example, `http://192.168.1.25/`) and make sure host firewall rules allow inbound HTTP. If you see the default Nginx welcome page after installing, re-run `./scripts/install_nginx_config.sh` and confirm that Nginx reloaded successfully. If you see a `502 Bad Gateway` page instead, make sure the Waitress host and port in `config.yaml` match the upstream address in `nginx/walter.conf`; the rendered config expects Waitress at the `flask_ip` and `flask_port` values from `config.yaml`.
 
-### HTTPS with TLS 1.3 and Let's Encrypt
+### HTTPS with TLS 1.2/1.3 and Let's Encrypt
 
 For production, set `tls_domain` in `config.yaml` to your public DNS name before running `./start-server.sh`. The startup script then checks `/etc/letsencrypt/live/<domain>/fullchain.pem`; if the certificate is missing or expires within `letsencrypt_renewal_days` days (default: 30), it installs Certbot/OpenSSL if needed, installs the HTTP Nginx config for HTTP-01 validation, requests a Let's Encrypt certificate, and then installs the rendered HTTPS Nginx config. Do **not** add `fullchain.pem`, `privkey.pem`, `chain.pem`, or any other certificate/private-key material to this repository.
 
@@ -60,7 +60,7 @@ You can still manage the Nginx config manually:
 3) Install the TLS config rendered for your production domain:
    - `./scripts/install_nginx_config.sh --tls-domain tournaments.example.com`
 
-The TLS template lives at `nginx/walter-tls.conf`. It serves HTTPS on port 443, redirects normal HTTP traffic to HTTPS, leaves `/.well-known/acme-challenge/` available on port 80 for Let's Encrypt renewals, only enables TLS 1.3, and restricts TLS 1.3 cipher suites to the FIPS-suitable AES-GCM suites `TLS_AES_256_GCM_SHA384` and `TLS_AES_128_GCM_SHA256`. If your certificate lives somewhere other than `/etc/letsencrypt/live/<domain>`, pass `--cert-dir /path/to/live/certdir`; if your ACME challenge webroot differs, pass `--acme-webroot /path/to/webroot`.
+The TLS template lives at `nginx/walter-tls.conf`. It serves HTTPS on port 443, redirects normal HTTP traffic to HTTPS, leaves `/.well-known/acme-challenge/` available on port 80 for Let's Encrypt renewals, enables TLS 1.2 and TLS 1.3, and restricts both TLS versions to FIPS-suitable AES-GCM cipher suites. TLS 1.2 is limited to `ECDHE-ECDSA-AES256-GCM-SHA384`, `ECDHE-RSA-AES256-GCM-SHA384`, `ECDHE-ECDSA-AES128-GCM-SHA256`, and `ECDHE-RSA-AES128-GCM-SHA256`; TLS 1.3 is limited to `TLS_AES_256_GCM_SHA384` and `TLS_AES_128_GCM_SHA256`. If your certificate lives somewhere other than `/etc/letsencrypt/live/<domain>`, pass `--cert-dir /path/to/live/certdir`; if your ACME challenge webroot differs, pass `--acme-webroot /path/to/webroot`.
 
 ## Account verification and invites
 

--- a/nginx/walter-tls.conf
+++ b/nginx/walter-tls.conf
@@ -46,12 +46,14 @@ server {
     ssl_certificate_key __WALTER_CERT_DIR__/privkey.pem;
     ssl_trusted_certificate __WALTER_CERT_DIR__/chain.pem;
 
-    # Only permit TLS 1.3. The configured cipher suites are the TLS 1.3
-    # AES-GCM suites that are suitable for FIPS-mode OpenSSL deployments.
-    # ChaCha20-Poly1305 is intentionally omitted because it is not FIPS-approved.
-    ssl_protocols TLSv1.3;
+    # Permit TLS 1.2 and TLS 1.3 while restricting negotiated cipher suites to
+    # FIPS-suitable AES-GCM options. ChaCha20-Poly1305 is intentionally omitted
+    # because it is not FIPS-approved. ssl_ciphers applies to TLS 1.2;
+    # ssl_conf_command Ciphersuites applies to TLS 1.3.
+    ssl_protocols TLSv1.2 TLSv1.3;
+    ssl_ciphers ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256;
     ssl_conf_command Ciphersuites TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256;
-    ssl_prefer_server_ciphers off;
+    ssl_prefer_server_ciphers on;
 
     ssl_session_timeout 1d;
     ssl_session_cache shared:WalterTLS:10m;

--- a/nginx/walter.conf
+++ b/nginx/walter.conf
@@ -2,7 +2,7 @@
 #
 # The application is expected to be running locally with start-server.sh.
 # The upstream address is rendered from flask_ip and flask_port in config.yaml.
-# For production HTTPS with TLS 1.3, FIPS-approved cipher suites, and
+# For production HTTPS with TLS 1.2/1.3, FIPS-approved cipher suites, and
 # Let's Encrypt certificates, install nginx/walter-tls.conf via
 # scripts/install_nginx_config.sh --tls-domain your.domain.example.
 

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -32,7 +32,7 @@ Copies the Walter Nginx config into the correct Linux Nginx location:
 
 Options:
   -c, --config PATH     Source Nginx config to install (default: $DEFAULT_CONFIG)
-      --tls-domain NAME  Render and install the TLS 1.3 Let's Encrypt config for NAME
+      --tls-domain NAME  Render and install the TLS 1.2/1.3 Let's Encrypt config for NAME
       --cert-dir PATH    Let's Encrypt live cert directory (default: /etc/letsencrypt/live/NAME)
       --acme-webroot PATH
                         Webroot for HTTP-01 challenges (default: $ACME_WEBROOT)


### PR DESCRIPTION
### Motivation
- Allow wider client compatibility by enabling TLS 1.2 in addition to TLS 1.3 while retaining FIPS-approved AES-GCM-only cipher selections.
- Make documentation and install script messaging consistent with the actual Nginx TLS configuration.
- Prefer server-chosen ciphers to ensure the server enforces the FIPS-safe cipher list.

### Description
- Updated `nginx/walter-tls.conf` to permit `TLSv1.2 TLSv1.3`, add an `ssl_ciphers` line limiting TLS 1.2 to FIPS-suitable AES-GCM suites, add `ssl_conf_command Ciphersuites` for TLS 1.3, and set `ssl_prefer_server_ciphers on`.
- Revised `README.md` to advertise "HTTPS with TLS 1.2/1.3 and Let's Encrypt" and to document the exact TLS 1.2 and TLS 1.3 cipher restrictions and related guidance.
- Tweaked `nginx/walter.conf` header text and the `scripts/install_nginx_config.sh` usage/help text to reference TLS 1.2/1.3 where appropriate.

### Testing
- No automated tests were run for these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20852ff2b88320ae955f95a26b11f3)

## Summary by Sourcery

Enable TLS 1.2 alongside TLS 1.3 with FIPS-safe AES-GCM cipher suites and align documentation and scripts with the updated TLS configuration.

New Features:
- Allow HTTPS connections over both TLS 1.2 and TLS 1.3 while restricting cipher suites to FIPS-suitable AES-GCM options.

Enhancements:
- Configure Nginx to prefer server-selected cipher suites to enforce the FIPS-safe cipher list across clients.
- Clarify README, Nginx config comments, and install script help text to describe the supported TLS versions and exact cipher restrictions.