### PR TITLE
Realign bulk registration, add admin current-connections, client IP logging, name fields, and table allocation improvements

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -33,6 +33,7 @@ import io
 import glob
 import secrets
 import csv
+import hashlib
 import urllib.parse
 import urllib.request
 from collections import OrderedDict
@@ -57,6 +58,7 @@ db = SQLAlchemy()
 login_manager = LoginManager()
 PASSWORD_KEY = None
 PASSWORD_SEED = None
+CURRENT_CONNECTIONS = OrderedDict()
 
 MAJOR_60_CARD_FORMATS = [
     'Standard',
@@ -237,6 +239,14 @@ def create_app():
             if 'permission_overrides' not in columns:
                 db.session.execute(text('ALTER TABLE user ADD COLUMN permission_overrides TEXT'))
                 db.session.commit()
+            if 'first_name' not in columns:
+                db.session.execute(text('ALTER TABLE user ADD COLUMN first_name VARCHAR(80)'))
+                db.session.execute(text("UPDATE user SET first_name=trim(substr(name, 1, CASE WHEN instr(name, ' ') = 0 THEN length(name) ELSE instr(name, ' ') - 1 END)) WHERE first_name IS NULL"))
+                db.session.commit()
+            if 'last_name' not in columns:
+                db.session.execute(text('ALTER TABLE user ADD COLUMN last_name VARCHAR(80)'))
+                db.session.execute(text("UPDATE user SET last_name=trim(CASE WHEN instr(name, ' ') = 0 THEN '' ELSE substr(name, instr(name, ' ') + 1) END) WHERE last_name IS NULL"))
+                db.session.commit()
         if 'message' in inspector.get_table_names():
             columns = [c['name'] for c in inspector.get_columns('message')]
             if 'sender_key_encrypted' not in columns:
@@ -298,6 +308,12 @@ def create_app():
 
         logs_engine = db.engines['logs']
         SiteLog.__table__.create(bind=logs_engine, checkfirst=True)
+        logs_inspector = inspect(logs_engine)
+        if 'site_log' in logs_inspector.get_table_names():
+            log_columns = [c['name'] for c in logs_inspector.get_columns('site_log')]
+            if 'ip_address' not in log_columns:
+                with logs_engine.begin() as conn:
+                    conn.execute(text('ALTER TABLE site_log ADD COLUMN ip_address VARCHAR(64)'))
         TournamentLog.__table__.create(bind=logs_engine, checkfirst=True)
         logs_inspector = inspect(logs_engine)
         log_tables = logs_inspector.get_table_names()
@@ -408,8 +424,8 @@ def create_app():
     TYPE_SORT_INDEX = {name: idx for idx, name in enumerate(TYPE_SORT_ORDER)}
 
     def _tournament_group_size(tournament):
-        fmt = (tournament.format or '').lower()
-        return 4 if fmt == 'commander' else 2
+        # Table reservations are based on physical two-seat tables.
+        return 2
 
     def _active_player_count(tournament):
         return sum(1 for p in getattr(tournament, 'players', []) if not getattr(p, 'dropped', False))
@@ -454,6 +470,17 @@ def create_app():
             if not errors:
                 return candidate
         return max_start
+
+    def table_reservations(exclude_tournament_id=None):
+        reservations = []
+        query = db.session.query(Tournament)
+        if exclude_tournament_id:
+            query = query.filter(Tournament.id != exclude_tournament_id)
+        for other in query.all():
+            start, end, tables, _ = compute_table_allocation(other)
+            if tables:
+                reservations.append({'start': start, 'end': end, 'name': other.name})
+        return reservations
 
     def tournament_has_capacity(tournament, slots=1):
         cap = getattr(tournament, 'player_cap', None)
@@ -629,7 +656,29 @@ def create_app():
         forwarded = request.headers.get('X-Forwarded-For', '')
         if forwarded:
             return forwarded.split(',')[0].strip()
+        real_ip = request.headers.get('X-Real-IP') or request.headers.get('CF-Connecting-IP')
+        if real_ip:
+            return real_ip.split(',')[0].strip()
         return request.remote_addr or 'unknown'
+
+    def _browser_fingerprint():
+        user_agent = request.headers.get('User-Agent', '')
+        accept_language = request.headers.get('Accept-Language', '')
+        raw = f'{user_agent}|{accept_language}'
+        return hashlib.sha256(raw.encode()).hexdigest()[:16]
+
+    def _split_name(name):
+        parts = (name or '').strip().split(None, 1)
+        return (parts[0] if parts else '', parts[1] if len(parts) > 1 else '')
+
+    def _set_user_name_parts(user, first_name=None, last_name=None, fallback_name=None):
+        first = (first_name or '').strip()
+        last = (last_name or '').strip()
+        if not first and not last and fallback_name:
+            first, last = _split_name(fallback_name)
+        user.first_name = first or None
+        user.last_name = last or None
+        user.name = ' '.join(part for part in [first, last] if part).strip() or (fallback_name or '').strip()
 
     def _hash_reset_token(token):
         key_material = app.config['SECRET_KEY'].encode()
@@ -772,7 +821,9 @@ def create_app():
             flash('Registration is currently closed. Contact an administrator for access.', 'error')
         if request.method == 'POST':
             email = request.form['email'].strip().lower()
-            name = request.form['name'].strip()
+            first_name = request.form.get('first_name', '').strip()
+            last_name = request.form.get('last_name', '').strip()
+            name = request.form.get('name', '').strip() or ' '.join(part for part in [first_name, last_name] if part).strip()
             password = request.form['password']
             confirm = request.form.get('password_confirm', '')
             tournament_id = request.form.get('tournament_id')
@@ -868,6 +919,7 @@ def create_app():
                 return redirect(url_for('register'))
         role_user = db.session.query(Role).filter_by(name='user').first()
         u = User(email=pending.email, name=pending.name, role=role_user)
+        _set_user_name_parts(u, fallback_name=pending.name)
         stored_password = password or ''
         u.password_hash = pending.password_hash
         u.salt = pending.salt
@@ -1426,6 +1478,7 @@ def create_app():
         return {
             'nav_unread_messages': unread,
             'nav_open_reports': open_reports,
+            'nav_registration_mode': registration_mode(),
         }
 
     @app.route('/reports', methods=['GET', 'POST'])
@@ -1698,7 +1751,8 @@ def create_app():
 
     def log_site(action, result, error=None):
         log = SiteLog(action=action, result=result, error=error,
-                      user_id=current_user.id if current_user.is_authenticated else None)
+                      user_id=current_user.id if current_user.is_authenticated else None,
+                      ip_address=_client_ip())
         db.session.add(log)
         db.session.commit()
 
