### PR TITLE
Keep tournament control buttons inline

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2236,7 +2236,15 @@ html[data-theme="dark"] .timer-display {
   display: flex;
   align-items: center;
   gap: 8px;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+
+.tournament-control-box .timer-bar {
+  flex-wrap: nowrap;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 .tournament-control-box .join-form input {
@@ -2272,13 +2280,13 @@ html[data-theme="dark"] .tournament-control-box .rounds-form {
   .tournament-control-box .join-form,
   .tournament-control-box .control-actions,
   .tournament-control-box .timer-actions {
-    align-items: stretch;
-    flex-direction: column;
+    align-items: center;
+    flex-direction: row;
   }
 
   .tournament-control-box .btn,
   .tournament-control-box .join-form input,
   .tournament-control-box .rounds-form {
-    width: 100%;
+    width: auto;
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure tournament control button groups (join controls, timer actions, and action buttons) remain on a single horizontal row inside their control boxes so controls stay visually grouped and usable instead of stacking vertically on narrow layouts.

### Description
- Update `app/static/style.css` to make `.tournament-control-box .join-controls`, `.join-form`, `.control-actions`, and `.timer-actions` use `flex-wrap: nowrap` with `overflow-x: auto` and add a `.tournament-control-box .timer-bar` rule to prevent wrapping, and change the mobile `@media (max-width: 720px)` override to keep `flex-direction: row` and use `width: auto` so buttons stay inline and can scroll horizontally if needed.

### Testing
- Ran `pytest` and the test suite passed (`72 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20fe7519c08320834824c2015b66f1)