### PR TITLE
Keep tournament action buttons in one row

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2265,6 +2265,20 @@ html[data-theme="dark"] .timer-display {
   box-shadow: none;
 }
 
+.tournament-actions-row {
+  display: flex;
+  flex-flow: row nowrap;
+  align-items: center;
+  gap: 8px;
+  overflow-x: auto;
+  padding-bottom: 2px;
+}
+
+.tournament-actions-row > *,
+.tournament-actions-row form {
+  flex: 0 0 auto;
+}
+
 html[data-theme="dark"] .tournament-control-box .rounds-form {
   background: rgba(15, 23, 42, 0.72);
 }

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -69,7 +69,7 @@
     <div class="section-heading">
       <div><h3>Tournament Controls</h3><p>Print materials, manage rounds, and open tournament tools.</p></div>
     </div>
-    <div class="control-actions">
+    <div class="control-actions tournament-actions-row">
       <button class="btn ghost" type="button" onclick="window.print()">Print</button>
       <a class="btn secondary" href="{{ url_for('standings', tid=t.id) }}">Standings</a>
       {% if t.cut.startswith('top') %}<a class="btn secondary" href="{{ url_for('bracket', tid=t.id) }}">Bracket</a>{% endif %}


### PR DESCRIPTION
### Motivation
- Prevent tournament action buttons and small forms from wrapping onto multiple lines and preserve a single horizontal control row for clarity and consistent layout.
- Allow horizontal scrolling when the viewport is too narrow so controls remain accessible without collapsing the design.

### Description
- Add `tournament-actions-row` to the tournament controls container in `app/templates/tournament/view.html` to target the action buttons as a dedicated row.
- Add CSS rules in `app/static/style.css` to set `display: flex` with `flex-flow: row nowrap`, `overflow-x: auto`, and spacing to keep children in one horizontal line.
- Ensure child controls and inline forms do not grow (`flex: 0 0 auto`) so buttons and the `rounds-form` remain on a single row and scroll horizontally when needed.

### Testing
- Ran the test suite with `pytest -q` and all tests passed (`72 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2100b51a488320aa32dab8347aa99f)