@@ -1707,6 +1761,24 @@ def create_app():
                              user_id=current_user.id if current_user.is_authenticated else None)
         db.session.add(log)
         db.session.commit()
+
+    @app.before_request
+    def track_current_connection():
+        if request.endpoint == 'static':
+            return
+        ip_address = _client_ip()
+        fingerprint = _browser_fingerprint()
+        key = f'{ip_address}:{fingerprint}'
+        CURRENT_CONNECTIONS[key] = {
+            'ip_address': ip_address,
+            'fingerprint': fingerprint,
+            'user_id': current_user.id if current_user.is_authenticated else None,
+            'user_name': current_user.name if current_user.is_authenticated else None,
+            'user_agent': request.headers.get('User-Agent', ''),
+            'last_seen': datetime.utcnow(),
+        }
+        while len(CURRENT_CONNECTIONS) > 250:
+            CURRENT_CONNECTIONS.popitem(last=False)
 
     @app.before_request
     def block_blacklisted_ip():
@@ -2083,6 +2155,8 @@ def create_app():
                     'id': u.id,
                     'email': u.email,
                     'name': u.name,
+                    'first_name': u.first_name,
+                    'last_name': u.last_name,
                     'password_hash': u.password_hash,
                     'salt': u.salt,
                     'is_admin': bool(u.is_admin),
@@ -2376,13 +2450,14 @@ def create_app():
             is_new = user is None
             if is_new:
                 user = User(name=name)
+                _set_user_name_parts(user, fallback_name=name)
                 db.session.add(user)
             if overwrite or is_new:
                 role = role_map.get(item.get('role_id'))
                 if not role and item.get('role_name'):
                     role = db.session.query(Role).filter_by(name=item.get('role_name')).first()
                 user.email = email
-                user.name = name
+                _set_user_name_parts(user, item.get('first_name'), item.get('last_name'), name)
                 user.password_hash = item.get('password_hash')
                 user.salt = item.get('salt')
                 user.is_admin = bool(item.get('is_admin'))
@@ -2693,6 +2768,7 @@ def create_app():
             'venues': venues,
             'formats': TOURNAMENT_FORMATS,
             'suggested_start_table_number': 1,
+            'table_reservations': table_reservations(),
         }
         if request.method == 'POST':
             provided_name = request.form['name'].strip()
@@ -2804,6 +2880,7 @@ def create_app():
             'formats': TOURNAMENT_FORMATS,
             'provided_name': extract_provided_tournament_name(t.name),
             'suggested_start_table_number': suggested_start_table_number,
+            'table_reservations': table_reservations(t.id),
         }
         if request.method == 'POST':
             provided_name = request.form['name'].strip()
@@ -3579,7 +3656,9 @@ def create_app():
         tournaments = db.session.query(Tournament).order_by(Tournament.created_at.desc()).all()
         if request.method == 'POST':
             email = request.form['email'].strip().lower()
-            name = request.form['name'].strip()
+            first_name = request.form.get('first_name', '').strip()
+            last_name = request.form.get('last_name', '').strip()
+            name = request.form.get('name', '').strip() or ' '.join(part for part in [first_name, last_name] if part).strip()
             password = request.form['password']
             password_confirm = request.form.get('password_confirm', '')
             if password != password_confirm:
@@ -3591,6 +3670,7 @@ def create_app():
             else:
                 role_user = db.session.query(Role).filter_by(name='user').first()
                 u = User(email=email, name=name, role=role_user)
+                _set_user_name_parts(u, request.form.get('first_name'), request.form.get('last_name'), name)
                 u.set_password(password)
                 db.session.add(u)
                 db.session.commit()
