### PR TITLE
Hide tournaments before login and fix redirect vulnerabilities

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -35,7 +35,7 @@ import csv
 import urllib.parse
 import urllib.request
 from collections import OrderedDict
-from urllib.parse import urlparse
+from urllib.parse import urljoin, urlparse
 from sqlalchemy import inspect, text, or_
 from sqlalchemy.exc import SQLAlchemyError
 from cryptography.hazmat.primitives import serialization, hashes
@@ -533,16 +533,17 @@ def create_app():
     # ---------- Routes ----------
     @app.route('/')
     def index():
+        if not current_user.is_authenticated:
+            return render_template(
+                'index.html',
+                tournaments=[],
+                player_counts={},
+                server_now=datetime.utcnow(),
+            )
+
         tournaments = db.session.query(Tournament).order_by(Tournament.created_at.desc()).all()
         visible_tournaments = [t for t in tournaments if not tournament_is_complete(t)]
         player_counts = {t.id: len(t.players) for t in visible_tournaments}
-        can_bulk_edit_tournaments = (
-            current_user.is_authenticated
-            and (
-                current_user.has_permission('tournaments.bulk_manage')
-                or current_user.has_permission('tournaments.manage')
-            )
-        )
         return render_template('index.html', tournaments=visible_tournaments, player_counts=player_counts,
                                server_now=datetime.utcnow())
 
@@ -802,11 +803,7 @@ def create_app():
                 except Exception:
                     session['private_key'] = None
                 log_site('login', 'success', f'ip={_client_ip()}')
-                if next_url:
-                    parsed = urlparse(next_url)
-                    if not parsed.netloc and parsed.path.startswith('/'):
-                        return redirect(next_url)
-                return redirect(url_for('index'))
+                return redirect(resolve_redirect_target(url_for('index'), next_url))
             _record_bad_login(email, u, 'bad_password' if u else 'unknown_user')
             flash("Invalid credentials", "error")
             log_site('login', 'failure', f'invalid credentials; ip={_client_ip()}')
@@ -3525,8 +3522,9 @@ def create_app():
                 counts = apply_backup_payload(payload, overwrite=overwrite)
             except Exception as exc:
                 db.session.rollback()
+                app.logger.warning('Backup import failed: %s', exc)
                 log_site('backup_import', 'failure', str(exc))
-                flash(f'Backup import failed: {exc}', 'error')
+                flash('Backup import failed. Please verify the file and password, then try again.', 'error')
                 return redirect(url_for('admin_backup'))
             summary = ', '.join(f'{value} {key.replace("_", " ")}' for key, value in counts.items() if value)
             flash(f'Backup imported successfully. Updated {summary or "no records"}.', 'success')
@@ -3974,7 +3972,8 @@ def create_app():
         try:
             path = ensure_card_database_ready()
         except Exception as exc:
-            return jsonify(error=str(exc), results=[]), 503
+            app.logger.warning('Card database unavailable during deck search: %s', exc)
+            return jsonify(error='Card database unavailable.', results=[]), 503
         results = card_db.search_cards(path, query, limit=20)
         return jsonify(results=results)
 
@@ -4019,7 +4018,8 @@ def create_app():
         try:
             db_path = ensure_card_database_ready()
         except Exception as exc:
-            flash(f'Card database unavailable: {exc}', 'error')
+            app.logger.warning('Card database unavailable during manual deck upload: %s', exc)
+            flash('Card database unavailable. Please try again later.', 'error')
             log_tournament(tid, 'deck_manual', 'failure', str(exc))
             return redirect(url_for('view_tournament', tid=tid))
         canonical_main, missing_main = canonicalize_card_group(main_entries, db_path=db_path)
@@ -4096,7 +4096,8 @@ def create_app():
         try:
             db_path = ensure_card_database_ready()
         except Exception as exc:
