### PR TITLE
Fix legacy bad login audit migration

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -298,6 +298,35 @@ def create_app():
                 db.session.commit()
 
         BadLoginAttempt.__table__.create(bind=db.engine, checkfirst=True)
+        inspector = inspect(db.engine)
+        if 'bad_login_attempt' in inspector.get_table_names():
+            columns = [c['name'] for c in inspector.get_columns('bad_login_attempt')]
+            if 'email' not in columns:
+                db.session.execute(text('ALTER TABLE bad_login_attempt ADD COLUMN email VARCHAR(255)'))
+                db.session.commit()
+            if 'user_id' not in columns:
+                db.session.execute(text('ALTER TABLE bad_login_attempt ADD COLUMN user_id INTEGER'))
+                db.session.commit()
+            if 'ip_address' not in columns:
+                db.session.execute(
+                    text("ALTER TABLE bad_login_attempt ADD COLUMN ip_address VARCHAR(64) NOT NULL DEFAULT ''")
+                )
+                db.session.commit()
+            if 'user_agent' not in columns:
+                db.session.execute(text('ALTER TABLE bad_login_attempt ADD COLUMN user_agent TEXT'))
+                db.session.commit()
+            if 'result' not in columns:
+                db.session.execute(
+                    text("ALTER TABLE bad_login_attempt ADD COLUMN result VARCHAR(50) NOT NULL DEFAULT 'bad_password'")
+                )
+                db.session.commit()
+            if 'created_at' not in columns:
+                db.session.execute(text('ALTER TABLE bad_login_attempt ADD COLUMN created_at DATETIME'))
+                db.session.execute(
+                    text('UPDATE bad_login_attempt SET created_at=CURRENT_TIMESTAMP WHERE created_at IS NULL')
+                )
+                db.session.commit()
+
         BlacklistedIP.__table__.create(bind=db.engine, checkfirst=True)
         PasswordResetToken.__table__.create(bind=db.engine, checkfirst=True)
         SiteSetting.__table__.create(bind=db.engine, checkfirst=True)

--- a/tests/test_db_upgrade.py
+++ b/tests/test_db_upgrade.py
@@ -156,3 +156,56 @@ def test_log_tables_created_on_startup(tmp_path, monkeypatch):
         assert 'site_log' in tables
         assert 'tournament_log' in tables
         db.session.remove()
+
+
+def test_legacy_bad_login_attempt_table_upgraded_and_used(tmp_path, monkeypatch):
+    db_path = tmp_path / "pre.db"
+    log_path = tmp_path / "logs.db"
+    conn = sqlite3.connect(db_path)
+    conn.execute(
+        """
+        CREATE TABLE bad_login_attempt (
+            id INTEGER PRIMARY KEY,
+            email VARCHAR(255)
+        )
+        """
+    )
+    conn.close()
+
+    monkeypatch.setenv("MTG_DB_PATH", str(db_path))
+    monkeypatch.setenv("MTG_LOG_DB_PATH", str(log_path))
+
+    app = create_app()
+    app.config['TESTING'] = True
+    app.config['ACCOUNT_LOCKOUT_ATTEMPTS'] = 3
+    with app.app_context():
+        from app.models import (
+            BadLoginAttempt,
+            DEFAULT_ROLE_LEVELS,
+            DEFAULT_ROLE_PERMISSIONS,
+            Role,
+            User,
+        )
+        import json
+
+        db.create_all()
+        user_role = Role(
+            name='user',
+            permissions=json.dumps(DEFAULT_ROLE_PERMISSIONS['user']),
+            level=DEFAULT_ROLE_LEVELS['user'],
+        )
+        user = User(email='legacy-lock@example.com', name='Legacy Lock', role=user_role)
+        user.set_password('secret')
+        db.session.add_all([user_role, user])
+        db.session.commit()
+
+        client = app.test_client()
+        for _ in range(3):
+            response = client.post('/login', data={'email': user.email, 'password': 'wrong'})
+            assert response.status_code == 200
+
+        db.session.refresh(user)
+        assert user.locked_at is not None
+        assert user.failed_login_count == 3
+        assert db.session.query(BadLoginAttempt).filter_by(email=user.email).count() == 3
+        db.session.remove()


### PR DESCRIPTION
### Motivation
- Older installations with a legacy `bad_login_attempt` table could be missing expected columns, causing failed-login auditing to fail or crash during login and preventing account lockout/audit records from being written. 
- Ensure the application can start against pre-upgrade databases and still record bad-login attempts and apply the 3-strike lockout logic. 

### Description
- Add startup schema upgrade logic in `create_app` to detect a legacy `bad_login_attempt` table and add missing columns (`email`, `user_id`, `ip_address`, `user_agent`, `result`, `created_at`) and populate `created_at` when absent. 
- Keep using the `BadLoginAttempt` model while making the on-startup DDL safe via `inspect` and `ALTER TABLE` statements. 
- Add a regression test `test_legacy_bad_login_attempt_table_upgraded_and_used` in `tests/test_db_upgrade.py` that creates a minimal legacy `bad_login_attempt` table, performs three failed logins, verifies the account is locked, and asserts three audit rows exist. 

### Testing
- Ran the new regression test `tests/test_db_upgrade.py::test_legacy_bad_login_attempt_table_upgraded_and_used`, which passed. 
- Ran `pytest -q` (full test suite), and all tests passed: `69 passed` with warnings only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ee65ec6c8320ba364084d1813f84)