@@ -3643,6 +3723,7 @@ def create_app():
                     continue
                 role_user = db.session.query(Role).filter_by(name='user').first()
                 u = User(name=name, role=role_user)
+                _set_user_name_parts(u, fallback_name=name)
                 db.session.add(u)
                 db.session.flush()
                 if tournament_id:
@@ -3671,38 +3752,44 @@ def create_app():
                 db.session.commit()
                 log_site('site_settings_update', 'success', f'registration_mode={mode}')
                 flash('Site settings saved.', 'success')
-            elif action == 'invite':
-                email = request.form.get('email', '').strip().lower()
-                if not email:
-                    flash('Invite email is required.', 'error')
-                elif db.session.query(User).filter_by(email=email).first():
-                    flash('That email already belongs to a user.', 'error')
-                else:
-                    token = secrets.token_urlsafe(32)
-                    invite = RegistrationInvite(
-                        email=email,
-                        token_hash=_hash_registration_token(token),
-                        created_by_id=current_user.id,
-                        expires_at=datetime.utcnow() + timedelta(days=app.config.get('REGISTRATION_INVITE_TTL_DAYS', 14)),
-                    )
-                    db.session.add(invite)
-                    try:
-                        _send_registration_invite(invite, token)
-                    except Exception as exc:
-                        db.session.rollback()
-                        log_site('registration_invite', 'failure', str(exc))
-                        flash('Invite email could not be sent. Check mail settings.', 'error')
-                        return redirect(url_for('site_settings'))
-                    db.session.commit()
-                    log_site('registration_invite', 'sent', f'invite_id={invite.id}; email={email}')
-                    flash('Registration invite sent.', 'success')
             return redirect(url_for('site_settings'))
-        invites = db.session.query(RegistrationInvite).order_by(RegistrationInvite.created_at.desc()).all()
         return render_template(
             'admin/site_settings.html',
             registration_mode=registration_mode(),
-            invites=invites,
         )
+
+    @app.route('/admin/registration-invites', methods=['GET', 'POST'])
+    @login_required
+    def admin_registration_invites():
+        require_permission('admin.site_settings')
+        if request.method == 'POST':
+            email = request.form.get('email', '').strip().lower()
+            if not email:
+                flash('Invite email is required.', 'error')
+            elif db.session.query(User).filter_by(email=email).first():
+                flash('That email already belongs to a user.', 'error')
+            else:
+                token = secrets.token_urlsafe(32)
+                invite = RegistrationInvite(
+                    email=email,
+                    token_hash=_hash_registration_token(token),
+                    created_by_id=current_user.id,
+                    expires_at=datetime.utcnow() + timedelta(days=app.config.get('REGISTRATION_INVITE_TTL_DAYS', 14)),
+                )
+                db.session.add(invite)
+                try:
+                    _send_registration_invite(invite, token)
+                except Exception as exc:
+                    db.session.rollback()
+                    log_site('registration_invite', 'failure', str(exc))
+                    flash('Invite email could not be sent. Check mail settings.', 'error')
+                    return redirect(url_for('admin_registration_invites'))
+                db.session.commit()
+                log_site('registration_invite', 'sent', f'invite_id={invite.id}; email={email}')
+                flash('Registration invite sent.', 'success')
+            return redirect(url_for('admin_registration_invites'))
+        invites = db.session.query(RegistrationInvite).order_by(RegistrationInvite.created_at.desc()).all()
+        return render_template('admin/registration_invites.html', invites=invites)
 
     @app.route('/admin/panel', methods=['GET', 'POST'])
     def admin_panel():
@@ -3874,6 +3961,38 @@ def create_app():
             mimetype='text/plain',
             headers={'Content-Disposition': 'attachment; filename=walter_bad_ips_iptables.sh'},
         )
+
+    @app.route('/admin/current-connections')
+    def admin_current_connections():
+        require_admin()
+        cutoff = datetime.utcnow() - timedelta(minutes=30)
+        connections = [
+            item for item in CURRENT_CONNECTIONS.values()
+            if item.get('last_seen') and item['last_seen'] >= cutoff
+        ]
+        connections.sort(key=lambda item: item['last_seen'], reverse=True)
+        log_site('view_current_connections', 'success')
+        return render_template('admin/current_connections.html', connections=connections)
+
+    @app.route('/admin/current-connections/blacklist', methods=['POST'])
+    def admin_blacklist_connection():
+        require_permission('admin.ip_blacklist')
+        ip_address = (request.form.get('ip_address') or '').strip()
+        if not ip_address:
+            flash('Missing IP address.', 'error')
+            return redirect(url_for('admin_current_connections'))
+        item = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address).first()
+        if not item:
+            item = BlacklistedIP(ip_address=ip_address, created_by_id=current_user.id)
+            db.session.add(item)
+        item.is_active = True
+        item.reason = request.form.get('reason') or 'Blacklisted from current connections'
+        if not item.created_by_id:
+            item.created_by_id = current_user.id
+        db.session.commit()
+        log_site('ip_blacklist_connection', 'success', f'ip={ip_address}')
+        flash(f'{ip_address} has been blacklisted.', 'success')
+        return redirect(url_for('admin_current_connections'))
 
     @app.route('/admin/tournaments/bulk', methods=['POST'])
     @login_required
