### PR TITLE
Fix bulk tournament delete logging

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3671,6 +3671,8 @@ def create_app():
         ordered_tournaments = [tournament_by_id[tid] for tid in tournament_ids if tid in tournament_by_id]
         count = 0
         now = datetime.utcnow()
+        user_id = current_user.id if current_user.is_authenticated else None
+        audit_entries = []
         if action == 'start':
             for tournament in ordered_tournaments:
                 tournament.started_at = now
@@ -3682,18 +3684,12 @@ def create_app():
                         extract_provided_tournament_name(tournament.name),
                     )
                 tournament.ended_at = None
-                db.session.add(TournamentLog(
-                    tournament_id=tournament.id,
-                    action='bulk_start',
-                    result='success',
-                    user_id=current_user.id,
-                ))
-                db.session.add(SiteLog(
-                    action='bulk_start_tournament',
-                    result='success',
-                    error=f'tournament_id={tournament.id}',
-                    user_id=current_user.id,
-                ))
+                audit_entries.append({
+                    'tournament_id': tournament.id,
+                    'tournament_action': 'bulk_start',
+                    'site_action': 'bulk_start_tournament',
+                    'site_error': f'tournament_id={tournament.id}',
+                })
                 count += 1
         elif action == 'end':
             for tournament in ordered_tournaments:
@@ -3701,35 +3697,23 @@ def create_app():
                 tournament.round_timer_end = None
                 tournament.draft_timer_end = None
                 tournament.deck_timer_end = None
-                db.session.add(TournamentLog(
-                    tournament_id=tournament.id,
-                    action='bulk_end',
-                    result='success',
-                    user_id=current_user.id,
-                ))
-                db.session.add(SiteLog(
-                    action='bulk_end_tournament',
-                    result='success',
-                    error=f'tournament_id={tournament.id}',
-                    user_id=current_user.id,
-                ))
+                audit_entries.append({
+                    'tournament_id': tournament.id,
+                    'tournament_action': 'bulk_end',
+                    'site_action': 'bulk_end_tournament',
+                    'site_error': f'tournament_id={tournament.id}',
+                })
                 count += 1
         elif action == 'delete':
             for tournament in ordered_tournaments:
                 tid = tournament.id
                 name = tournament.name
-                db.session.add(TournamentLog(
-                    tournament_id=tid,
-                    action='bulk_delete',
-                    result='success',
-                    user_id=current_user.id,
-                ))
-                db.session.add(SiteLog(
-                    action='bulk_delete_tournament',
-                    result='success',
-                    error=f'tournament_id={tid}; name={name}',
-                    user_id=current_user.id,
-                ))
+                audit_entries.append({
+                    'tournament_id': tid,
+                    'tournament_action': 'bulk_delete',
+                    'site_action': 'bulk_delete_tournament',
+                    'site_error': f'tournament_id={tid}; name={name}',
+                })
                 db.session.delete(tournament)
                 count += 1
         else:
@@ -3742,6 +3726,33 @@ def create_app():
             app.logger.exception('Bulk tournament action failed: %s', exc)
             flash('Bulk action failed. Please try again or review the selected tournaments.', 'error')
             return redirect(url_for('index'))
