### PR TITLE
Fix Let's Encrypt cert checks under sudo

### DIFF
--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -68,6 +68,25 @@ run_root() {
   fi
 }
 
+file_exists_root() {
+  local path="$1"
+
+  if [[ -f "$path" ]]; then
+    return 0
+  fi
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    return 1
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    sudo test -f "$path"
+    return $?
+  fi
+
+  return 1
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     -c|--config)
@@ -164,7 +183,7 @@ if [[ -n "$TLS_DOMAIN" ]]; then
 
   if [[ "$DRY_RUN" -ne 1 ]]; then
     for cert_file in "$CERT_DIR/fullchain.pem" "$CERT_DIR/privkey.pem" "$CERT_DIR/chain.pem"; do
-      if [[ ! -f "$cert_file" ]]; then
+      if ! file_exists_root "$cert_file"; then
         log "Missing Let's Encrypt certificate file: $cert_file" >&2
         log "Create certificates on this machine first, for example:" >&2
         log "  certbot certonly --webroot -w $ACME_WEBROOT -d $TLS_DOMAIN" >&2

--- a/start-server.sh
+++ b/start-server.sh
@@ -132,13 +132,39 @@ ensure_nginx_running() {
   fi
 }
 
+cert_file_exists() {
+  local cert_file="$1"
+
+  if [[ -f "$cert_file" ]]; then
+    return 0
+  fi
+
+  if [[ "$(id -u)" -eq 0 ]]; then
+    return 1
+  fi
+
+  if command -v sudo >/dev/null 2>&1; then
+    sudo test -f "$cert_file"
+    return $?
+  fi
+
+  return 1
+}
+
 cert_expires_within() {
   local cert_file="$1"
   local days="$2"
   local seconds=$((days * 24 * 60 * 60))
 
-  [[ ! -f "$cert_file" ]] && return 0
-  ! openssl x509 -checkend "$seconds" -noout -in "$cert_file" >/dev/null 2>&1
+  if ! cert_file_exists "$cert_file"; then
+    return 0
+  fi
+
+  if openssl x509 -checkend "$seconds" -noout -in "$cert_file" >/dev/null 2>&1; then
+    return 1
+  fi
+
+  ! run_as_root openssl x509 -checkend "$seconds" -noout -in "$cert_file" >/dev/null 2>&1
 }
 
 is_truthy() {
@@ -235,7 +261,7 @@ ensure_letsencrypt_certificate() {
   if [[ "$dry_run" -eq 1 ]] || cert_expires_within "$fullchain" "$renewal_days"; then
     if [[ "$dry_run" -eq 1 ]]; then
       echo "Running Let's Encrypt dry run for $TLS_DOMAIN; no certificate files will be created or replaced."
-    elif [[ -f "$fullchain" ]]; then
+    elif cert_file_exists "$fullchain"; then
       echo "Let's Encrypt certificate for $TLS_DOMAIN expires within $renewal_days days; requesting a replacement."
       certbot_args+=(--force-renewal)
     else


### PR DESCRIPTION
### Motivation
- When run by a non-root user the scripts could not detect Certbot-created files under `/etc/letsencrypt/live/<domain>` and reported missing certificates or made incorrect renewal decisions. 
- The expiry check also failed when the current user could not read the certificate file but `sudo` could.

### Description
- Added `file_exists_root()` to `scripts/install_nginx_config.sh` to check certificate file existence using `sudo test -f` when the current user cannot read the path, and replaced direct `-f` checks with this helper. 
- Added `cert_file_exists()` to `start-server.sh` and updated the renewal/decision code to use it instead of `-f` when testing for an existing certificate. 
- Modified `cert_expires_within()` to fall back to `run_as_root openssl ...` for expiry checks when the non-root user cannot read the cert file, ensuring correct renewal decisions.

### Testing
- `bash -n scripts/install_nginx_config.sh` succeeded. 
- `bash -n start-server.sh` succeeded. 
- Executed `./scripts/install_nginx_config.sh --tls-domain walter-pair.us --cert-dir /tmp/nonexistent-certs --dry-run --no-reload --app-config config.yaml` to validate dry-run install path and observed expected output. 
- Ran `git diff --check` with no issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2087e5c54c832092a6991a6cfad06b)

## Summary by Sourcery

Improve Let's Encrypt certificate detection and renewal logic when scripts are run by non-root users, including when access to cert files requires sudo.

Bug Fixes:
- Ensure certificate existence checks in start-server and nginx install scripts work when certificate files are only readable via sudo.
- Fix certificate expiry checks so renewal decisions are correct even when the current user cannot read the certificate file but sudo/root can.

Enhancements:
- Introduce shared helper functions to perform file existence and certificate checks with root privileges when necessary, reducing direct -f usage in scripts.