@@ -4106,8 +4225,10 @@ def create_app():
             if player_user_ids:
                 user_query = user_query.filter(~User.id.in_(player_user_ids))
             available_users = user_query.order_by(User.name).all()
+        table_start, table_end, table_count, _ = compute_table_allocation(t)
         return render_template('tournament/view.html', t=t, players=players, rounds=rounds,
                                standings=standings, rec_rounds=rec_rounds,
+                               table_range=_format_table_range(table_start, table_end, table_count),
                                timer_end=timer_end, timer_type=timer_type,
                                timer_remaining=timer_remaining,
                                is_player=is_player, show_passcode=show_passcode,
@@ -4581,6 +4702,7 @@ def create_app():
                 return redirect(url_for('view_tournament', tid=tid))
             role_user = db.session.query(Role).filter_by(name='user').first()
             player = User(name=new_name, email=email_value, role=role_user)
+            _set_user_name_parts(player, fallback_name=new_name)
             db.session.add(player)
             db.session.flush()
             created_user = True
@@ -5374,7 +5496,16 @@ def create_app():
                 u.locked_at = None
                 u.lock_reason = None
                 log_events.append(('admin_account_unlock', 'success', f'user_id={u.id}'))
+            first_name = request.form.get('first_name', '').strip()
+            last_name = request.form.get('last_name', '').strip()
+            if 'first_name' not in request.form and 'last_name' not in request.form:
+                first_name = u.first_name or _split_name(u.name)[0]
+                last_name = u.last_name or _split_name(u.name)[1]
+            if not first_name and not last_name:
+                flash('First or last name is required.', 'error')
+                return redirect(redirect_target)
             u.email = email
+            _set_user_name_parts(u, first_name, last_name, request.form.get('name'))
             u.notes = request.form.get('notes', '').strip() or None
             role_id = request.form.get('role_id')
             if role_id:

--- a/app/models.py
+++ b/app/models.py
@@ -106,6 +106,8 @@ class User(db.Model, UserMixin):
     # requiring login credentials.
     email = db.Column(db.String(255), unique=True, nullable=True)
     name = db.Column(db.String(120), nullable=False)
+    first_name = db.Column(db.String(80), nullable=True)
+    last_name = db.Column(db.String(80), nullable=True)
     password_hash = db.Column(db.Text, nullable=True)
     salt = db.Column(db.String(32), nullable=True)
     is_admin = db.Column(db.Boolean, default=False)
@@ -401,6 +403,7 @@ class SiteLog(db.Model):
     error = db.Column(db.Text, nullable=True)
     timestamp = db.Column(db.DateTime, default=utc_now)
     user_id = db.Column(db.Integer, nullable=True)
+    ip_address = db.Column(db.String(64), nullable=True)
     # relationship loaded manually to avoid cross-db foreign key
 
 class TournamentLog(db.Model):

--- a/app/templates/admin/bulk_register_players.html
+++ b/app/templates/admin/bulk_register_players.html
@@ -4,34 +4,60 @@
   <div class="page-header__title">
     <span class="eyebrow">Tournament Tools</span>
     <h2>Bulk Register Players</h2>
-    <p class="page-description">Create placeholder player records from a list, add existing people with a multi-select, or do both at once.</p>
+    <p class="page-description">Choose one tournament, find existing users quickly, and paste new player names in a clean two-step layout.</p>
   </div>
 </section>
-<form method="post" class="panel-card stacked-form">
-  <div class="form-grid two-column bulk-register-grid">
+<form method="post" class="panel-card stacked-form bulk-register-form">
+  <section class="form-section">
+    <h3>1. Tournament</h3>
     <label>Tournament
       <select name="tournament_id">
-        <option value="">-- None --</option>
+        <option value="">-- Create players only --</option>
         {% for t in tournaments %}
           <option value="{{ t.id }}">{{ t.name }}</option>
         {% endfor %}
       </select>
     </label>
-    <label>Existing people in system
-      <select name="existing_user_ids" multiple size="12" class="multi-select">
-        {% for user in existing_users %}
-          <option value="{{ user.id }}">{{ user.name }}{% if user.email %} — {{ user.email }}{% endif %}</option>
-        {% endfor %}
-      </select>
-      <span class="field-help">Hold Ctrl/Command or Shift to select multiple people. Existing people are added to the selected tournament.</span>
-    </label>
+  </section>
+
+  <div class="form-grid two-column bulk-register-grid">
+    <section class="form-section">
+      <h3>2. Add Existing People</h3>
+      <label>Search existing people
+        <input type="search" id="bulk-player-search" placeholder="Type a name or email...">
+      </label>
+      <label>People
+        <select name="existing_user_ids" multiple size="12" class="multi-select" id="bulk-player-select">
+          {% for user in existing_users %}
+            <option value="{{ user.id }}">{{ user.name }}{% if user.email %} — {{ user.email }}{% endif %}</option>
+          {% endfor %}
+        </select>
+      </label>
+      <span class="field-help">Hold Ctrl/Command or Shift to select multiple people. Existing people are added only when a tournament is selected.</span>
+    </section>
+
+    <section class="form-section">
+      <h3>3. Create New Players</h3>
+      <label>New player names (one per line)
+        <textarea name="names" rows="12" placeholder="Ada Lovelace&#10;Grace Hopper&#10;Katherine Johnson"></textarea>
+      </label>
+      <span class="field-help">New names create player records. If a tournament is selected, they are also added to it.</span>
+    </section>
   </div>
-  <label>New player names (one per line)
-    <textarea name="names" rows="10" placeholder="Ada Lovelace&#10;Grace Hopper&#10;Katherine Johnson"></textarea>
-    <span class="field-help">New names create player records. If a tournament is selected, they are also added to it.</span>
-  </label>
   <div class="form-actions">
     <button class="btn" type="submit">Register / Add Players</button>
   </div>
 </form>
+<script>
+const bulkPlayerSearch = document.getElementById('bulk-player-search');
+const bulkPlayerSelect = document.getElementById('bulk-player-select');
+if (bulkPlayerSearch && bulkPlayerSelect) {
+  bulkPlayerSearch.addEventListener('input', function(){
+    const query = bulkPlayerSearch.value.trim().toLowerCase();
+    Array.prototype.forEach.call(bulkPlayerSelect.options, function(option){
+      option.hidden = query && !option.text.toLowerCase().includes(query);
+    });
+  });
+}
+</script>
 {% endblock %}

--- a/app/templates/admin/current_connections.html
+++ b/app/templates/admin/current_connections.html
@@ -1,0 +1,36 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header">
+  <div class="page-header__title">
+    <span class="eyebrow">Admin</span>
+    <h2>Current Connections</h2>
+    <p class="page-description">Recent client connections seen by this WaLTER process in the last 30 minutes.</p>
+  </div>
+</section>
+<section class="panel-card">
+  {% if connections %}
+  <table class="table compact-table">
+    <thead><tr><th>IP</th><th>Browser fingerprint</th><th>User</th><th>Last seen</th><th>User agent</th><th>Action</th></tr></thead>
+    <tbody>
+      {% for connection in connections %}
+      <tr>
+        <td>{{ connection.ip_address }}</td>
+        <td><code>{{ connection.fingerprint }}</code></td>
+        <td>{{ connection.user_name or 'Anonymous' }}</td>
+        <td>{{ connection.last_seen }}</td>
+        <td class="muted-text">{{ connection.user_agent or '-' }}</td>
+        <td>
+          <form method="post" action="{{ url_for('admin_blacklist_connection') }}" onsubmit="return confirm('Blacklist {{ connection.ip_address }}?');">
+            <input type="hidden" name="ip_address" value="{{ connection.ip_address }}">
+            <button class="btn danger" type="submit">Blacklist</button>
+          </form>
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-state compact-empty">No recent connections have been recorded.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/admin/edit_tournament.html
+++ b/app/templates/admin/edit_tournament.html
@@ -117,6 +117,36 @@
   </table>
 </form>
 <script>
+
+const tableReservations = {{ table_reservations|tojson }};
+const capInput = document.querySelector('input[name="player_cap"]');
+const startTableInput = document.querySelector('input[name="start_table_number"]');
+let tableStartTouched = false;
+if(startTableInput){
+  startTableInput.addEventListener('input', function(){ tableStartTouched = true; });
+}
+function lowestAvailableTableStart(cap){
+  const tablesNeeded = Math.max(1, Math.ceil((parseInt(cap, 10) || 1) / 2));
+  for(let candidate = 1; candidate < 10000; candidate++){
+    const end = candidate + tablesNeeded - 1;
+    const overlaps = tableReservations.some(function(range){
+      return !(end < range.start || candidate > range.end);
+    });
+    if(!overlaps){ return candidate; }
+  }
+  return 1;
+}
+if(capInput && startTableInput){
+  capInput.addEventListener('input', function(){
+    if(!tableStartTouched){
+      startTableInput.value = lowestAvailableTableStart(capInput.value);
+    }
+  });
+  if(capInput.value && !startTableInput.value){
+    startTableInput.value = lowestAvailableTableStart(capInput.value);
+  }
+}
+
 const fmtSel = document.querySelector('#tournament-format');
 const structureSel = document.querySelector('#tournament-structure');
 const cutSel = document.querySelector('select[name="cut"]');

--- a/app/templates/admin/league_detail.html
+++ b/app/templates/admin/league_detail.html
@@ -56,7 +56,7 @@
 <section class="league-actions-grid">
   <form method="post" class="panel-card modern-form">
     <input type="hidden" name="action" value="add_players">
-    <h3>Assign Players</h3>
+    <h3>Assign Players / Mass Add</h3>
     <div class="league-player-search">
       <label>Search players
         <input type="search" id="league-player-search" placeholder="Type a player name or email...">
@@ -122,7 +122,6 @@
   <p class="empty-state">No tournament results have been imported yet.</p>
   {% endif %}
 </section>
-{% endblock %}
 
 <script>
 const leaguePlayerSearch = document.getElementById('league-player-search');
@@ -136,3 +135,4 @@ if (leaguePlayerSearch && leaguePlayerSelect) {
   });
 }
 </script>
