### PR TITLE
Adjust tournament join controls (inline layout + manager-only QR)

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2234,6 +2234,7 @@ html[data-theme="dark"] .timer-display {
 .tournament-control-box .control-actions,
 .tournament-control-box .timer-actions {
   display: flex;
+  flex-direction: row;
   align-items: center;
   gap: 8px;
   flex-wrap: nowrap;

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -29,10 +29,15 @@
   {% if not is_player %}
   <section class="panel-card join-row tournament-control-box" aria-label="Player passcode and QR controls">
     <div class="section-heading">
-      <div><h3>QR and Passcode</h3><p>Share the player join QR link or enter a tournament passcode.</p></div>
+      <div>
+        {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+          <h3>QR and Passcode</h3><p>Share the player join QR link or enter a tournament passcode.</p>
+        {% else %}
+          <h3>Passcode</h3><p>Enter a tournament passcode to join.</p>
+        {% endif %}
+      </div>
     </div>
     <div class="join-controls">
-      <a class="btn ghost" href="{{ url_for('tournament_join_link', tid=t.id) }}" target="_blank" rel="noopener">Player Join QR</a>
       {% if current_user.is_authenticated %}
         {% set join_pending = user_join_request and user_join_request.status == 'pending' %}
         {% set join_rejected = user_join_request and user_join_request.status == 'rejected' %}
@@ -50,6 +55,9 @@
           <input type="text" name="passcode" maxlength="4" pattern="\d{4}" placeholder="Passcode" required>
           <button class="btn" type="submit">{% if t.join_requires_approval %}Request Join{% else %}Join{% endif %}</button>
         </form>
+        {% endif %}
+        {% if current_user.has_permission('tournaments.manage') %}
+          <a class="btn ghost" href="{{ url_for('tournament_join_link', tid=t.id) }}" target="_blank" rel="noopener">Player Join QR</a>
         {% endif %}
       {% else %}
         <a class="btn" href="{{ url_for('login') }}">Login to Join</a>

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -661,3 +661,30 @@ def test_duplicate_booth_numbers_are_blocked_across_artists_and_vendors(client, 
     assert response.status_code == 200
     assert b'already assigned to vendor Existing Vendor' in response.data
     assert session.query(ArtistProfile).filter_by(name='Duplicate Artist').first() is None
+
+
+def test_player_join_qr_only_visible_to_tournament_managers(client, session):
+    manager_role = session.query(Role).filter_by(name='manager').one()
+    user_role = session.query(Role).filter_by(name='user').one()
+    manager = User(email='qr-manager@example.com', name='QR Manager', role=manager_role)
+    manager.set_password('secret')
+    player = User(email='qr-player@example.com', name='QR Player', role=user_role)
+    player.set_password('secret')
+    tournament = Tournament(name='QR Visibility Event', format='Constructed')
+    session.add_all([manager, player, tournament])
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': player.email, 'password': 'secret'}).status_code == 302
+        response = client.get(f'/t/{tournament.id}')
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert 'Player Join QR' not in html
+        assert 'placeholder="Passcode"' in html
+
+        client.get('/logout')
+        assert client.post('/login', data={'email': manager.email, 'password': 'secret'}).status_code == 302
+        response = client.get(f'/t/{tournament.id}')
+        assert response.status_code == 200
+        html = response.get_data(as_text=True)
+        assert 'Player Join QR' in html


### PR DESCRIPTION
### Motivation
- Keep the passcode input, join button, and Player Join QR control on a single row so the join UI is more compact and aligned.
- Prevent normal players from seeing the Player Join QR link while still allowing tournament managers to access it.

### Description
- Update `app/templates/tournament/view.html` to show manager-only heading/copy for the QR controls and only render the `Player Join QR` link when the user has `tournaments.manage` permission.
- Move the `Player Join QR` link into the same `.join-controls` block so it sits inline with the passcode form for managers.
- Update `app/static/style.css` to set `flex-direction: row` for `.tournament-control-box` control groups so controls remain on one line.
- Add `test_player_join_qr_only_visible_to_tournament_managers` to `tests/test_tournament.py` verifying normal players do not see the QR link while managers do.

### Testing
- Ran `pytest tests/test_tournament.py` and observed all tests in that file passed (`21 passed`).
- Ran `pytest tests/test_tournament.py::test_player_join_qr_only_visible_to_tournament_managers` and it passed.
- Captured an automated screenshot of the updated controls at `/tmp/walter-join-controls.png` to visually confirm the layout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a27227f3fac83208f2d87d86be1a731)

## Summary by Sourcery

Restrict visibility of the player join QR link to tournament managers and align the join controls into a single inline control group.

Enhancements:
- Adjust tournament view copy and headings so only managers see QR-related messaging while players see passcode-only instructions.
- Update tournament join controls layout so passcode form and QR button appear inline within the same control box.
- Ensure player join QR link is only rendered for users with tournament management permission.

Tests:
- Add a test verifying that normal players cannot see the Player Join QR link while tournament managers can.