### PR TITLE
Stack tournament control boxes vertically

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2197,7 +2197,7 @@ html[data-theme="dark"] .timer-display {
 /* Tournament control boxes */
 .tournament-control-grid {
   display: grid;
-  grid-template-columns: repeat(3, minmax(220px, 1fr));
+  grid-template-columns: 1fr;
   gap: 14px;
   margin-bottom: 20px;
 }


### PR DESCRIPTION
### Motivation
- Ensure each main tournament control box (QR & Passcode, Time Controls, Tournament Controls) appears on its own row in the tournament view for improved readability and mobile friendliness.

### Description
- Modify `app/static/style.css` to set the `.tournament-control-grid` `grid-template-columns` to `1fr` instead of `repeat(3, minmax(220px, 1fr))`, causing the control boxes to stack vertically.

### Testing
- Ran `pytest -q` and the test suite passed with `72 passed` (182 warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21adbd8c788320a1e13210a5270b37)

## Summary by Sourcery

New Features:
- Display tournament control boxes in a single-column grid layout instead of three columns to improve layout clarity and mobile friendliness.