### PR TITLE
Resolve Bandit security findings

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -24,6 +24,7 @@ from datetime import datetime, timedelta, timezone
 import math
 import os
 import random
+import re
 import click
 import psutil
 import json
@@ -67,6 +68,17 @@ MAJOR_60_CARD_FORMATS = [
 ]
 BASE_TOURNAMENT_FORMATS = ['Commander', 'Draft']
 TOURNAMENT_FORMATS = BASE_TOURNAMENT_FORMATS + MAJOR_60_CARD_FORMATS
+MAILGUN_DOMAIN_PATTERN = re.compile(r'^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$')
+
+
+def _mailgun_messages_url(domain):
+    if not domain or not MAILGUN_DOMAIN_PATTERN.fullmatch(domain) or '..' in domain:
+        raise RuntimeError('Mailgun domain must be a valid domain name.')
+    url = f'https://api.mailgun.net/v3/{domain}/messages'
+    parsed = urllib.parse.urlparse(url)
+    if parsed.scheme != 'https' or parsed.netloc != 'api.mailgun.net':
+        raise RuntimeError('Mailgun API URL must use https://api.mailgun.net/.')
+    return url
 
 
 def format_tournament_name(fmt, start_time, provided_name):
@@ -562,7 +574,7 @@ def create_app():
             'text': text,
         }).encode()
         request_obj = urllib.request.Request(
-            f'https://api.mailgun.net/v3/{domain}/messages',
+            _mailgun_messages_url(domain),
             data=data,
             headers={
                 'Authorization': 'Basic ' + base64.b64encode(f'api:{api_key}'.encode()).decode(),
@@ -570,7 +582,8 @@ def create_app():
             },
             method='POST',
         )
-        with urllib.request.urlopen(request_obj, timeout=10) as response:
+        # _mailgun_messages_url pins the destination to https://api.mailgun.net/.
+        with urllib.request.urlopen(request_obj, timeout=10) as response:  # nosec B310
             if response.status >= 400:
                 raise RuntimeError(f'Mailgun returned HTTP {response.status}')
 

--- a/app/card_db.py
+++ b/app/card_db.py
@@ -6,6 +6,7 @@ import tempfile
 import zipfile
 from contextlib import contextmanager
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Union
+from urllib.parse import urlparse
 from urllib.request import Request, urlopen
 
 ATOMIC_CARDS_URL = "https://mtgjson.com/api/v5/AtomicCards.json.zip"
@@ -243,6 +244,9 @@ def _read_atomic_cards_from_zip(path: str) -> List[Dict[str, Any]]:
 
 
 def _card_database_request(url: str) -> Request:
+    parsed_url = urlparse(url)
+    if parsed_url.scheme != 'https' or not parsed_url.netloc:
+        raise ValueError('Card database URL must be an absolute https URL.')
     return Request(url, headers={'User-Agent': CARD_DB_USER_AGENT})
 
 
@@ -252,7 +256,8 @@ def build_card_database(path: str, source_url: Optional[str] = None) -> None:
     request = _card_database_request(url)
     with tempfile.NamedTemporaryFile(delete=False) as tmp:
         temp_name = tmp.name
-        with urlopen(request) as response:
+        # _card_database_request only permits absolute https URLs.
+        with urlopen(request) as response:  # nosec B310
             while True:
                 chunk = response.read(1024 * 1024)
                 if not chunk:
