### PR TITLE
Add site dark mode and tidy tournament controls

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -740,6 +740,12 @@ def create_app():
             return mode
         return 'invite_only' if app.config.get('ACCOUNT_CREATION_INVITE_ONLY', False) else 'open'
 
+    def site_theme():
+        theme = get_site_setting('site_theme', 'light')
+        if theme in {'light', 'dark'}:
+            return theme
+        return 'light'
+
     def _send_registration_verification(email, token, pin=None):
         verify_url = url_for('verify_registration_token', token=token, _external=True)
         pin_text = f'\n\nIf prompted, your fallback PIN is: {pin}' if pin else ''
@@ -1603,6 +1609,7 @@ def create_app():
             'nav_unread_messages': unread,
             'nav_open_reports': open_reports,
             'nav_registration_mode': registration_mode(),
+            'site_theme': site_theme(),
         }
 
     @app.route('/reports', methods=['GET', 'POST'])
@@ -3892,14 +3899,19 @@ def create_app():
                 mode = request.form.get('registration_mode', 'open')
                 if mode not in {'open', 'invite_only', 'closed'}:
                     mode = 'open'
+                theme = request.form.get('site_theme', 'light')
+                if theme not in {'light', 'dark'}:
+                    theme = 'light'
                 set_site_setting('registration_mode', mode)
+                set_site_setting('site_theme', theme)
                 db.session.commit()
-                log_site('site_settings_update', 'success', f'registration_mode={mode}')
+                log_site('site_settings_update', 'success', f'registration_mode={mode}; site_theme={theme}')
                 flash('Site settings saved.', 'success')
             return redirect(url_for('site_settings'))
         return render_template(
             'admin/site_settings.html',
             registration_mode=registration_mode(),
+            selected_site_theme=site_theme(),
         )
 
     @app.route('/admin/registration-invites', methods=['GET', 'POST'])

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1965,3 +1965,200 @@ ul.flashes {
     width: auto;
   }
 }
