### PR TITLE
Avoid locking admin accounts on bad logins; integrate timer controls and update Bandit workflow

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -44,7 +44,7 @@ jobs:
           # Report only issues of a given confidence level or higher. Can be LOW, MEDIUM or HIGH. Default is UNDEFINED (everything)
           # confidence: # optional, default is UNDEFINED
           # comma-separated list of paths (glob patterns supported) to exclude from scan (note that these are in addition to the excluded paths provided in the config file) (default: .svn,CVS,.bzr,.hg,.git,__pycache__,.tox,.eggs,*.egg)
-          # excluded_paths: # optional, default is DEFAULT
+          excluded_paths: tests,*/tests,test_*.py,**/test_*.py # ignore testing code
           # comma-separated list of test IDs to skip
           # skips: # optional, default is DEFAULT
           # path to a .bandit file that supplies command line arguments

--- a/app/app.py
+++ b/app/app.py
@@ -832,28 +832,42 @@ def create_app():
         if user and result == 'bad_password':
             user.failed_login_count = (user.failed_login_count or 0) + 1
             lockout_attempts = max(app.config.get('ACCOUNT_LOCKOUT_ATTEMPTS', 3), 1)
+            is_admin_account = bool(user.is_admin or (user.role and user.role.name == 'admin'))
             app.logger.info(
-                'Bad password count updated: user_id=%s email=%r failed_count=%s lockout_attempts=%s locked_at=%s',
+                'Bad password count updated: user_id=%s email=%r failed_count=%s lockout_attempts=%s locked_at=%s is_admin_account=%s',
                 user.id,
                 user.email,
                 user.failed_login_count,
                 lockout_attempts,
                 user.locked_at,
+                is_admin_account,
             )
             if user.failed_login_count >= lockout_attempts and not user.locked_at:
-                user.locked_at = datetime.now(timezone.utc).replace(tzinfo=None)
-                user.lock_reason = f'{user.failed_login_count} incorrect password attempts'
-                app.logger.warning(
-                    'Account lock threshold reached: user_id=%s email=%r ip=%s failed_count=%s lock_reason=%r',
-                    user.id,
-                    user.email,
-                    ip_address,
-                    user.failed_login_count,
-                    user.lock_reason,
-                )
-                site_log_events.append(
-                    ('account_lock', 'success', f'user_id={user.id}; ip={ip_address}; attempts={user.failed_login_count}')
-                )
+                if is_admin_account:
+                    app.logger.warning(
+                        'Admin account lock threshold reached; blacklisting IP instead: user_id=%s email=%r ip=%s failed_count=%s',
+                        user.id,
+                        user.email,
+                        ip_address,
+                        user.failed_login_count,
+                    )
+                    site_log_events.append(
+                        ('admin_ip_blacklist', 'success', f'user_id={user.id}; ip={ip_address}; attempts={user.failed_login_count}')
+                    )
+                else:
+                    user.locked_at = datetime.now(timezone.utc).replace(tzinfo=None)
+                    user.lock_reason = f'{user.failed_login_count} incorrect password attempts'
+                    app.logger.warning(
+                        'Account lock threshold reached: user_id=%s email=%r ip=%s failed_count=%s lock_reason=%r',
+                        user.id,
+                        user.email,
+                        ip_address,
+                        user.failed_login_count,
+                        user.lock_reason,
+                    )
+                    site_log_events.append(
+                        ('account_lock', 'success', f'user_id={user.id}; ip={ip_address}; attempts={user.failed_login_count}')
+                    )
         db.session.commit()
         app.logger.info(
             'Bad login audit persisted: attempt_id=%s email=%r user_id=%s result=%s ip=%s',
@@ -872,7 +886,13 @@ def create_app():
             threshold,
             result,
         )
-        if ip_attempts >= threshold:
+        admin_lockout_reached = bool(
+            user
+            and result == 'bad_password'
+            and (user.is_admin or (user.role and user.role.name == 'admin'))
+            and (user.failed_login_count or 0) >= max(app.config.get('ACCOUNT_LOCKOUT_ATTEMPTS', 3), 1)
+        )
+        if ip_attempts >= threshold or admin_lockout_reached:
             existing = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address).first()
             if not existing:
                 existing = BlacklistedIP(ip_address=ip_address)
@@ -881,7 +901,11 @@ def create_app():
             if not existing.is_active:
                 existing.is_active = True
                 app.logger.info('Reactivating IP blacklist entry after bad logins: ip=%s attempts=%s', ip_address, ip_attempts)
