### PR TITLE
Fix dark mode styling and organize tournament controls

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -1968,6 +1968,7 @@ ul.flashes {
 
 /* Site-wide dark mode */
 html[data-theme="dark"] {
+  color-scheme: dark;
   --brand-surface: #111827;
   --brand-surface-soft: rgba(17, 24, 39, 0.88);
   --brand-muted: #94a3b8;
@@ -2008,13 +2009,36 @@ html[data-theme="dark"] textarea::placeholder {
   color: #94a3b8;
 }
 
+html[data-theme="dark"] .dropdown-menu,
 html[data-theme="dark"] .dropdown-item,
 html[data-theme="dark"] .role-card,
 html[data-theme="dark"] .permission-fieldset,
 html[data-theme="dark"] .judge-row,
 html[data-theme="dark"] .join-request-status,
-html[data-theme="dark"] .round-link-card {
+html[data-theme="dark"] .round-link-card,
+html[data-theme="dark"] .panel-card,
+html[data-theme="dark"] .summary-card,
+html[data-theme="dark"] .page-header,
+html[data-theme="dark"] .auth-card,
+html[data-theme="dark"] .message-card,
+html[data-theme="dark"] .deck-form,
+html[data-theme="dark"] .deck-builder,
+html[data-theme="dark"] .league-card,
+html[data-theme="dark"] .round-card,
+html[data-theme="dark"] .join-qr-card,
+html[data-theme="dark"] .inline-add-player.panel-card {
   background: rgba(15, 23, 42, 0.72);
+}
+
+html[data-theme="dark"] .modern-hero::after {
+  opacity: 0.28;
+}
+
+html[data-theme="dark"] .table,
+html[data-theme="dark"] table,
+html[data-theme="dark"] td,
+html[data-theme="dark"] th {
+  border-color: rgba(148, 163, 184, 0.24);
 }
 
 html[data-theme="dark"] .btn.ghost {
@@ -2057,13 +2081,14 @@ html[data-theme="dark"] .timer-display {
 
 /* Tournament control bar polish */
 .tournament-control-card {
-  display: grid;
-  grid-template-columns: minmax(230px, auto) minmax(280px, 1fr) minmax(340px, 1.5fr);
+  display: flex;
+  flex-direction: column;
   align-items: stretch;
-  gap: 14px;
+  gap: 12px;
   padding: 16px;
 }
 
+.control-row,
 .control-cluster {
   display: flex;
   flex-direction: column;
@@ -2073,6 +2098,16 @@ html[data-theme="dark"] .timer-display {
   border-radius: var(--radius-md);
   background: rgba(255, 255, 255, 0.52);
   min-width: 0;
+}
+
+.join-row .join-controls,
+.timer-row .timer-bar,
+.action-row .control-actions {
+  width: 100%;
+}
+
+.control-passcode {
+  min-height: 42px;
 }
 
 .control-label {
@@ -2136,15 +2171,11 @@ html[data-theme="dark"] .timer-display {
   box-shadow: none;
 }
 
+html[data-theme="dark"] .control-row,
 html[data-theme="dark"] .control-cluster,
-html[data-theme="dark"] .tournament-toolbar .rounds-form {
+html[data-theme="dark"] .tournament-toolbar .rounds-form,
+html[data-theme="dark"] .timer-display {
   background: rgba(15, 23, 42, 0.58);
-}
-
-@media (max-width: 980px) {
-  .tournament-control-card {
-    grid-template-columns: 1fr;
-  }
 }
 
 @media (max-width: 720px) {

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -26,16 +26,12 @@
 {% set round_limit = t.rounds_override or rec_rounds %}
 {% set current_rounds = rounds|length %}
 <section class="toolbar tournament-toolbar panel-card tournament-control-card" aria-label="Tournament controls">
-  <div class="control-cluster timer-cluster">
-    <span class="control-label">Timer</span>
-    {% include 'tournament/_timer_bar.html' %}
-  </div>
-
   {% if not is_player %}
-  <div class="control-cluster join-cluster">
+  <div class="control-row join-row" aria-label="Player join controls">
     <span class="control-label">Players</span>
     <div class="join-controls">
       <a class="btn ghost" href="{{ url_for('tournament_join_link', tid=t.id) }}" target="_blank" rel="noopener">Player Join QR</a>
+      {% if show_passcode %}<span class="metric-pill control-passcode">Passcode {{ t.passcode }}</span>{% endif %}
       {% if current_user.is_authenticated %}
         {% set join_pending = user_join_request and user_join_request.status == 'pending' %}
         {% set join_rejected = user_join_request and user_join_request.status == 'rejected' %}
@@ -61,7 +57,12 @@
   </div>
   {% endif %}
 
-  <div class="control-cluster action-cluster">
+  <div class="control-row timer-row" aria-label="Tournament timer controls">
+    <span class="control-label">Timer</span>
+    {% include 'tournament/_timer_bar.html' %}
+  </div>
+
+  <div class="control-row action-row" aria-label="Tournament actions">
     <span class="control-label">Tournament</span>
     <div class="control-actions">
       <button class="btn ghost" type="button" onclick="window.print()">Print</button>


### PR DESCRIPTION
### Motivation
- The tournament control area needed a clearer layout so QR/passcode, timer controls, and action buttons are visually separated and easier to use. 
- Dark mode was incomplete for cards, dropdowns, tables and control elements which caused poor contrast in low-light themes.

### Description
- Reworked the tournament control markup in `app/templates/tournament/view.html` to use stacked rows (`.join-row`, `.timer-row`, `.action-row`) so the Player Join QR and passcode are on one line, the timer controls on another, and all other controls on a third line. 
- Updated `app/static/style.css` to change the tournament control container from a three-column grid to a stacked flex layout and added `.control-row`, `.control-passcode`, and related rules to ensure full-width rows and responsive wrapping. 
- Expanded dark-mode rules (including `color-scheme: dark`) to cover dropdowns, panel cards, hero panels, tables, inputs and tournament controls for consistent dark backgrounds and borders.

### Testing
- Ran the full automated test suite with `pytest`, which completed successfully with `72 passed` and warnings only. 
- Sanity-checked CSS/HTML edits locally and ensured no style lint or template errors were raised during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20f869896083209f66fa0f89bda8e1)