### PR TITLE
Group tournament controls into card boxes

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2203,9 +2203,13 @@ html[data-theme="dark"] .timer-display {
 }
 
 .tournament-control-box {
-  background: rgba(255, 255, 255, 0.76);
-  box-shadow: var(--shadow-soft);
+  display: flex;
+  flex-direction: column;
   min-height: 100%;
+}
+
+.tournament-control-box .section-heading {
+  margin-bottom: 18px;
 }
 
 .tournament-control-box .btn,
@@ -2253,7 +2257,6 @@ html[data-theme="dark"] .timer-display {
   box-shadow: none;
 }
 
-html[data-theme="dark"] .tournament-control-box,
 html[data-theme="dark"] .tournament-control-box .rounds-form {
   background: rgba(15, 23, 42, 0.72);
 }

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -26,14 +26,11 @@
 {% set round_limit = t.rounds_override or rec_rounds %}
 {% set current_rounds = rounds|length %}
 <section class="tournament-control-grid" aria-label="Tournament controls">
-  <div class="control-row timer-row tournament-control-box" aria-label="Tournament timer controls">
-    <span class="control-label">Timer</span>
-    {% include 'tournament/_timer_bar.html' %}
-  </div>
-
   {% if not is_player %}
-  <div class="control-row join-row tournament-control-box" aria-label="Player passcode and QR controls">
-    <span class="control-label">Passcode / QR</span>
+  <section class="panel-card join-row tournament-control-box" aria-label="Player passcode and QR controls">
+    <div class="section-heading">
+      <div><h3>QR and Passcode</h3><p>Share the player join QR link or enter a tournament passcode.</p></div>
+    </div>
     <div class="join-controls">
       <a class="btn ghost" href="{{ url_for('tournament_join_link', tid=t.id) }}" target="_blank" rel="noopener">Player Join QR</a>
       {% if current_user.is_authenticated %}
@@ -58,11 +55,20 @@
         <a class="btn" href="{{ url_for('login') }}">Login to Join</a>
       {% endif %}
     </div>
-  </div>
+  </section>
   {% endif %}
 
-  <div class="control-row action-row tournament-control-box" aria-label="Tournament actions">
-    <span class="control-label">Tournament Controls</span>
+  <section class="panel-card timer-row tournament-control-box" aria-label="Tournament timer controls">
+    <div class="section-heading">
+      <div><h3>Time Controls</h3><p>Start, pause, stop, or restart round timers.</p></div>
+    </div>
+    {% include 'tournament/_timer_bar.html' %}
+  </section>
+
+  <section class="panel-card action-row tournament-control-box" aria-label="Tournament actions">
+    <div class="section-heading">
+      <div><h3>Tournament Controls</h3><p>Print materials, manage rounds, and open tournament tools.</p></div>
+    </div>
     <div class="control-actions">
       <button class="btn ghost" type="button" onclick="window.print()">Print</button>
       <a class="btn secondary" href="{{ url_for('standings', tid=t.id) }}">Standings</a>
@@ -80,7 +86,7 @@
         <a class="btn ghost" href="{{ url_for('tournament_logs', tid=t.id) }}">Logs</a>
       {% endif %}
     </div>
-  </div>
+  </section>
 </section>
 
 {% if is_player %}


### PR DESCRIPTION
### Motivation
- Reorganize the tournament control area to match the visual structure of the Rounds panel by placing controls into three distinct boxes: QR/passcode, time controls, and tournament controls.
- Improve clarity and visual grouping while preserving existing control behavior and accessibility.

### Description
- Rearranged `app/templates/tournament/view.html` to place the join QR/passcode controls, the timer include (`tournament/_timer_bar.html`), and the tournament action buttons into three `section` elements using the `panel-card` and `tournament-control-box` classes with new section headings (`QR and Passcode`, `Time Controls`, `Tournament Controls`).
- Kept all existing forms, buttons and the timer include intact so behavior and routes are unchanged (e.g. `join_tournament`, `start_timer`, `set_rounds`, `pair_next_round`).
- Updated `app/static/style.css` so `.tournament-control-box` is a column flex container and added spacing for `.tournament-control-box .section-heading` so the boxes inherit the `panel-card` look used elsewhere instead of duplicating backgrounds/box-shadow.
- Adjusted the dark-theme rule so the `panel-card` visual treatment is applied consistently and layout rules for join/timer/rounds forms remain unchanged.

### Testing
- Ran the test suite with `pytest -q` and all tests passed (`72 passed, 182 warnings`).
- Captured a visual smoke test using Playwright and saved a screenshot at `/tmp/tournament-control-boxes.png` to verify layout and visual grouping (screenshot generation completed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20fc0878608320832355362cd9ff52)

## Summary by Sourcery

Group tournament view controls into three card-style sections for QR/passcode, time controls, and tournament actions while aligning styling with existing panel cards.

Enhancements:
- Restructure the tournament view template to wrap join QR/passcode, timer, and tournament action controls into separate panel-card sections with headings and descriptions.
- Adjust tournament control box styling to use flex column layout and shared panel-card appearance, including consistent dark theme treatment.