+{% endblock %}

--- a/app/templates/admin/new_tournament.html
+++ b/app/templates/admin/new_tournament.html
@@ -123,6 +123,36 @@
   </table>
 </form>
 <script>
+
+const tableReservations = {{ table_reservations|tojson }};
+const capInput = document.querySelector('input[name="player_cap"]');
+const startTableInput = document.querySelector('input[name="start_table_number"]');
+let tableStartTouched = false;
+if(startTableInput){
+  startTableInput.addEventListener('input', function(){ tableStartTouched = true; });
+}
+function lowestAvailableTableStart(cap){
+  const tablesNeeded = Math.max(1, Math.ceil((parseInt(cap, 10) || 1) / 2));
+  for(let candidate = 1; candidate < 10000; candidate++){
+    const end = candidate + tablesNeeded - 1;
+    const overlaps = tableReservations.some(function(range){
+      return !(end < range.start || candidate > range.end);
+    });
+    if(!overlaps){ return candidate; }
+  }
+  return 1;
+}
+if(capInput && startTableInput){
+  capInput.addEventListener('input', function(){
+    if(!tableStartTouched){
+      startTableInput.value = lowestAvailableTableStart(capInput.value);
+    }
+  });
+  if(capInput.value && !startTableInput.value){
+    startTableInput.value = lowestAvailableTableStart(capInput.value);
+  }
+}
+
 const fmtSel = document.querySelector('#tournament-format');
 const structureSel = document.querySelector('#tournament-structure');
 const cutSel = document.querySelector('select[name="cut"]');