-            flash(f'Card database unavailable: {exc}', 'error')
+            app.logger.warning('Card database unavailable during MTGO deck upload: %s', exc)
+            flash('Card database unavailable. Please try again later.', 'error')
             log_tournament(tid, 'deck_mtgo', 'failure', str(exc))
             return redirect(url_for('view_tournament', tid=tid))
         canonical_main, missing_main = canonicalize_card_group(main_entries, db_path=db_path)
@@ -4977,11 +4978,24 @@ def create_app():
             search_query=q,
         )
 
+    def is_safe_redirect_target(candidate):
+        if not candidate:
+            return False
+        candidate = candidate.strip()
+        if not candidate or '\\' in candidate:
+            return False
+        ref_url = urlparse(request.host_url)
+        test_url = urlparse(urljoin(request.host_url, candidate))
+        return (
+            test_url.scheme in ('http', 'https')
+            and ref_url.netloc == test_url.netloc
+            and candidate.startswith('/')
+            and not candidate.startswith('//')
+        )
+
     def resolve_redirect_target(default_url, candidate):
-        if candidate:
-            parsed = urlparse(candidate)
-            if not parsed.scheme and not parsed.netloc:
-                return candidate
+        if is_safe_redirect_target(candidate):
+            return candidate.strip()
         return default_url
 
     @app.route('/admin/users/<int:uid>')

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -1,19 +1,39 @@
 {% extends 'base.html' %}
 {% block content %}
+{% if not current_user.is_authenticated %}
+<section class="page-header">
+  <div class="page-header__title">
+    <h2>Welcome to WaLTER</h2>
+    <p class="page-description">Sign in to view and manage your tournament activity.</p>
+  </div>
+  <div class="page-header__actions">
+    <a class="btn" href="{{ url_for('login') }}">Login</a>
+    <a class="btn secondary" href="{{ url_for('register') }}">Create Account</a>
+  </div>
+</section>
+<section class="panel-card">
+  <div class="section-heading">
+    <div>
+      <h3>Tournament information is private</h3>
+      <p>Active tournaments are only shown after you log in.</p>
+    </div>
+  </div>
+</section>
+{% else %}
 <section class="page-header">
   <div class="page-header__title">
     <h2>Active Tournaments</h2>
     <p class="page-description">Track live timers, manage players, and jump into any event with a single tap.</p>
   </div>