@@ -359,19 +364,25 @@ def get_card_metadata(path: str, names: Sequence[str]) -> Dict[str, Dict[str, bo
     if not names:
         return {}
     unique_names = list(dict.fromkeys(names))
-    placeholders = ','.join('?' for _ in unique_names)
-    if not placeholders:
-        return {}
     with open_card_database(path) as connection:
         _ensure_schema(connection)
+        connection.execute(
+            "CREATE TEMP TABLE IF NOT EXISTS requested_card_names (name TEXT PRIMARY KEY)"
+        )
+        connection.execute("DELETE FROM requested_card_names")
+        connection.executemany(
+            "INSERT OR IGNORE INTO requested_card_names(name) VALUES (?)",
+            ((name,) for name in unique_names),
+        )
         rows = connection.execute(
-            f"""
-            SELECT name, is_land, is_basic_land, is_standard_banned, is_vintage_restricted,
-                   type_line, primary_type
+            """
+            SELECT cards.name, cards.is_land, cards.is_basic_land,
+                   cards.is_standard_banned, cards.is_vintage_restricted,
+                   cards.type_line, cards.primary_type
             FROM cards
-            WHERE name IN ({placeholders})
-            """,
-            tuple(unique_names),
+            INNER JOIN requested_card_names requested
+                ON requested.name = cards.name
+            """
         ).fetchall()
     metadata: Dict[str, Dict[str, bool]] = {}
     for row in rows:

--- a/app/models.py
+++ b/app/models.py
@@ -4,7 +4,6 @@ from datetime import datetime, timezone
 from sqlalchemy import UniqueConstraint
 import uuid
 import os
-import random
 import json
 import secrets
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
@@ -316,7 +315,7 @@ class Tournament(db.Model):
     round_timer_remaining = db.Column(db.Integer, nullable=True)
     draft_timer_remaining = db.Column(db.Integer, nullable=True)
     deck_timer_remaining = db.Column(db.Integer, nullable=True)
-    passcode = db.Column(db.String(4), nullable=False, default=lambda: f"{random.randint(0,9999):04d}")
+    passcode = db.Column(db.String(4), nullable=False, default=lambda: f"{secrets.randbelow(10000):04d}")
     join_requires_approval = db.Column(db.Boolean, default=False)
     league_id = db.Column(db.Integer, db.ForeignKey('league.id'), nullable=True)
     venue_id = db.Column(db.Integer, db.ForeignKey('venue.id'), nullable=True)

--- a/app/pairing.py
+++ b/app/pairing.py
@@ -1,5 +1,6 @@
 import json
 import random
+import secrets
 from itertools import combinations
 from .models import Tournament, TournamentPlayer, Match, MatchResult, Round
 
@@ -288,7 +289,7 @@ def round_robin_pair_round(t: Tournament, r: Round, session):
             bye_player = pid1 or pid2
             m = Match(round_id=r.id, table_number=table, player1_id=bye_player, player2_id=None)
         else:
-            if random.random() < 0.5:
+            if secrets.randbelow(2) == 0:
                 pid1, pid2 = pid2, pid1
             m = Match(round_id=r.id, table_number=table, player1_id=pid1, player2_id=pid2)
         session.add(m)

--- a/tests/test_card_db.py
+++ b/tests/test_card_db.py
@@ -51,3 +51,15 @@ def test_build_card_database_sends_user_agent(monkeypatch, tmp_path):
     assert seen['request'].full_url == 'https://mtgjson.example/cards.zip'
     assert seen['request'].get_header('User-agent') == card_db.CARD_DB_USER_AGENT
     assert card_db.lookup_card(str(db_path), 'Black Lotus') == 'Black Lotus'
+
+
+def test_build_card_database_rejects_non_https_urls(tmp_path):
+    db_path = tmp_path / 'cards.db'
+
+    for source_url in ['http://mtgjson.example/cards.zip', 'file:///tmp/cards.zip', 'mtgjson.example/cards.zip']:
+        try:
+            card_db.build_card_database(str(db_path), source_url=source_url)
+        except ValueError as exc:
+            assert 'https URL' in str(exc)
+        else:
+            raise AssertionError(f'{source_url} should have been rejected')

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -150,6 +150,20 @@ def test_registration_sends_mailgun_pin_and_requires_verification(client, sessio
     assert session.query(PendingRegistration).filter_by(email='new@example.com').first() is None
 
 
+def test_mailgun_domain_validation_rejects_url_syntax(app):
+    from app.app import _mailgun_messages_url
+
+    assert _mailgun_messages_url('mg.example.com') == 'https://api.mailgun.net/v3/mg.example.com/messages'
+
+    for domain in ['https://evil.example', 'mg.example.com/messages', 'mg..example.com', 'file:mg.example.com']:
+        try:
+            _mailgun_messages_url(domain)
+        except RuntimeError as exc:
+            assert 'Mailgun domain' in str(exc) or 'Mailgun API URL' in str(exc)
+        else:
+            raise AssertionError(f'{domain} should have been rejected')
+
+
 def test_invite_only_registration_requires_tournament_passcode(client, session, app, monkeypatch):
     from app.models import Tournament
 


### PR DESCRIPTION
### Motivation
- Address static analysis findings that allowed unexpected URL schemes and unsafe query construction, and replace insecure randomness in security-sensitive contexts. 
- Prevent attackers or misconfiguration from causing `urlopen` to access local or non-HTTPS endpoints and avoid SQL injection-style risks from dynamic `IN (...)` string construction. 

### Description
- Validate card database download URLs in `app/card_db.py` by parsing with `urlparse` and rejecting non-`https` absolute URLs in `_card_database_request`, and annotate the guarded `urlopen` with `# nosec B310`. 
- Replace dynamic `IN` list SQL construction in `get_card_metadata` with a temporary table populated via `executemany` and a safe `JOIN` to avoid building queries from untrusted input. 
- Add `MAILGUN_DOMAIN_PATTERN` and `_mailgun_messages_url` in `app/app.py` to validate Mailgun domains and pin Mailgun requests to `https://api.mailgun.net/`, and mark the `urlopen` call with `# nosec B310`. 
- Replace uses of `random` for security-sensitive operations with `secrets` usages: use `secrets.randbelow(10000)` for tournament `passcode` in `app/models.py` and `secrets.randbelow(2)` for the coin-flip in `app/pairing.py`. 
- Add regression tests: `tests/test_card_db.py::test_build_card_database_rejects_non_https_urls` and `tests/test_users.py::test_mailgun_domain_validation_rejects_url_syntax` to cover the new validation behavior. 

### Testing
- Ran `python -m compileall -q app tests` which completed successfully. 
- Ran `python -m bandit -q -r app` after changes with no new high/medium findings reported. 
- Ran `pytest -q` and all tests passed (`68 passed`, with expected deprecation warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20a2118d7483209908a4a30f6a7d66)

## Summary by Sourcery

Tighten external URL handling and randomness in security-sensitive code while addressing static analysis findings.

Bug Fixes:
- Validate card database download URLs to allow only absolute HTTPS endpoints and reject invalid schemes.
- Constrain Mailgun API requests to well-formed domain names and the https://api.mailgun.net/ endpoint to prevent unsafe URL usage.
- Avoid constructing dynamic IN clauses for card metadata lookups by using a temporary table join instead, preventing unsafe query composition.
- Replace insecure use of the random module in tournament passcode generation and pairing coin flips with cryptographically safer randomness.

Tests:
- Add regression tests to enforce rejection of non-HTTPS card database URLs.
- Add regression tests to enforce Mailgun domain validation and rejection of URL-like or malformed domains.