--- a/app/templates/admin/panel.html
+++ b/app/templates/admin/panel.html
@@ -33,6 +33,7 @@
 <section class="panel-card">
   <div class="section-heading"><div><h3>Security Controls</h3><p>Audit bad logins and manage IP lockouts.</p></div></div>
   <div class="form-actions">
+    <a class="btn" href="{{ url_for('admin_current_connections') }}">Current Connections</a>
     <a class="btn" href="{{ url_for('admin_bad_logins') }}">Bad Login Audit</a>
     <a class="btn" href="{{ url_for('admin_ip_blacklist') }}">IP Blacklist</a>
   </div>

--- a/app/templates/admin/register_player.html
+++ b/app/templates/admin/register_player.html
@@ -5,8 +5,12 @@
   <table class="table center-table">
     <tbody>
       <tr>
-        <td>Name</td>
-        <td><input name="name" required></td>
+        <td>First Name</td>
+        <td><input name="first_name" required></td>
+      </tr>
+      <tr>
+        <td>Last Name</td>
+        <td><input name="last_name" required></td>
       </tr>
       <tr>
         <td>Email</td>

--- a/app/templates/admin/registration_invites.html
+++ b/app/templates/admin/registration_invites.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header">
+  <div class="page-header__title">
+    <span class="eyebrow">Admin</span>
+    <h2>Registration Invites</h2>
+    <p class="page-description">Send audited registration invite links and review invite history.</p>
+  </div>
+</section>
+<section class="panel-card">
+  <h3>Send Registration Invite</h3>
+  <form method="post" class="form-grid two-column">
+    <label>Email
+      <input type="email" name="email" required placeholder="player@example.com">
+    </label>
+    <div class="form-actions start-actions"><button class="btn" type="submit">Send Invite</button></div>
+  </form>
+</section>
+<section class="panel-card">
+  <h3>Invite Log</h3>
+  {% if invites %}
+  <table class="table compact-table">
+    <thead><tr><th>Email</th><th>Status</th><th>Sent</th><th>Expires</th><th>Used</th><th>Admin</th></tr></thead>
+    <tbody>
+      {% for invite in invites %}
+      <tr>
+        <td>{{ invite.email }}</td>
+        <td>{{ invite.status }}</td>
+        <td>{{ invite.created_at }}</td>
+        <td>{{ invite.expires_at or '-' }}</td>
+        <td>{{ invite.used_at or '-' }}</td>
+        <td>{{ invite.created_by.name if invite.created_by else '-' }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-state compact-empty">No registration invites have been sent yet.</p>
+  {% endif %}
+</section>
+{% endblock %}

--- a/app/templates/admin/site_logs.html
+++ b/app/templates/admin/site_logs.html
@@ -2,11 +2,12 @@
 {% block content %}
 <h2>Site Logs</h2>
 <table>
-  <tr><th>Time</th><th>User</th><th>Action</th><th>Result</th><th>Error</th></tr>
+  <tr><th>Time</th><th>User</th><th>Client IP</th><th>Action</th><th>Result</th><th>Error</th></tr>
   {% for l in logs %}
   <tr>
     <td>{{ l.timestamp }}</td>
     <td>{{ l.user.name if l.user else '' }}</td>
+    <td>{{ l.ip_address or '' }}</td>
     <td>{{ l.action }}</td>
     <td>{{ l.result }}</td>
     <td>{{ l.error or '' }}</td>

--- a/app/templates/admin/site_settings.html
+++ b/app/templates/admin/site_settings.html
@@ -4,7 +4,7 @@
   <div class="page-header__title">
     <span class="eyebrow">Admin</span>
     <h2>Site Settings</h2>
-    <p class="page-description">Control public registration and send audited invite links.</p>
+    <p class="page-description">Control public registration access for new accounts.</p>
   </div>
 </section>
 
@@ -21,39 +21,5 @@
     </label>
     <div class="form-actions"><button class="btn" type="submit">Save Settings</button></div>
   </form>
-</section>
-
-<section class="panel-card">
-  <h3>Send Registration Invite</h3>
-  <form method="post" class="form-grid two-column">
-    <input type="hidden" name="action" value="invite">
-    <label>Email
-      <input type="email" name="email" required placeholder="player@example.com">
-    </label>
-    <div class="form-actions start-actions"><button class="btn" type="submit">Send Invite</button></div>
-  </form>
-</section>
-
-<section class="panel-card">
-  <h3>Invite Log</h3>
-  {% if invites %}
-  <table class="table compact-table">
-    <thead><tr><th>Email</th><th>Status</th><th>Sent</th><th>Expires</th><th>Used</th><th>Admin</th></tr></thead>
-    <tbody>
-      {% for invite in invites %}
-      <tr>
-        <td>{{ invite.email }}</td>
-        <td>{{ invite.status }}</td>
-        <td>{{ invite.created_at }}</td>
-        <td>{{ invite.expires_at or '-' }}</td>
-        <td>{{ invite.used_at or '-' }}</td>
-        <td>{{ invite.created_by.name if invite.created_by else '-' }}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% else %}
-  <p class="empty-state compact-empty">No registration invites have been sent yet.</p>
-  {% endif %}
 </section>
 {% endblock %}