-            existing.reason = f'{ip_attempts} bad login attempts'
+            existing.reason = (
+                f'Admin account bad login threshold reached ({user.failed_login_count} attempts)'
+                if admin_lockout_reached
+                else f'{ip_attempts} bad login attempts'
+            )
             db.session.commit()
             app.logger.warning('IP address %s blacklisted after %s bad login attempts', ip_address, ip_attempts)
             site_log_events.append(('ip_blacklist', 'success', f'ip={ip_address}; attempts={ip_attempts}'))

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1900,3 +1900,68 @@ ul.flashes {
 .league-player-search input {
   width: 100%;
 }
+
+.timer-bar.tournament-control-group {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 0;
+  background: transparent;
+  border: 0;
+  box-shadow: none;
+}
+
+.timer-display {
+  min-width: 54px;
+  text-align: center;
+  color: var(--brand-accent-dark);
+}
+
+.timer-actions {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.timer-actions form,
+.timer-bar form {
+  margin: 0;
+}
+
+.tournament-toolbar .join-controls {
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tournament-toolbar .join-controls .join-form {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tournament-toolbar .join-controls .join-form input {
+  width: 170px;
+}
+
+.tournament-toolbar .rounds-form input {
+  width: 76px;
+}
+
+@media (max-width: 720px) {
+  .timer-bar.tournament-control-group,
+  .timer-actions,
+  .tournament-toolbar .join-controls,
+  .tournament-toolbar .join-controls .join-form {
+    width: 100%;
+  }
+
+  .tournament-toolbar .join-controls .join-form input {
+    flex: 1 1 150px;
+    width: auto;
+  }
+}

--- a/app/templates/tournament/_timer_bar.html
+++ b/app/templates/tournament/_timer_bar.html
@@ -1,28 +1,30 @@
-<div class="timer-bar">
-  <span class="timer"{% if timer_end %} data-timer-end="{{ timer_end.isoformat() }}Z" data-server-now="{{ server_now.isoformat() }}Z"{% endif %}
+<div class="timer-bar tournament-control-group" aria-label="Tournament timer controls">
+  <span class="timer timer-display"{% if timer_end %} data-timer-end="{{ timer_end.isoformat() }}Z" data-server-now="{{ server_now.isoformat() }}Z"{% endif %}
         data-tournament-id="{{ t.id }}" data-tournament-name="{{ t.name }}"{% if timer_type %} data-timer-type="{{ timer_type }}"{% endif %}{% if timer_remaining %} data-timer-remaining="{{ timer_remaining }}"{% endif %}></span>
   {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
-    <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='round') }}" style="display:inline;">
-      <button class="btn" type="submit">Start Round</button>
-    </form>
-    {% if t.format == 'Draft' %}
-    <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='draft') }}" style="display:inline;">
-      <button class="btn" type="submit">Start Draft</button>
-    </form>
-    <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='deck') }}" style="display:inline;">
-      <button class="btn" type="submit">Start Deck</button>
-    </form>
-    {% endif %}
-    {% if timer_type %}
-    <form method="post" action="{{ url_for('pause_timer', tid=t.id, timer=timer_type) }}" style="display:inline;">
-      <button class="btn" type="submit">Pause</button>
-    </form>
-    <form method="post" action="{{ url_for('stop_timer', tid=t.id, timer=timer_type) }}" style="display:inline;">
-      <button class="btn" type="submit">Stop</button>
-    </form>
-    <form method="post" action="{{ url_for('restart_timer', tid=t.id, timer=timer_type) }}" style="display:inline;">
-      <button class="btn" type="submit">Restart</button>
-    </form>
-    {% endif %}
+    <div class="timer-actions">
+      <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='round') }}">
+        <button class="btn" type="submit">Start Round</button>
+      </form>
+      {% if t.format == 'Draft' %}
+      <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='draft') }}">
+        <button class="btn" type="submit">Start Draft</button>
+      </form>
+      <form method="post" action="{{ url_for('start_timer', tid=t.id, timer='deck') }}">
+        <button class="btn" type="submit">Start Deck</button>
+      </form>
+      {% endif %}
+      {% if timer_type %}
+      <form method="post" action="{{ url_for('pause_timer', tid=t.id, timer=timer_type) }}">
+        <button class="btn ghost" type="submit">Pause</button>
+      </form>
+      <form method="post" action="{{ url_for('stop_timer', tid=t.id, timer=timer_type) }}">
+        <button class="btn ghost" type="submit">Stop</button>
+      </form>
+      <form method="post" action="{{ url_for('restart_timer', tid=t.id, timer=timer_type) }}">
+        <button class="btn ghost" type="submit">Restart</button>
+      </form>
+      {% endif %}
+    </div>
   {% endif %}
 </div>

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -23,10 +23,10 @@
   <div class="summary-card"><span>Floor Judges</span><strong>{% if floor_judges %}{% for u in floor_judges %}{{ u.name }}{% if not loop.last %}, {% endif %}{% endfor %}{% else %}None{% endif %}</strong></div>
 </section>
 
-{% include 'tournament/_timer_bar.html' %}
 {% set round_limit = t.rounds_override or rec_rounds %}
 {% set current_rounds = rounds|length %}
 <section class="toolbar tournament-toolbar panel-card tournament-control-card" aria-label="Tournament controls">
+  {% include 'tournament/_timer_bar.html' %}
   <button class="btn ghost" onclick="window.print()">Print</button>
   {% if not is_player %}
   <div class="join-controls">
@@ -465,6 +465,19 @@ Sideboard
 </section>
 {% endif %}
 