+
+/* Site-wide dark mode */
+html[data-theme="dark"] {
+  --brand-surface: #111827;
+  --brand-surface-soft: rgba(17, 24, 39, 0.88);
+  --brand-muted: #94a3b8;
+  --brand-text: #e5e7eb;
+  --border-soft: rgba(148, 163, 184, 0.22);
+  --border-strong: rgba(203, 213, 225, 0.34);
+  --shadow-soft: 0 16px 38px rgba(0, 0, 0, 0.34);
+  --shadow-hover: 0 24px 54px rgba(0, 0, 0, 0.44);
+  --creamy-yellow: #0f172a;
+}
+
+html[data-theme="dark"] body {
+  background: radial-gradient(circle at 15% 0%, rgba(37, 99, 235, 0.22), transparent 30%),
+              linear-gradient(160deg, #020617 0%, #0f172a 52%, #111827 100%);
+}
+
+html[data-theme="dark"] .app-header {
+  background: rgba(2, 6, 23, 0.92);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+html[data-theme="dark"] input,
+html[data-theme="dark"] select,
+html[data-theme="dark"] textarea {
+  background: rgba(15, 23, 42, 0.9);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--brand-text);
+}
+
+html[data-theme="dark"] input:focus,
+html[data-theme="dark"] select:focus,
+html[data-theme="dark"] textarea:focus {
+  background: rgba(15, 23, 42, 0.98);
+}
+
+html[data-theme="dark"] input::placeholder,
+html[data-theme="dark"] textarea::placeholder {
+  color: #94a3b8;
+}
+
+html[data-theme="dark"] .dropdown-item,
+html[data-theme="dark"] .role-card,
+html[data-theme="dark"] .permission-fieldset,
+html[data-theme="dark"] .judge-row,
+html[data-theme="dark"] .join-request-status,
+html[data-theme="dark"] .round-link-card {
+  background: rgba(15, 23, 42, 0.72);
+}
+
+html[data-theme="dark"] .btn.ghost {
+  background: rgba(15, 23, 42, 0.5);
+  border-color: rgba(148, 163, 184, 0.34);
+  color: var(--brand-text);
+}
+
+html[data-theme="dark"] .btn.ghost:hover {
+  background: rgba(30, 41, 59, 0.92);
+}
+
+html[data-theme="dark"] .table th,
+html[data-theme="dark"] table th {
+  background: rgba(30, 41, 59, 0.82);
+}
+
+html[data-theme="dark"] .flashes li.success {
+  color: #86efac;
+}
+
+html[data-theme="dark"] .flashes li.error {
+  color: #fca5a5;
+}
+
+html[data-theme="dark"] .metric-pill,
+html[data-theme="dark"] .permission-chip,
+html[data-theme="dark"] .status-pill {
+  color: #bfdbfe;
+}
+
+html[data-theme="dark"] .eyebrow {
+  color: #fdba74;
+}
+
+html[data-theme="dark"] .timer,
+html[data-theme="dark"] .timer-display {
+  color: #93c5fd;
+}
+
+/* Tournament control bar polish */
+.tournament-control-card {
+  display: grid;
+  grid-template-columns: minmax(230px, auto) minmax(280px, 1fr) minmax(340px, 1.5fr);
+  align-items: stretch;
+  gap: 14px;
+  padding: 16px;
+}
+
+.control-cluster {
+  display: flex;
+  flex-direction: column;
+  gap: 9px;
+  padding: 14px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-md);
+  background: rgba(255, 255, 255, 0.52);
+  min-width: 0;
+}
+
+.control-label {
+  color: var(--brand-muted);
+  font-size: 0.74rem;
+  font-weight: 800;
+  letter-spacing: 0.09em;
+  line-height: 1;
+  text-transform: uppercase;
+}
+
+.control-actions,
+.timer-actions,
+.tournament-toolbar .join-controls,
+.tournament-toolbar .join-controls .join-form {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tournament-toolbar .btn,
+.tournament-toolbar input {
+  min-height: 42px;
+}
+
+.tournament-toolbar .btn {
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.10);
+  white-space: nowrap;
+}
+
+.timer-bar.tournament-control-group {
+  align-items: center;
+}
+
+.timer-display {
+  min-width: 64px;
+  padding: 9px 10px;
+  border-radius: var(--radius-sm);
+  background: rgba(37, 99, 235, 0.10);
+  font-size: 1.05rem;
+  font-weight: 800;
+  text-align: center;
+}
+
+.tournament-toolbar .join-controls .join-form input {
+  width: 190px;
+}
+
+.tournament-toolbar .rounds-form {
+  padding: 4px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.tournament-toolbar .rounds-form input {
+  width: 74px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+html[data-theme="dark"] .control-cluster,
+html[data-theme="dark"] .tournament-toolbar .rounds-form {
+  background: rgba(15, 23, 42, 0.58);
+}
+
+@media (max-width: 980px) {
+  .tournament-control-card {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .control-actions,
+  .timer-actions,
+  .tournament-toolbar .join-controls,
+  .tournament-toolbar .join-controls .join-form {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .tournament-toolbar .btn,
+  .tournament-toolbar .join-controls .join-form input,
+  .tournament-toolbar .rounds-form {
+    width: 100%;
+  }
+}

--- a/app/templates/admin/site_settings.html
+++ b/app/templates/admin/site_settings.html
@@ -4,7 +4,7 @@
   <div class="page-header__title">
     <span class="eyebrow">Admin</span>
     <h2>Site Settings</h2>
-    <p class="page-description">Control public registration access for new accounts.</p>
+    <p class="page-description">Control public registration access and the site-wide appearance.</p>
   </div>
 </section>
 
@@ -17,6 +17,12 @@
         <option value="open"{% if registration_mode == 'open' %} selected{% endif %}>Open — anyone can register before login</option>
         <option value="invite_only"{% if registration_mode == 'invite_only' %} selected{% endif %}>Invite only — admin email links required</option>
         <option value="closed"{% if registration_mode == 'closed' %} selected{% endif %}>Closed — no public self registration</option>
+      </select>
+    </label>
+    <label>Color mode
+      <select name="site_theme" required>
+        <option value="light"{% if selected_site_theme == 'light' %} selected{% endif %}>Light — bright default interface</option>
+        <option value="dark"{% if selected_site_theme == 'dark' %} selected{% endif %}>Dark — low-light interface</option>
       </select>
     </label>
     <div class="form-actions"><button class="btn" type="submit">Save Settings</button></div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en" data-theme="{{ site_theme|default('light') }}">
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -26,48 +26,61 @@
 {% set round_limit = t.rounds_override or rec_rounds %}
 {% set current_rounds = rounds|length %}
 <section class="toolbar tournament-toolbar panel-card tournament-control-card" aria-label="Tournament controls">
-  {% include 'tournament/_timer_bar.html' %}
-  <button class="btn ghost" onclick="window.print()">Print</button>
+  <div class="control-cluster timer-cluster">
+    <span class="control-label">Timer</span>
+    {% include 'tournament/_timer_bar.html' %}
+  </div>
+
   {% if not is_player %}
-  <div class="join-controls">
-    <a class="btn ghost" href="{{ url_for('tournament_join_link', tid=t.id) }}" target="_blank" rel="noopener">Player Join QR</a>
-    {% if current_user.is_authenticated %}
-      {% set join_pending = user_join_request and user_join_request.status == 'pending' %}
-      {% set join_rejected = user_join_request and user_join_request.status == 'rejected' %}
-      {% if t.join_requires_approval %}
-        <div class="join-approval-note">Approval required before players may join this tournament.</div>
+  <div class="control-cluster join-cluster">
+    <span class="control-label">Players</span>
+    <div class="join-controls">
+      <a class="btn ghost" href="{{ url_for('tournament_join_link', tid=t.id) }}" target="_blank" rel="noopener">Player Join QR</a>
+      {% if current_user.is_authenticated %}
+        {% set join_pending = user_join_request and user_join_request.status == 'pending' %}
+        {% set join_rejected = user_join_request and user_join_request.status == 'rejected' %}
+        {% if t.join_requires_approval %}
+          <div class="join-approval-note">Approval required before players may join this tournament.</div>
+        {% endif %}
+        {% if join_pending %}
+          <div class="join-request-status info">Your join request is pending approval.</div>
+        {% elif join_rejected %}
+          <div class="join-request-status error">Your previous join request was rejected{% if user_join_request.note %}: {{ user_join_request.note }}{% endif %}.</div>
+        {% endif %}
+        {% set allow_join_form = (not t.join_requires_approval) or (not join_pending) %}
+        {% if allow_join_form %}
+        <form method="post" action="{{ url_for('join_tournament', tid=t.id) }}" class="join-form">
+          <input type="text" name="passcode" maxlength="4" pattern="\d{4}" placeholder="Passcode" required>
+          <button class="btn" type="submit">{% if t.join_requires_approval %}Request Join{% else %}Join{% endif %}</button>
+        </form>
+        {% endif %}
+      {% else %}
+        <a class="btn" href="{{ url_for('login') }}">Login to Join</a>
       {% endif %}
-      {% if join_pending %}
-        <div class="join-request-status info">Your join request is pending approval.</div>
-      {% elif join_rejected %}
-        <div class="join-request-status error">Your previous join request was rejected{% if user_join_request.note %}: {{ user_join_request.note }}{% endif %}.</div>
-      {% endif %}
-      {% set allow_join_form = (not t.join_requires_approval) or (not join_pending) %}
-      {% if allow_join_form %}
-      <form method="post" action="{{ url_for('join_tournament', tid=t.id) }}" class="join-form">
-        <input type="text" name="passcode" maxlength="4" pattern="\d{4}" placeholder="Passcode" required>
-        <button class="btn" type="submit">{% if t.join_requires_approval %}Request Join{% else %}Join{% endif %}</button>
-      </form>
-      {% endif %}
-    {% else %}
-      <a class="btn" href="{{ url_for('login') }}">Login to Join</a>
-    {% endif %}
+    </div>
   </div>
   {% endif %}
-  <a class="btn secondary" href="{{ url_for('standings', tid=t.id) }}">Standings</a>
-  {% if t.cut.startswith('top') %}<a class="btn secondary" href="{{ url_for('bracket', tid=t.id) }}">Bracket</a>{% endif %}
-  {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
-    {% if current_rounds < round_limit or t.cut.startswith('top') %}
-    <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}"><button class="btn" type="submit">Pair Next Round</button></form>
-    {% endif %}
-    <form method="post" action="{{ url_for('set_rounds', tid=t.id) }}" class="rounds-form">
-      <input type="number" name="rounds" min="1" value="{{ t.rounds_override or rec_rounds }}" aria-label="Round count">
-      <button class="btn ghost" type="submit">Set Rounds</button>
-    </form>
-    {% if t.format == 'Draft' %}<a class="btn ghost" href="{{ url_for('draft_seating', tid=t.id) }}">Draft Seating</a>{% endif %}
-    {% if can_view_player_decks %}<a class="btn ghost" href="{{ url_for('tournament_decklists', tid=t.id) }}">Player Deck Lists</a>{% endif %}
-    <a class="btn ghost" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
-  {% endif %}
+
+  <div class="control-cluster action-cluster">
+    <span class="control-label">Tournament</span>
+    <div class="control-actions">
+      <button class="btn ghost" type="button" onclick="window.print()">Print</button>
+      <a class="btn secondary" href="{{ url_for('standings', tid=t.id) }}">Standings</a>
+      {% if t.cut.startswith('top') %}<a class="btn secondary" href="{{ url_for('bracket', tid=t.id) }}">Bracket</a>{% endif %}
+      {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+        {% if current_rounds < round_limit or t.cut.startswith('top') %}
+        <form method="post" action="{{ url_for('pair_next_round', tid=t.id) }}"><button class="btn" type="submit">Pair Next Round</button></form>
+        {% endif %}
+        <form method="post" action="{{ url_for('set_rounds', tid=t.id) }}" class="rounds-form">
+          <input type="number" name="rounds" min="1" value="{{ t.rounds_override or rec_rounds }}" aria-label="Round count">
+          <button class="btn ghost" type="submit">Set Rounds</button>
+        </form>
+        {% if t.format == 'Draft' %}<a class="btn ghost" href="{{ url_for('draft_seating', tid=t.id) }}">Draft Seating</a>{% endif %}
+        {% if can_view_player_decks %}<a class="btn ghost" href="{{ url_for('tournament_decklists', tid=t.id) }}">Player Deck Lists</a>{% endif %}
+        <a class="btn ghost" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
+      {% endif %}
+    </div>
+  </div>
 </section>
 
 {% if is_player %}

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -490,3 +490,48 @@ def test_admin_user_actions_ignore_tampered_next(client, session):
 
     assert response.status_code == 302
     assert response.headers['Location'] == f'/admin/users/{user.id}'
+
+
+def test_site_settings_save_site_theme(client, session):
+    from app.models import SiteSetting
+
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(email='admin-theme@example.com', name='Theme Admin', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    session.add(admin)
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/admin/site-settings',
+            data={'action': 'settings', 'registration_mode': 'closed', 'site_theme': 'dark'},
+            follow_redirects=True,
+        )
+
+    assert response.status_code == 200
+    assert b'data-theme="dark"' in response.data
+    assert session.get(SiteSetting, 'registration_mode').value == 'closed'
+    assert session.get(SiteSetting, 'site_theme').value == 'dark'
+
+
+def test_invalid_site_theme_falls_back_to_light(client, session):
+    from app.models import SiteSetting
+
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(email='admin-theme-invalid@example.com', name='Theme Invalid Admin', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    session.add(admin)
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/admin/site-settings',
+            data={'action': 'settings', 'registration_mode': 'open', 'site_theme': 'sepia'},
+            follow_redirects=True,
+        )
+
+    assert response.status_code == 200
+    assert b'data-theme="light"' in response.data
+    assert session.get(SiteSetting, 'site_theme').value == 'light'


### PR DESCRIPTION
### Motivation
- Make the UI cleaner and more usable by tidying the tournament control toolbar into labeled clusters and improving button/form layout. 
- Provide a site-wide light/dark appearance option that can be set in site settings and persisted for all users.

### Description
- Add a persisted `site_theme` setting with validation and a `site_theme()` helper exposed to templates so pages can apply the chosen theme via `data-theme` on `<html>`.
- Add a Color mode selector to the admin Site Settings page and save `site_theme` alongside `registration_mode`.
- Add dark-mode CSS token overrides and component styles in `style.css` (variables, form inputs, buttons, tables, flashes, timer display) and responsive styling for a polished tournament control bar.
- Reorganize the tournament toolbar into three `control-cluster` groups (Timer, Players, Tournament) and make the Print button use `type="button"` to avoid accidental form submission.
- Add two unit tests to validate saving and validating the `site_theme` setting.

### Testing
- Compiled the code and templates with `python -m compileall app tests` which succeeded.
- Ran the new theme tests with `pytest -q tests/test_users.py::test_site_settings_save_site_theme tests/test_users.py::test_invalid_site_theme_falls_back_to_light` and both passed.
- Ran the users tests `pytest -q tests/test_users.py` and the full test suite `pytest -q`, with all tests passing (full run reported `72 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20f5ab9940832083cbeaa3a67d633d)