--- a/app/templates/admin/user_detail.html
+++ b/app/templates/admin/user_detail.html
@@ -12,6 +12,14 @@
   <form method="post" action="{{ url_for('admin_update_user', uid=user.id) }}" class="user-settings-form">
     <input type="hidden" name="search_query" value="{{ search_query }}">
     <div class="form-row">
+      <label for="user-first-name">First Name</label>
+      <input id="user-first-name" name="first_name" value="{{ user.first_name or '' }}">
+    </div>
+    <div class="form-row">
+      <label for="user-last-name">Last Name</label>
+      <input id="user-last-name" name="last_name" value="{{ user.last_name or '' }}">
+    </div>
+    <div class="form-row">
       <label for="user-email">Email</label>
       <input id="user-email" type="email" name="email" value="{{ user.email or '' }}">
     </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -23,7 +23,7 @@
       </button>
       <nav class="app-nav" id="main-nav">
         <ul class="nav-list">
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">All Tournaments</a></li>
+          {% if current_user.is_authenticated %}<li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">All Tournaments</a></li>{% endif %}
           {% if current_user.is_authenticated %}
           <li class="nav-item"><a class="nav-link" href="{{ url_for('my_tournaments') }}">My Tournaments</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('messages_home') }}">Messages <span id="nav-messages-count" class="nav-badge{% if not nav_unread_messages %} hidden{% endif %}">{{ nav_unread_messages }}</span></a></li>
@@ -53,9 +53,11 @@
               {% endif %}
               {% if current_user.has_permission('admin.site_settings') %}
               <a class="dropdown-item" href="{{ url_for('site_settings') }}">Site Settings</a>
+              <a class="dropdown-item" href="{{ url_for('admin_registration_invites') }}">Registration Invites</a>
               {% endif %}
               {% if current_user.has_permission('admin.panel') %}
               <a class="dropdown-item" href="{{ url_for('admin_panel') }}">Admin Panel</a>
+              <a class="dropdown-item" href="{{ url_for('admin_current_connections') }}">Current Connections</a>
               <a class="dropdown-item" href="{{ url_for('site_logs') }}">Site Logs</a>
               <a class="dropdown-item" href="{{ url_for('admin_backup') }}">Backup &amp; Transfer</a>
               <a class="dropdown-item" href="{{ url_for('admin_reports') }}">Reports <span id="nav-reports-count" class="nav-badge{% if not nav_open_reports %} hidden{% endif %}">{{ nav_open_reports }}</span></a>
@@ -75,7 +77,7 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('logout') }}">Logout</a></li>
           {% else %}
           <li class="nav-item"><a class="nav-link" href="{{ url_for('login') }}">Login</a></li>
-          <li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}">Register</a></li>
+          {% if nav_registration_mode == 'open' %}<li class="nav-item"><a class="nav-link" href="{{ url_for('register') }}">Register</a></li>{% endif %}
           {% endif %}
         </ul>
       </nav>

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -9,8 +9,12 @@
   <form method="post" class="form-stacked">
     <input type="hidden" name="invite" value="{{ invite_token or '' }}">
     <div class="form-field">
-      <label for="name">Name</label>
-      <input id="name" name="name" required>
+      <label for="first_name">First Name</label>
+      <input id="first_name" name="first_name" required>
+    </div>
+    <div class="form-field">
+      <label for="last_name">Last Name</label>
+      <input id="last_name" name="last_name" required>
     </div>
     <div class="form-field">
       <label for="email">Email</label>

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -4,7 +4,7 @@
   <div class="page-header__title">
     <span class="eyebrow">Tournament Control</span>
     <h2>{{ t.name }}</h2>
