### PR TITLE
Persist draft seating, implement draft pairing helpers, and add seeded cut pairing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -437,7 +437,7 @@ def create_app():
         ArtistProfile,
         all_permission_keys,
     )
-    from .pairing import pair_round, recommended_rounds, compute_standings, player_points
+    from .pairing import pair_round, recommended_rounds, compute_standings, player_points, draft_seating_tables, seeded_cut_pairs
 
     TYPE_SORT_ORDER = [
         'Creature',
@@ -5004,9 +5004,8 @@ def create_app():
         t = db.session.get(Tournament, tid)
         if not t or t.format != 'Draft':
             abort(404)
-        players = db.session.query(TournamentPlayer).filter_by(tournament_id=tid).all()
-        random.shuffle(players)
-        tables = [players[i:i+8] for i in range(0, len(players), 8)]
+        tables = draft_seating_tables(t, db.session)
+        db.session.commit()
         timer_end = None
         timer_type = None
         timer_remaining = None
@@ -5188,9 +5187,7 @@ def create_app():
                         table += 1
                         i += group_size
                 else:
-                    for i in range(top_n // 2):
-                        p1 = seeds[i]
-                        p2 = seeds[top_n - 1 - i]
+                    for p1, p2 in seeded_cut_pairs(seeds):
                         m = Match(round_id=r.id, player1_id=p1.id, player2_id=p2.id, table_number=table)
                         db.session.add(m)
                         table += 1

--- a/app/pairing.py
+++ b/app/pairing.py
@@ -157,13 +157,94 @@ def _build_pods(players, group_size, session, *, up_to_round_number=None, allow_
     return total[1]
 
 
+def seeded_cut_pairs(seeds):
+    return [(seeds[i], seeds[len(seeds) - 1 - i]) for i in range(len(seeds) // 2)]
+
+
+def _draft_seating_tables(t: Tournament, players, session, table_size=8):
+    state = _load_pairing_state(t)
+    saved_tables = state.get('draft_seating') or []
+    active_ids = [tp.id for tp in players]
+    active_set = set(active_ids)
+    player_by_id = {tp.id: tp for tp in players}
+
+    seated_ids = []
+    for table in saved_tables:
+        for player_id in table:
+            if player_id in active_set and player_id not in seated_ids:
+                seated_ids.append(player_id)
+
+    missing_ids = [player_id for player_id in active_ids if player_id not in seated_ids]
+    if missing_ids:
+        random.shuffle(missing_ids)
+        seated_ids.extend(missing_ids)
+
+    tables = [seated_ids[i:i+table_size] for i in range(0, len(seated_ids), table_size)]
+    if tables != saved_tables:
+        state['draft_seating'] = tables
+        _save_pairing_state(t, state, session)
+
+    return [[player_by_id[player_id] for player_id in table if player_id in player_by_id] for table in tables]
+
+
+def draft_seating_tables(t: Tournament, session, *, include_dropped=True):
+    query = session.query(TournamentPlayer).filter_by(tournament_id=t.id)
+    if not include_dropped:
+        query = query.filter_by(dropped=False)
+    return _draft_seating_tables(t, query.all(), session)
+
+
+def _partial_draft_pod_pairs(pod):
+    circle = pod[:]
+    pairs = []
+    idx = random.randrange(len(circle))
+    while len(circle) > 1:
+        first = circle.pop(idx)
+        opponent_idx = (idx + 2) % len(circle)
+        opponent = circle.pop(opponent_idx)
+        pairs.append((first, opponent))
+        if circle:
+            idx = opponent_idx % len(circle)
+    if circle:
+        pairs.append((circle[0], None))
+    return pairs
+
+
+def _big_x_little_x_pairs(pod):
+    if len(pod) <= 1:
+        return [(pod[0], None)] if pod else []
+    if len(pod) < 8:
+        return _partial_draft_pod_pairs(pod)
+
+    return [(pod[i], pod[i + 4]) for i in range(4)]
+
+
+def _draft_round_one_pairs(t: Tournament, players, session):
+    pairs = []
+    for pod in _draft_seating_tables(t, players, session):
+        pairs.extend(_big_x_little_x_pairs(pod))
+    return pairs
+
+
 def swiss_pair_round(t: Tournament, r: Round, session):
     players = session.query(TournamentPlayer).filter_by(tournament_id=t.id, dropped=False).all()
     group_size = 4 if t.format.lower() == 'commander' else 2
     if r.number == 1:
-        random.shuffle(players)
         table = t.start_table_number or 1
         created = []
+        if t.format.lower() == 'draft' and group_size == 2:
+            pairings = _draft_round_one_pairs(t, players, session)
+            for p1, p2 in pairings:
+                m = Match(round_id=r.id, table_number=table,
+                          player1_id=p1.id,
+                          player2_id=p2.id if p2 else None)
+                session.add(m)
+                created.append(m)
+                table += 1
+            session.commit()
+            return created
+
+        random.shuffle(players)
         i = 0
         while i < len(players):
             pod = players[i:i+group_size]

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -4,7 +4,7 @@ from itertools import product
 
 from app.app import db
 from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult, Venue, SiteLog, TournamentLog
-from app.pairing import pair_round, compute_standings
+from app.pairing import pair_round, compute_standings, draft_seating_tables, seeded_cut_pairs
 from datetime import datetime
 
 
@@ -246,6 +246,108 @@ def test_swiss_all_unique_until_cut_then_repeat_allowed(session):
             m.completed = True
         session.commit()
 
+
+def _add_tournament_players(session, tournament, count, prefix):
+    role_user = session.query(Role).filter_by(name='user').first()
+    players = []
+    for i in range(count):
+        user = User(email=f'{prefix}{i}@ex.com', name=f'{prefix}{i}', role=role_user)
+        session.add(user)
+        session.commit()
+        player = TournamentPlayer(tournament_id=tournament.id, user_id=user.id)
+        session.add(player)
+        session.commit()
+        players.append(player)
+    return players
+
+
+def test_draft_round_one_uses_big_x_little_x_from_saved_seating(session):
+    tournament = Tournament(name='Draft Seating Event', format='Draft')
+    session.add(tournament)
+    session.commit()
+    players = _add_tournament_players(session, tournament, 8, 'draftseat')
+    tournament.pairing_options = json.dumps({'draft_seating': [[player.id for player in players]]})
+    session.commit()
+
+    rnd = Round(tournament_id=tournament.id, number=1)
+    session.add(rnd)
+    session.commit()
+
+    matches = pair_round(tournament, rnd, session)
+    pairs = [(match.player1_id, match.player2_id) for match in sorted(matches, key=lambda m: m.table_number)]
+
+    assert pairs == [
+        (players[0].id, players[4].id),
+        (players[1].id, players[5].id),
+        (players[2].id, players[6].id),
+        (players[3].id, players[7].id),
+    ]
+
+
+def test_draft_round_one_uses_big_x_little_x_for_each_pod_with_partial_pod(session, monkeypatch):
+    tournament = Tournament(name='Partial Pod Draft Event', format='Draft')
+    session.add(tournament)
+    session.commit()
+    players = _add_tournament_players(session, tournament, 15, 'draftpartial')
+    tournament.pairing_options = json.dumps({
+        'draft_seating': [
+            [player.id for player in players[:8]],
+            [player.id for player in players[8:]],
+        ]
+    })
+    session.commit()
+    monkeypatch.setattr('app.pairing.random.randrange', lambda stop: 0)
+
+    rnd = Round(tournament_id=tournament.id, number=1)
+    session.add(rnd)
+    session.commit()
+
+    matches = pair_round(tournament, rnd, session)
+    pairs = [(match.player1_id, match.player2_id) for match in sorted(matches, key=lambda m: m.table_number)]
+
+    assert pairs == [
+        (players[0].id, players[4].id),
+        (players[1].id, players[5].id),
+        (players[2].id, players[6].id),
+        (players[3].id, players[7].id),
+        (players[8].id, players[11].id),
+        (players[12].id, players[9].id),
+        (players[10].id, players[13].id),
+        (players[14].id, None),
+    ]
+
+
+def test_draft_seating_is_persisted_for_round_one_pairings(session):
+    tournament = Tournament(name='Persisted Draft Seating Event', format='Draft')
+    session.add(tournament)
+    session.commit()
+    _add_tournament_players(session, tournament, 8, 'draftpersist')
+
+    random.seed(99)
+    seating = draft_seating_tables(tournament, session)
+    saved_seating = [[player.id for player in table] for table in seating]
+    session.commit()
+
+    rnd = Round(tournament_id=tournament.id, number=1)
+    session.add(rnd)
+    session.commit()
+    matches = pair_round(tournament, rnd, session)
+    pairs = [(match.player1_id, match.player2_id) for match in sorted(matches, key=lambda m: m.table_number)]
+
+    table = saved_seating[0]
+    assert pairs == [
+        (table[0], table[4]),
+        (table[1], table[5]),
+        (table[2], table[6]),
+        (table[3], table[7]),
+    ]
+    assert json.loads(tournament.pairing_options)['draft_seating'] == saved_seating
+
+
+def test_seeded_cut_pairs_first_against_last():
+    seeds = list(range(1, 9))
+
+    assert seeded_cut_pairs(seeds) == [(1, 8), (2, 7), (3, 6), (4, 5)]
 
 def test_bulk_register_adds_existing_users(client, session):
     manager_role = session.query(Role).filter_by(name='manager').one()


### PR DESCRIPTION
### Motivation

- Preserve and reuse draft seating to produce repeatable round-one draft pairings and to display seating in the UI. 
- Simplify and centralize seeded cut pairing logic for single-elimination cuts. 
- Support draft-specific pairing patterns (big-x/little-x and partial-pod handling) during round one.

### Description

- Added pairing helpers in `app/pairing.py`: `seeded_cut_pairs`, `_draft_seating_tables`, `draft_seating_tables`, `_partial_draft_pod_pairs`, `_big_x_little_x_pairs`, and `_draft_round_one_pairs` to generate and persist draft seating and draft-first-round pairings. 
- Updated `swiss_pair_round` to use draft seating and big-x/little-x pairing for `Draft` format round one, creating `Match` rows from the persisted seating and committing the session. 
- Replaced inline cut-seeding loop with `seeded_cut_pairs` in `app/app.py` so seeded cuts pair first-vs-last consistently. 
- Updated the `/t/<int:tid>/draft-seating` view in `app/app.py` to use `draft_seating_tables` instead of in-place random shuffling and to persist seating state via the pairing helpers.

### Testing

- Added unit tests in `tests/test_tournament.py` for draft seating persistence and round-one draft pairing behavior using `draft_seating_tables` and `seeded_cut_pairs`. 
- Ran the test suite including the new tests in `tests/test_tournament.py`; all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2727f1fed08320ad347228eee47721)

## Summary by Sourcery

Persist and reuse draft seating to drive deterministic round-one draft pairings and centralize seeded cut pairing logic.

New Features:
- Support draft round-one pairings based on saved draft seating using big-x/little-x and partial-pod patterns.
- Expose a reusable helper to compute draft seating tables for tournaments.

Enhancements:
- Centralize seeded cut pairing into a shared helper to consistently pair first-vs-last seeds for elimination cuts.
- Update swiss pairing to special-case draft round one using seating-based pair generation instead of random shuffling.
- Ensure draft seating is stored in tournament pairing state when generated or reused from the UI draft seating view.

Tests:
- Add tests covering draft seating persistence, big-x/little-x and partial-pod draft round-one pairings, and seeded cut pairing behavior.