-  {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+  {% if current_user.has_permission('tournaments.manage') %}
   <div class="page-header__actions">
     <a class="btn" href="{{ url_for('new_tournament') }}">Create Tournament</a>
   </div>
   {% endif %}
 </section>
 
-{% set can_manage_tournaments = current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
-{% set can_bulk_edit = current_user.is_authenticated and (current_user.has_permission('tournaments.bulk_manage') or can_manage_tournaments) %}
+{% set can_manage_tournaments = current_user.has_permission('tournaments.manage') %}
+{% set can_bulk_edit = current_user.has_permission('tournaments.bulk_manage') or can_manage_tournaments %}
 {% if can_manage_tournaments %}
   {% for t in tournaments %}
   <form id="delete-tournament-form-{{ t.id }}" method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');"></form>
@@ -75,5 +95,6 @@
 </ul>
 {% if can_bulk_edit %}
 </form>
+{% endif %}
 {% endif %}
 {% endblock %}

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -360,3 +360,68 @@ def test_admin_password_change_rekeys_user_and_preserves_lock_without_unlock_act
     assert target.decrypt_private_key('new-secret').startswith(b'-----BEGIN PRIVATE KEY-----')
     assert target.locked_at is not None
     assert target.lock_reason == 'manual review'
+
+
+def test_anonymous_home_hides_tournaments(client, session):
+    from app.models import Tournament
+
+    tournament = Tournament(name='Private Event', format='Constructed')
+    session.add(tournament)
+    session.commit()
+
+    response = client.get('/')
+
+    assert response.status_code == 200
+    assert b'Private Event' not in response.data
+    assert b'Tournament information is private' in response.data
+
+
+def test_authenticated_home_shows_tournaments(client, session):
+    from app.models import Tournament
+
+    user_role = session.query(Role).filter_by(name='user').one()
+    user = User(email='home-user@example.com', name='Home User', role=user_role)
+    user.set_password('secret')
+    tournament = Tournament(name='Visible Event', format='Constructed')
+    session.add_all([user, tournament])
+    session.commit()
+
+    with client:
+        login_response = client.post('/login', data={'email': user.email, 'password': 'secret'})
+        assert login_response.status_code == 302
+        response = client.get('/')
+
+    assert response.status_code == 200
+    assert b'Visible Event' in response.data
+
+
+def test_login_next_rejects_external_redirect(client, session):
+    user_role = session.query(Role).filter_by(name='user').one()
+    user = User(email='next-user@example.com', name='Next User', role=user_role)
+    user.set_password('secret')
+    session.add(user)
+    session.commit()
+
+    response = client.post(
+        '/login?next=https://evil.example/phish',
+        data={'email': user.email, 'password': 'secret'},
+    )
+
+    assert response.status_code == 302
+    assert response.headers['Location'] == '/'
+
+
+def test_login_next_allows_local_redirect(client, session):
+    user_role = session.query(Role).filter_by(name='user').one()
+    user = User(email='local-next-user@example.com', name='Local Next User', role=user_role)
+    user.set_password('secret')
+    session.add(user)
+    session.commit()
+
+    response = client.post(
+        '/login?next=/t/1/join-link',
+        data={'email': user.email, 'password': 'secret'},
+    )
+
+    assert response.status_code == 302
+    assert response.headers['Location'] == '/t/1/join-link'


### PR DESCRIPTION
### Motivation
- Prevent unauthenticated visitors from seeing active tournament data on the home page.  
- Eliminate open-redirect and information-leak vectors where user-controlled `next` URLs or exception messages could expose internal details or redirect to external sites.  

### Description
- Updated the `/` route to return an empty tournament list for anonymous users and keep the full list for authenticated users by protecting the `index` view logic. (`app/app.py`, `index` route).  
- Reworked the home template to show a login/register prompt for anonymous visitors and to rely on permission checks without redundant `is_authenticated` checks (`app/templates/index.html`).  
- Added a same-origin/local redirect validator `is_safe_redirect_target` and wired login redirects to `resolve_redirect_target` to prevent open-redirects (`app/app.py`).  
- Replaced several user-facing exception details with generic messages and retained server-side logging for failures in backup import and card-database access paths (`admin_backup`, `deck` search/upload handlers in `app/app.py`).  
- Added regression tests for anonymous/home visibility and safe redirect handling: `test_anonymous_home_hides_tournaments`, `test_authenticated_home_shows_tournaments`, `test_login_next_rejects_external_redirect`, and `test_login_next_allows_local_redirect` (`tests/test_users.py`).  

### Testing
- Ran the test suite with `pytest -q`; all tests passed: `63 passed, 28 warnings`.  
- New regression tests covering anonymous vs authenticated home rendering and `next` redirect safety were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2089bd97bc8320b32727bfb36bcbbb)

## Summary by Sourcery

Restrict home page tournament visibility to authenticated users, harden login redirect handling, and replace detailed error disclosures with generic messages while preserving server-side logging.

Bug Fixes:
- Hide active tournaments on the home page from anonymous visitors while preserving full visibility for logged-in users.
- Validate and constrain post-login `next` URLs to safe same-origin paths to prevent open redirects.
- Avoid leaking internal exception details in backup import and card database failure paths by showing generic user-facing errors instead.

Enhancements:
- Adjust the home page template to present a login/register prompt and private-tournament messaging for unauthenticated visitors while simplifying permission checks for authenticated users.

Tests:
- Add regression tests covering anonymous vs authenticated home visibility and safe handling of external and local post-login redirect targets.