### PR TITLE
Split tournament controls into separate Timer, Passcode/QR, and Actions boxes

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2193,3 +2193,89 @@ html[data-theme="dark"] .timer-display {
     width: 100%;
   }
 }
+
+/* Tournament control boxes */
+.tournament-control-grid {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(220px, 1fr));
+  gap: 14px;
+  margin-bottom: 20px;
+}
+
+.tournament-control-box {
+  background: rgba(255, 255, 255, 0.76);
+  box-shadow: var(--shadow-soft);
+  min-height: 100%;
+}
+
+.tournament-control-box .btn,
+.tournament-control-box input {
+  min-height: 42px;
+}
+
+.tournament-control-box .btn {
+  box-shadow: 0 8px 18px rgba(15, 23, 42, 0.10);
+  white-space: nowrap;
+}
+
+.tournament-control-box form {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin: 0;
+}
+
+.tournament-control-box .join-controls,
+.tournament-control-box .join-form,
+.tournament-control-box .control-actions,
+.tournament-control-box .timer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.tournament-control-box .join-form input {
+  width: 190px;
+}
+
+.tournament-control-box .rounds-form {
+  padding: 4px;
+  border: 1px solid var(--border-soft);
+  border-radius: var(--radius-sm);
+  background: rgba(255, 255, 255, 0.56);
+}
+
+.tournament-control-box .rounds-form input {
+  width: 74px;
+  border: 0;
+  background: transparent;
+  box-shadow: none;
+}
+
+html[data-theme="dark"] .tournament-control-box,
+html[data-theme="dark"] .tournament-control-box .rounds-form {
+  background: rgba(15, 23, 42, 0.72);
+}
+
+@media (max-width: 980px) {
+  .tournament-control-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 720px) {
+  .tournament-control-box .join-controls,
+  .tournament-control-box .join-form,
+  .tournament-control-box .control-actions,
+  .tournament-control-box .timer-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .tournament-control-box .btn,
+  .tournament-control-box .join-form input,
+  .tournament-control-box .rounds-form {
+    width: 100%;
+  }
+}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -25,13 +25,17 @@
 
 {% set round_limit = t.rounds_override or rec_rounds %}
 {% set current_rounds = rounds|length %}
-<section class="toolbar tournament-toolbar panel-card tournament-control-card" aria-label="Tournament controls">
+<section class="tournament-control-grid" aria-label="Tournament controls">
+  <div class="control-row timer-row tournament-control-box" aria-label="Tournament timer controls">
+    <span class="control-label">Timer</span>
+    {% include 'tournament/_timer_bar.html' %}
+  </div>
+
   {% if not is_player %}
-  <div class="control-row join-row" aria-label="Player join controls">
-    <span class="control-label">Players</span>
+  <div class="control-row join-row tournament-control-box" aria-label="Player passcode and QR controls">
+    <span class="control-label">Passcode / QR</span>
     <div class="join-controls">
       <a class="btn ghost" href="{{ url_for('tournament_join_link', tid=t.id) }}" target="_blank" rel="noopener">Player Join QR</a>
-      {% if show_passcode %}<span class="metric-pill control-passcode">Passcode {{ t.passcode }}</span>{% endif %}
       {% if current_user.is_authenticated %}
         {% set join_pending = user_join_request and user_join_request.status == 'pending' %}
         {% set join_rejected = user_join_request and user_join_request.status == 'rejected' %}
@@ -57,13 +61,8 @@
   </div>
   {% endif %}
 
-  <div class="control-row timer-row" aria-label="Tournament timer controls">
-    <span class="control-label">Timer</span>
-    {% include 'tournament/_timer_bar.html' %}
-  </div>
-
-  <div class="control-row action-row" aria-label="Tournament actions">
-    <span class="control-label">Tournament</span>
+  <div class="control-row action-row tournament-control-box" aria-label="Tournament actions">
+    <span class="control-label">Tournament Controls</span>
     <div class="control-actions">
       <button class="btn ghost" type="button" onclick="window.print()">Print</button>
       <a class="btn secondary" href="{{ url_for('standings', tid=t.id) }}">Standings</a>


### PR DESCRIPTION
### Motivation
- Break the single tournament control strip into three distinct UI boxes (Timer, Passcode / QR, and Tournament Controls) so each control group is visually separated and easier to scan and interact with.
- Remove the duplicated passcode display from the lower join controls while keeping the header-level passcode pill visible for managers.
- Provide a responsive layout so the controls sit side-by-side on wide viewports and stack on smaller screens for better mobile usability.

### Description
- Reworked the tournament controls block in `app/templates/tournament/view.html` to a three-column grid and split the content into separate boxes for the timer, passcode/QR/join flow, and tournament action controls, and adjusted control labels accordingly.
- Moved the included timer bar (`tournament/_timer_bar.html`) into its own `Timer` box so timer actions are isolated from join and action controls.
- Removed the lower `metric-pill control-passcode` element from the join controls while leaving the header passcode display intact.
- Added styling in `app/static/style.css` for `.tournament-control-grid` and `.tournament-control-box` including responsive media queries to collapse to a single column under narrow widths.

### Testing
- Ran the tournament test suite with `python -m pytest tests/test_tournament.py` which completed successfully with all tests passing (`20 passed, 32 warnings`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20fa41665c83209dfabdab86ebf23c)