+<section class="panel-card">
+  <div class="section-heading"><div><h3>Rounds</h3><p>Jump into pairings, tables, and result entry for each round.</p></div></div>
+  {% if rounds %}
+  <div class="round-link-grid">
+  {% for r in rounds %}
+    <a class="round-link-card" href="{{ url_for('view_round', tid=t.id, rid=r.id) }}">Round {{ r.number }}</a>
+  {% endfor %}
+  </div>
+  {% else %}
+  <p class="empty-state compact-empty">No rounds paired yet.</p>
+  {% endif %}
+</section>
+
 {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
 <details class="inline-add-player panel-card">
   <summary class="section-heading"><div><h3>Add Players</h3><p>Add a single searched player, choose several existing people, or quick-create one new player.</p></div></summary>
@@ -548,16 +561,4 @@ Sideboard
 </table>
 </section>
 
-<section class="panel-card">
-  <div class="section-heading"><div><h3>Rounds</h3><p>Jump into pairings, tables, and result entry for each round.</p></div></div>
-  {% if rounds %}
-  <div class="round-link-grid">
-  {% for r in rounds %}
-    <a class="round-link-card" href="{{ url_for('view_round', tid=t.id, rid=r.id) }}">Round {{ r.number }}</a>
-  {% endfor %}
-  </div>
-  {% else %}
-  <p class="empty-state compact-empty">No rounds paired yet.</p>
-  {% endif %}
-</section>
 {% endblock %}

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -232,6 +232,33 @@ def test_account_locks_after_three_bad_passwords(client, session, app):
     assert b'Account locked' in response.data
 
 
+def test_admin_bad_passwords_blacklist_ip_without_locking_account(client, session, app):
+    app.config['ACCOUNT_LOCKOUT_ATTEMPTS'] = 3
+    app.config['IP_BLACKLIST_ATTEMPTS'] = 10
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(email='admin-threshold@example.com', name='Admin Threshold', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    session.add(admin)
+    session.commit()
+
+    for _ in range(3):
+        response = client.post('/login', data={'email': admin.email, 'password': 'wrong'})
+        assert response.status_code == 200
+
+    session.refresh(admin)
+    assert admin.locked_at is None
+    assert admin.lock_reason is None
+    assert admin.failed_login_count == 3
+
+    from app.models import BlacklistedIP
+    entry = session.query(BlacklistedIP).filter_by(ip_address='127.0.0.1').one()
+    assert entry.is_active
+    assert 'Admin account bad login threshold reached' in entry.reason
+
+    response = client.get('/')
+    assert response.status_code == 403
+
+
 def test_ip_blacklisted_after_ten_bad_logins(client, session, app):
     app.config['IP_BLACKLIST_ATTEMPTS'] = 10
     for _ in range(10):


### PR DESCRIPTION
### Motivation
- Prevent administrators from becoming unusable if they mistype passwords repeatedly by avoiding account locks for admin accounts and instead blocking the offending IP.  
- Make tournament timer controls visually integrated with the main tournament toolbar and align the related controls for a cleaner UI.  
- Surface important tournament controls in a more logical order: show Rounds first, then Add Players, then Players.  
- Reduce noise from security scans by excluding test files from the Bandit workflow.

### Description
- Change failed-login handling in `app/app.py` so admin accounts (`is_admin` or role name `admin`) are not locked after reaching `ACCOUNT_LOCKOUT_ATTEMPTS`; when the threshold is reached for an admin the code marks the originating IP for blacklisting instead while non-admin accounts retain the existing lock behavior.  
- Extend the IP-blacklist trigger to also fire when an admin reaches the account lock threshold so offending IPs are blocked automatically.  
- Move and refactor the timer UI into `app/templates/tournament/_timer_bar.html`, include it in the main toolbar in `app/templates/tournament/view.html`, and add grouped action markup so start/pause/stop/restart controls render consistently.  
- Add CSS in `app/static/style.css` to style the integrated timer and to make the join/rounds controls wrap neatly (`.timer-bar.tournament-control-group`, `.timer-actions`, and related rules).  
- Reorder tournament page sections in `app/templates/tournament/view.html` to display the Rounds block before Add Players and Players.  
- Update `.github/workflows/bandit.yml` to set `excluded_paths` for test files so Bandit ignores testing code.  
- Add a regression test `test_admin_bad_passwords_blacklist_ip_without_locking_account` to `tests/test_users.py` that asserts admin accounts are not locked and the IP is blacklisted after repeated bad passwords.

### Testing
- Ran the new and related unit tests: `pytest tests/test_users.py::test_account_locks_after_three_bad_passwords tests/test_users.py::test_admin_bad_passwords_blacklist_ip_without_locking_account tests/test_users.py::test_ip_blacklisted_after_ten_bad_logins`, and they passed.  
- Ran the full relevant test suite: `pytest tests/test_tournament.py tests/test_users.py`, and all tests passed (`42 passed`).  
- Ensured Python source compiles with `python -m compileall app` with no errors.  
- Performed a repository check (`git diff --check`) with no whitespace/error issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20f332a21083209212bee771745426)