+
+        if audit_entries:
+            try:
+                for entry in audit_entries:
+                    db.session.add(TournamentLog(
+                        tournament_id=entry['tournament_id'],
+                        action=entry['tournament_action'],
+                        result='success',
+                        user_id=user_id,
+                    ))
+                    db.session.add(SiteLog(
+                        action=entry['site_action'],
+                        result='success',
+                        error=entry['site_error'],
+                        user_id=user_id,
+                    ))
+                db.session.commit()
+            except Exception as exc:
+                db.session.rollback()
+                app.logger.exception(
+                    'Bulk tournament audit logging failed after action commit: user_id=%s action=%s tournament_ids=%s error=%s',
+                    user_id,
+                    action,
+                    [entry['tournament_id'] for entry in audit_entries],
+                    exc,
+                )
+
         flash(f'Bulk action applied to {count} tournament' + ('s' if count != 1 else '') + '.', 'success')
         return redirect(url_for('index'))
 

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -461,6 +461,80 @@ def test_venue_bulk_add_keeps_assignment_when_audit_logging_fails(client, sessio
     session.expire_all()
     assert session.get(Tournament, tournament.id).venue_id == venue.id
 
+
+def test_bulk_delete_tournaments_removes_selected_tournaments(client, session):
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(
+        email='bulk-delete-admin@example.com',
+        name='Bulk Delete Admin',
+        role=admin_role,
+        is_admin=True,
+    )
+    admin.set_password('secret')
+    first = Tournament(name='Bulk Delete Event One', format='Modern')
+    second = Tournament(name='Bulk Delete Event Two', format='Legacy')
+    session.add_all([admin, first, second])
+    session.commit()
+    first_id = first.id
+    second_id = second.id
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/admin/tournaments/bulk',
+            data={
+                'bulk_action': 'delete',
+                'tournament_ids': [str(first_id), str(second_id)],
+            },
+        )
+
+    assert response.status_code == 302
+    assert response.location == '/'
+    session.expire_all()
+    assert session.get(Tournament, first_id) is None
+    assert session.get(Tournament, second_id) is None
+    assert session.query(TournamentLog).filter_by(tournament_id=first_id, action='bulk_delete').one()
+    assert session.query(SiteLog).filter_by(action='bulk_delete_tournament').count() == 2
+
+
+def test_bulk_delete_keeps_deletion_when_audit_logging_fails(client, session, monkeypatch):
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(
+        email='bulk-delete-log-failure-admin@example.com',
+        name='Bulk Delete Log Failure Admin',
+        role=admin_role,
+        is_admin=True,
+    )
+    admin.set_password('secret')
+    tournament = Tournament(name='Audit Failure Delete Event', format='Modern')
+    session.add_all([admin, tournament])
+    session.commit()
+    tournament_id = tournament.id
+
+    original_add = db.session.add
+
+    def fail_on_audit_log(instance):
+        if isinstance(instance, (SiteLog, TournamentLog)):
+            raise RuntimeError('simulated audit log failure')
+        return original_add(instance)
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        monkeypatch.setattr(db.session, 'add', fail_on_audit_log)
+        response = client.post(
+            '/admin/tournaments/bulk',
+            data={
+                'bulk_action': 'delete',
+                'tournament_ids': [str(tournament_id)],
+            },
+        )
+
+    assert response.status_code == 302
+    assert response.location == '/'
+    session.expire_all()
+    assert session.get(Tournament, tournament_id) is None
+
+
 def test_venue_bulk_add_rejects_empty_tournament_selection(client, session):
     admin_role = session.query(Role).filter_by(name='admin').one()
     admin = User(


### PR DESCRIPTION
### Motivation
- Prevent completed bulk tournament actions (start/end/delete) from being rolled back when audit log writes fail by mirroring the safer venue bulk-add pattern. 
- Add regression coverage to ensure bulk delete behavior and resilience to audit-log failures.

### Description
- Collect audit log entries in an `audit_entries` list and capture `user_id` while applying start/end/delete changes to `ordered_tournaments` instead of writing logs inline. 
- Commit the primary tournament updates/deletes with `db.session.commit()` first, and then attempt to write `TournamentLog`/`SiteLog` records in a separate `try/except` block so logging failures do not revert the main action. 
- On logging failure, rollback only the audit-log writes and record an exception with `app.logger.exception` while leaving the action results (updates/deletes) persisted. 
- Add two tests to `tests/test_tournament.py`: `test_bulk_delete_tournaments_removes_selected_tournaments` and `test_bulk_delete_keeps_deletion_when_audit_logging_fails` to verify correct behavior.

### Testing
- Ran `pytest -q tests/test_tournament.py -q` which executed the new and existing tournament tests and succeeded. 
- Ran the full test suite with `pytest -q` which completed successfully; all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a208c44def88320b64abe9f183f8eb6)

## Summary by Sourcery

Ensure bulk tournament admin actions commit primary changes independently of audit logging and add regression coverage for bulk delete behavior.

Bug Fixes:
- Prevent bulk tournament start/end/delete operations from being rolled back when audit log writes fail by separating the main commit from logging commits.

Enhancements:
- Defer creation of tournament and site audit log records for bulk start/end/delete into a post-commit step using collected audit entries, and log detailed context when audit logging fails.

Tests:
- Add tests to verify bulk delete removes the selected tournaments and that deletions remain committed even when audit logging fails.