-    <p class="page-description">{{ t.format }}{% if t.format == 'Draft' and t.is_cube %} · Cube{% endif %} · {{ t.cut|upper }} cut · {{ t.rules_enforcement_level }} REL</p>
+    <p class="page-description">{{ t.format }}{% if t.format == 'Draft' and t.is_cube %} · Cube{% endif %} · {{ t.cut|upper }} cut · {{ t.rules_enforcement_level }} REL · Tables {{ table_range }}</p>
   </div>
   <div class="page-header__actions">
     {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
@@ -17,6 +17,7 @@
 <section class="tournament-summary-grid">
   <div class="summary-card"><span>Players</span><strong>{{ players|length }}</strong></div>
   <div class="summary-card"><span>Rounds</span><strong>{{ rounds|length }} / {{ t.rounds_override or rec_rounds }}</strong></div>
+  <div class="summary-card"><span>Tables</span><strong>{{ table_range }}</strong></div>
   <div class="summary-card"><span>Venue</span><strong>{{ t.venue.name if t.venue else 'None' }}</strong></div>
   <div class="summary-card"><span>Head Judge</span><strong>{{ t.head_judge.name if t.head_judge else 'None' }}</strong></div>
   <div class="summary-card"><span>Floor Judges</span><strong>{% if floor_judges %}{% for u in floor_judges %}{{ u.name }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}None{% endif %}</strong></div>


### PR DESCRIPTION
### Motivation
- Make the bulk register UI easier to use by clearly separating tournament selection, existing-user lookup, and new-player paste steps. 
- Improve admin security tooling by surfacing recent client connections so staff can inspect and blacklist suspicious sources. 
- Record the actual client IP and browser fingerprint for auditing (site logs, bad login events) rather than relying on the server address. 
- Support first/last name fields and improve table-number allocation so starting table suggestions match physical two-seat tables and avoid overlapping reservations.

### Description
- Reworked the bulk player registration UI into a 1) tournament selector, 2) searchable existing-user multi-select, and 3) new-player paste area with client-side filtering (`app/templates/admin/bulk_register_players.html`).
- Added a current connections tracker and admin pages `GET /admin/current-connections` and `POST /admin/current-connections/blacklist` that display IP, browser fingerprint, user (if logged in), user-agent, last-seen, and provide a blacklist button; connections are kept in an in-memory `CURRENT_CONNECTIONS` map (`app/app.py`, `app/templates/admin/current_connections.html`).
- Log client IPs into the logs database (`SiteLog.ip_address`) and updated `_client_ip()` to prefer `X-Forwarded-For`, `X-Real-IP`, and `CF-Connecting-IP`; site logs now include client IP and the site logs template shows it (`app/models.py`, `app/app.py`, `app/templates/admin/site_logs.html`).
- Moved registration-invite sending/audit UI out of site settings into a dedicated admin page at `/admin/registration-invites` and simplified `site_settings` to only control registration mode (`app/app.py`, `app/templates/admin/registration_invites.html`, `app/templates/admin/site_settings.html`).
- Added schema upgrades and model fields for `User.first_name` and `User.last_name`, helper functions to split/compose names, and updated registration, admin user edit, and bulk import flows to populate and preserve first/last name fields (`app/models.py`, `app/app.py`, `app/templates/register.html`, `app/templates/admin/user_detail.html`, `app/templates/admin/register_player.html`).
- Changed table allocation logic to treat a physical table as two seats, added `table_reservations()` to compute reserved ranges, exposed suggestions to the new/edit tournament templates, added client-side logic to pre-fill the starting table number based on the player cap, and display the table range in tournament headers (`app/app.py`, `app/templates/admin/new_tournament.html`, `app/templates/admin/edit_tournament.html`, `app/templates/tournament/view.html`).
- Misc: moved league player search input above the assign/mass-add control, added small UI adjustments across admin templates, and hid public tournament browsing/register nav items for anonymous users unless registration mode is open (`app/templates/admin/league_detail.html`, `app/templates/base.html`).

### Testing
- Ran the full test suite with `pytest -q` and all automated tests passed: `68 passed` (with warnings). 
- Compiled and smoke-tested affected modules during development (`python -m py_compile` and targeted test runs) and verified templates render and admin endpoints exercise the new flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20b0d047ac8320a1cef15c500bcd49)

## Summary by Sourcery

Realign bulk player registration, introduce connection tracking and IP logging for security auditing, add first/last name support to user flows, and improve tournament table allocation and navigation behavior.

New Features:
- Add first_name and last_name fields to users and use them across registration, admin user management, and bulk creation flows.
- Introduce an in-memory current-connections tracker with admin UI to view recent clients and blacklist IPs.
- Add a dedicated admin page for managing registration invites with an audited invite log.
- Expose tournament table range information in tournament views and provide client-side suggestions for starting table numbers based on player caps and existing reservations.
- Enhance bulk player registration UI with separate tournament selection, searchable existing-user multi-select, and new-player paste area.

Enhancements:
- Record client IP addresses on site logs using forward headers when present and display them in the admin site logs table.
- Standardize table allocation to treat a physical table as two seats and surface existing reservations to avoid overlapping allocations.
- Hide public tournament listing and registration links for anonymous users unless registration is open, and surface registration mode in navigation context.
- Refine league player assignment layout and various admin UI texts and layouts for clarity.