### PR TITLE
Add cube-league voting & Cube Cobra previews, league deletion, and registration/drop rule changes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -38,6 +38,7 @@ import urllib.parse
 import urllib.request
 from collections import OrderedDict
 from urllib.parse import urlparse
+from html.parser import HTMLParser
 from sqlalchemy import inspect, text, or_
 from sqlalchemy.exc import SQLAlchemyError
 from cryptography.hazmat.primitives import serialization, hashes
@@ -71,6 +72,85 @@ MAJOR_60_CARD_FORMATS = [
 BASE_TOURNAMENT_FORMATS = ['Commander', 'Draft']
 TOURNAMENT_FORMATS = BASE_TOURNAMENT_FORMATS + MAJOR_60_CARD_FORMATS
 MAILGUN_DOMAIN_PATTERN = re.compile(r'^[A-Za-z0-9](?:[A-Za-z0-9.-]{0,251}[A-Za-z0-9])?$')
+
+
+class CubeCobraMetadataParser(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self.meta = {}
+        self.title = None
+        self._in_title = False
+
+    def handle_starttag(self, tag, attrs):
+        attrs = dict(attrs)
+        if tag.lower() == 'title':
+            self._in_title = True
+        if tag.lower() == 'meta':
+            key = attrs.get('property') or attrs.get('name')
+            content = attrs.get('content')
+            if key and content:
+                self.meta[key.lower()] = content.strip()
+
+    def handle_endtag(self, tag):
+        if tag.lower() == 'title':
+            self._in_title = False
+
+    def handle_data(self, data):
+        if self._in_title:
+            value = data.strip()
+            if value:
+                self.title = value
+
+
+def normalize_cube_cobra_url(raw_url):
+    url = (raw_url or '').strip()
+    if not url:
+        raise ValueError('Cube Cobra link is required.')
+    if not re.match(r'^https?://', url, re.I):
+        url = f'https://{url}'
+    parsed = urllib.parse.urlparse(url)
+    host = (parsed.netloc or '').lower()
+    if host.startswith('www.'):
+        host = host[4:]
+    if host != 'cubecobra.com':
+        raise ValueError('Only Cube Cobra links are supported.')
+    if parsed.scheme not in {'http', 'https'}:
+        raise ValueError('Cube Cobra link must use http or https.')
+    return urllib.parse.urlunparse(('https', parsed.netloc, parsed.path, '', parsed.query, ''))
+
+
+def fetch_cube_cobra_metadata(raw_url):
+    url = normalize_cube_cobra_url(raw_url)
+    title = 'Cube Cobra Cube'
+    image_url = None
+    try:
+        req = urllib.request.Request(
+            url,
+            headers={'User-Agent': 'WaLTER cube preview bot/1.0'},
+        )
+        with urllib.request.urlopen(req, timeout=8) as response:
+            content_type = response.headers.get('Content-Type', '')
+            if 'text/html' in content_type or not content_type:
+                html = response.read(512000).decode('utf-8', errors='ignore')
+                parser = CubeCobraMetadataParser()
+                parser.feed(html)
+                title = (
+                    parser.meta.get('og:title')
+                    or parser.meta.get('twitter:title')
+                    or parser.title
+                    or title
+                ).strip()
+                image_url = (
+                    parser.meta.get('og:image')
+                    or parser.meta.get('twitter:image')
+                    or None
+                )
+    except Exception:
+        title = title
+    title = re.sub(r'\s*[|\-]\s*Cube Cobra\s*$', '', title, flags=re.I).strip() or 'Cube Cobra Cube'
+    if image_url:
+        image_url = urllib.parse.urljoin(url, image_url)
+    return url, title[:250], image_url
 
 
 def _mailgun_messages_url(domain):
@@ -268,6 +348,19 @@ def create_app():
                     {'level': level, 'name': role_name},
                 )
             db.session.commit()
+            from .models import DEFAULT_ROLE_PERMISSIONS, Role  # lazy import to avoid circular reference
+            for role_name, default_perms in DEFAULT_ROLE_PERMISSIONS.items():
+                role = db.session.query(Role).filter_by(name=role_name).first()
+                if role:
+                    current_perms = role.permissions_dict()
+                    changed = False
+                    for key, allowed in default_perms.items():
+                        if key not in current_perms:
+                            current_perms[key] = allowed
+                            changed = True
+                    if changed:
+                        role.permissions = json.dumps(current_perms)
+            db.session.commit()
         from .models import (
             Report,
             TournamentJoinRequest,
@@ -373,11 +466,24 @@ def create_app():
                 db.session.commit()
         TournamentJoinRequest.__table__.create(bind=db.engine, checkfirst=True)
         PendingRegistration.__table__.create(bind=db.engine, checkfirst=True)
-        from .models import LostFoundItem, TournamentPlayerDeck, League, LeaguePlayer, LeagueResult
+        from .models import (
+            LostFoundItem, TournamentPlayerDeck, League, LeaguePlayer, LeagueResult,
+            LeagueCube, LeaguePlayDate, LeaguePlayDateCube, LeagueCubeVote,
+        )
 
         League.__table__.create(bind=db.engine, checkfirst=True)
         LeaguePlayer.__table__.create(bind=db.engine, checkfirst=True)
         LeagueResult.__table__.create(bind=db.engine, checkfirst=True)
+        if 'league' in inspector.get_table_names():
+            columns = [c['name'] for c in inspector.get_columns('league')]
+            if 'is_cube_league' not in columns:
+                db.session.execute(text('ALTER TABLE league ADD COLUMN is_cube_league BOOLEAN DEFAULT 0'))
+                db.session.execute(text('UPDATE league SET is_cube_league=0 WHERE is_cube_league IS NULL'))
+                db.session.commit()
+        LeagueCube.__table__.create(bind=db.engine, checkfirst=True)
+        LeaguePlayDate.__table__.create(bind=db.engine, checkfirst=True)
+        LeaguePlayDateCube.__table__.create(bind=db.engine, checkfirst=True)
+        LeagueCubeVote.__table__.create(bind=db.engine, checkfirst=True)
 
         media_engine = db.engines['media']
         LostFoundItem.__table__.create(bind=media_engine, checkfirst=True)
@@ -427,6 +533,10 @@ def create_app():
         League,
         LeaguePlayer,
         LeagueResult,
+        LeagueCube,
+        LeaguePlayDate,
+        LeaguePlayDateCube,
+        LeagueCubeVote,
         BadLoginAttempt,
         BlacklistedIP,
         PasswordResetToken,
@@ -959,9 +1069,9 @@ def create_app():
                     selected_tournament = db.session.get(Tournament, int(tournament_id))
                 except (TypeError, ValueError):
                     selected_tournament = None
-                if not selected_tournament or tournament_passcode != selected_tournament.passcode:
-                    flash("Invalid tournament passcode", "error")
-                    log_site('register', 'failure', 'invalid tournament passcode')
+                if not selected_tournament:
+                    flash("Selected tournament was not found", "error")
+                    log_site('register', 'failure', 'invalid tournament selection')
                     return redirect(url_for('register', invite=invite_token) if invite_token else url_for('register'))
             if mode == 'invite_only' and not invite and not selected_tournament:
                 flash('Account creation is invite only. Use the invite link sent by an administrator.', 'error')
@@ -982,7 +1092,7 @@ def create_app():
                 verification_token_hash=_hash_registration_token(verification_token),
                 invite_id=invite.id if invite else None,
                 tournament_id=selected_tournament.id if selected_tournament else None,
-                tournament_passcode=tournament_passcode if selected_tournament else None,
+                tournament_passcode=None,
                 expires_at=datetime.utcnow() + timedelta(minutes=app.config.get('REGISTRATION_PIN_TTL_MINUTES', 15)),
             )
             pending.set_password(password)
@@ -1021,7 +1131,7 @@ def create_app():
         selected_tournament = None
         if pending.tournament_id:
             selected_tournament = db.session.get(Tournament, pending.tournament_id)
-            if not selected_tournament or pending.tournament_passcode != selected_tournament.passcode:
+            if not selected_tournament:
                 db.session.delete(pending)
                 db.session.commit()
                 flash("Tournament invite expired or is no longer valid. Please register again.", "error")
@@ -3696,6 +3806,26 @@ def create_app():
         users = db.session.query(User).order_by(User.name).all()
         return player_rows, results, available_tournaments, users, league_tournament_ids
 
+    def league_vote_context(league):
+        play_dates = db.session.query(LeaguePlayDate).filter_by(league_id=league.id).order_by(LeaguePlayDate.play_date).all()
+        cubes = db.session.query(LeagueCube).filter_by(league_id=league.id).order_by(LeagueCube.title).all()
+        totals = {}
+        user_votes = {}
+        for vote in db.session.query(LeagueCubeVote).filter_by(league_id=league.id).all():
+            totals[(vote.play_date_id, vote.cube_id)] = totals.get((vote.play_date_id, vote.cube_id), 0) + (vote.votes or 0)
+            if current_user.is_authenticated and vote.user_id == current_user.id:
+                user_votes[(vote.play_date_id, vote.cube_id)] = vote.votes or 0
+        available_by_date = {
+            play_date.id: [link.cube_id for link in play_date.available_cubes]
+            for play_date in play_dates
+        }
+        return play_dates, cubes, totals, user_votes, available_by_date
+
+    def require_league_member_or_manager(league):
+        if current_user.has_permission('tournaments.manage'):
+            return True
+        return db.session.query(LeaguePlayer).filter_by(league_id=league.id, user_id=current_user.id).first() is not None
+
     @app.route('/admin/leagues', methods=['GET', 'POST'])
     def leagues():
         require_permission('tournaments.manage')
@@ -3708,7 +3838,7 @@ def create_app():
             if not name:
                 flash('League name is required.', 'error')
                 return redirect(url_for('leagues'))
-            league = League(name=name, start_date=start_date, end_date=end_date)
+            league = League(name=name, start_date=start_date, end_date=end_date, is_cube_league=bool(request.form.get('is_cube_league')))
             db.session.add(league)
             db.session.flush()
             for user_id in request.form.getlist('player_ids'):
@@ -3755,8 +3885,59 @@ def create_app():
                     result.deck_archetype = (request.form.get(f'archetype_{result.id}') or '').strip()
                 db.session.commit()
                 flash('Deck archetypes updated.', 'success')
+            elif action == 'update_settings':
+                league.is_cube_league = bool(request.form.get('is_cube_league'))
+                db.session.commit()
+                log_site('league_update', 'success', f'league_id={league.id}; cube={league.is_cube_league}')
+                flash('League settings updated.', 'success')
+            elif action == 'add_cube':
+                if not league.is_cube_league:
+                    flash('Enable cube league mode before adding Cube Cobra links.', 'error')
+                else:
+                    try:
+                        url, title, image_url = fetch_cube_cobra_metadata(request.form.get('cube_url'))
+                    except ValueError as exc:
+                        flash(str(exc), 'error')
+                    else:
+                        db.session.add(LeagueCube(league_id=league.id, cube_cobra_url=url, title=title, image_url=image_url))
+                        db.session.commit()
+                        log_site('league_cube_add', 'success', f'league_id={league.id}; url={url}')
+                        flash('Cube added.', 'success')
+            elif action == 'add_play_date':
+                if not league.is_cube_league:
+                    flash('Enable cube league mode before adding play dates.', 'error')
+                else:
+                    play_date_value = parse_date_input(request.form.get('play_date'))
+                    if not play_date_value:
+                        flash('Choose a play date.', 'error')
+                    elif db.session.query(LeaguePlayDate).filter_by(league_id=league.id, play_date=play_date_value).first():
+                        flash('That play date already exists.', 'error')
+                    else:
+                        play_date = LeaguePlayDate(league_id=league.id, play_date=play_date_value, is_active=bool(request.form.get('is_active', '1')))
+                        db.session.add(play_date)
+                        db.session.flush()
+                        cube_ids = {int(cid) for cid in request.form.getlist('cube_ids') if cid.isdigit()}
+                        for cube in db.session.query(LeagueCube).filter(LeagueCube.league_id == league.id, LeagueCube.id.in_(cube_ids)).all():
+                            db.session.add(LeaguePlayDateCube(play_date_id=play_date.id, cube_id=cube.id))
+                        db.session.commit()
+                        log_site('league_play_date_add', 'success', f'league_id={league.id}; date={play_date_value}')
+                        flash('Play date added.', 'success')
+            elif action == 'update_play_date':
+                play_date = db.session.get(LeaguePlayDate, int(request.form.get('play_date_id') or 0))
+                if not play_date or play_date.league_id != league.id:
+                    flash('Play date not found.', 'error')
+                else:
+                    play_date.is_active = bool(request.form.get('is_active'))
+                    db.session.query(LeaguePlayDateCube).filter_by(play_date_id=play_date.id).delete()
+                    cube_ids = {int(cid) for cid in request.form.getlist('cube_ids') if cid.isdigit()}
+                    for cube in db.session.query(LeagueCube).filter(LeagueCube.league_id == league.id, LeagueCube.id.in_(cube_ids)).all():
+                        db.session.add(LeaguePlayDateCube(play_date_id=play_date.id, cube_id=cube.id))
+                    db.session.commit()
+                    log_site('league_play_date_update', 'success', f'league_id={league.id}; play_date_id={play_date.id}')
+                    flash('Play date updated.', 'success')
             return redirect(url_for('league_detail', league_id=league.id))
         leaderboard, results, available_tournaments, users, league_tournament_ids = build_league_context(league)
+        play_dates, cubes, cube_vote_totals, cube_user_votes, available_cube_ids = league_vote_context(league)
         return render_template(
             'admin/league_detail.html',
             league=league,
@@ -3765,6 +3946,73 @@ def create_app():
             available_tournaments=available_tournaments,
             users=users,
             league_tournament_ids=league_tournament_ids,
+            play_dates=play_dates,
+            cubes=cubes,
+            cube_vote_totals=cube_vote_totals,
+            cube_user_votes=cube_user_votes,
+            available_cube_ids=available_cube_ids,
+        )
+
+    @app.route('/admin/leagues/<int:league_id>/delete', methods=['POST'])
+    def delete_league(league_id):
+        require_permission('tournaments.delete_leagues')
+        league = db.session.get(League, league_id)
+        if not league:
+            abort(404)
+        name = league.name
+        tournament_count = db.session.query(Tournament).filter_by(league_id=league.id).update({'league_id': None})
+        db.session.delete(league)
+        db.session.commit()
+        log_site('league_delete', 'success', f'league_id={league_id}; name={name}; tournaments_unlinked={tournament_count}')
+        flash(f'Deleted league {name}.', 'success')
+        return redirect(url_for('leagues'))
+
+    @app.route('/leagues/<int:league_id>/cubes', methods=['GET', 'POST'])
+    @login_required
+    def league_cube_voting(league_id):
+        league = db.session.get(League, league_id)
+        if not league or not league.is_cube_league:
+            abort(404)
+        if not require_league_member_or_manager(league):
+            abort(403)
+        if request.method == 'POST':
+            for play_date in db.session.query(LeaguePlayDate).filter_by(league_id=league.id, is_active=True).all():
+                available_ids = {link.cube_id for link in play_date.available_cubes}
+                requested = {}
+                total = 0
+                for cube_id in available_ids:
+                    raw = request.form.get(f'votes_{play_date.id}_{cube_id}', '0')
+                    try:
+                        count = max(0, min(3, int(raw)))
+                    except ValueError:
+                        count = 0
+                    requested[cube_id] = count
+                    total += count
+                if total > 3:
+                    flash(f'{play_date.play_date}: use no more than 3 total votes.', 'error')
+                    return redirect(url_for('league_cube_voting', league_id=league.id))
+                for cube_id, count in requested.items():
+                    vote = db.session.query(LeagueCubeVote).filter_by(play_date_id=play_date.id, cube_id=cube_id, user_id=current_user.id).first()
+                    if count:
+                        if not vote:
+                            vote = LeagueCubeVote(league_id=league.id, play_date_id=play_date.id, cube_id=cube_id, user_id=current_user.id)
+                            db.session.add(vote)
+                        vote.votes = count
+                    elif vote:
+                        db.session.delete(vote)
+            db.session.commit()
+            log_site('league_cube_vote', 'success', f'league_id={league.id}; user_id={current_user.id}')
+            flash('Cube votes saved.', 'success')
+            return redirect(url_for('league_cube_voting', league_id=league.id))
+        play_dates, cubes, cube_vote_totals, cube_user_votes, available_cube_ids = league_vote_context(league)
+        return render_template(
+            'league_cubes.html',
+            league=league,
+            play_dates=play_dates,
+            cubes=cubes,
+            cube_vote_totals=cube_vote_totals,
+            cube_user_votes=cube_user_votes,
+            available_cube_ids=available_cube_ids,
         )
 
     @app.route('/admin/schedule')
@@ -5344,11 +5592,22 @@ def create_app():
             return redirect(url_for('view_round', tid=t.id, rid=m.round_id))
         if request.method == 'POST':
             dropped_ids = []
+            can_drop_any_player = current_user.has_permission('tournaments.manage')
+
+            def player_drop_requested(field_name, tournament_player):
+                if not request.form.get(field_name):
+                    return False
+                if can_drop_any_player or (tournament_player and tournament_player.user_id == current_user.id):
+                    return True
+                flash('Players may only drop themselves from a tournament.', 'error')
+                log_tournament(t.id, 'drop', 'failure', f'user_id={current_user.id}; attempted={tournament_player.user_id if tournament_player else ""}')
+                return False
+
             if t.format.lower() == 'commander':
-                drop_p1 = bool(request.form.get('drop_p1'))
-                drop_p2 = bool(request.form.get('drop_p2'))
-                drop_p3 = bool(request.form.get('drop_p3'))
-                drop_p4 = bool(request.form.get('drop_p4'))
+                drop_p1 = player_drop_requested('drop_p1', m.player1)
+                drop_p2 = player_drop_requested('drop_p2', m.player2) if m.player2_id else False
+                drop_p3 = player_drop_requested('drop_p3', m.player3) if m.player3_id else False
+                drop_p4 = player_drop_requested('drop_p4', m.player4) if m.player4_id else False
                 if request.form.get('is_draw') and not any([drop_p1, drop_p2, drop_p3, drop_p4]):
                     m.result = MatchResult(is_draw=True)
                 else:
@@ -5381,10 +5640,10 @@ def create_app():
                 draws   = int(request.form.get('draws', 0))
                 m.result = MatchResult(player1_wins=p1_wins, player2_wins=p2_wins, draws=draws)
                 m.completed = True
-                if request.form.get('drop_p1'):
+                if player_drop_requested('drop_p1', m.player1):
                     m.player1.dropped = True
                     dropped_ids.append(m.player1.user_id)
-                if m.player2_id and request.form.get('drop_p2'):
+                if m.player2_id and player_drop_requested('drop_p2', m.player2):
                     m.player2.dropped = True
                     dropped_ids.append(m.player2.user_id)
                 # Auto-drop losers in elimination rounds

--- a/app/models.py
+++ b/app/models.py
@@ -19,6 +19,7 @@ PERMISSION_GROUPS = {
         'join': 'Join tournaments',
         'approve_join': 'Approve tournament join requests',
         'bulk_manage': 'Bulk edit tournaments',
+        'delete_leagues': 'Delete leagues',
     },
     'venues': {
         'manage': 'Create and manage venues, vendors, and artists',
@@ -560,6 +561,7 @@ class League(db.Model):
     name = db.Column(db.String(200), nullable=False)
     start_date = db.Column(db.Date, nullable=True)
     end_date = db.Column(db.Date, nullable=True)
+    is_cube_league = db.Column(db.Boolean, default=False)
     created_at = db.Column(db.DateTime, default=utc_now)
 
 
@@ -592,6 +594,57 @@ class LeagueResult(db.Model):
     user = db.relationship('User')
 
     __table_args__ = (UniqueConstraint('league_id', 'tournament_id', 'user_id', name='_league_tournament_user_uc'),)
+
+
+class LeagueCube(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    league_id = db.Column(db.Integer, db.ForeignKey('league.id'), nullable=False)
+    cube_cobra_url = db.Column(db.Text, nullable=False)
+    title = db.Column(db.String(250), nullable=False)
+    image_url = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=utc_now)
+
+    league = db.relationship('League', backref=db.backref('cubes', cascade='all, delete-orphan'))
+
+
+class LeaguePlayDate(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    league_id = db.Column(db.Integer, db.ForeignKey('league.id'), nullable=False)
+    play_date = db.Column(db.Date, nullable=False)
+    is_active = db.Column(db.Boolean, default=True)
+    created_at = db.Column(db.DateTime, default=utc_now)
+
+    league = db.relationship('League', backref=db.backref('play_dates', cascade='all, delete-orphan'))
+
+    __table_args__ = (UniqueConstraint('league_id', 'play_date', name='_league_play_date_uc'),)
+
+
+class LeaguePlayDateCube(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    play_date_id = db.Column(db.Integer, db.ForeignKey('league_play_date.id'), nullable=False)
+    cube_id = db.Column(db.Integer, db.ForeignKey('league_cube.id'), nullable=False)
+
+    play_date = db.relationship('LeaguePlayDate', backref=db.backref('available_cubes', cascade='all, delete-orphan'))
+    cube = db.relationship('LeagueCube')
+
+    __table_args__ = (UniqueConstraint('play_date_id', 'cube_id', name='_league_play_date_cube_uc'),)
+
+
+class LeagueCubeVote(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    league_id = db.Column(db.Integer, db.ForeignKey('league.id'), nullable=False)
+    play_date_id = db.Column(db.Integer, db.ForeignKey('league_play_date.id'), nullable=False)
+    cube_id = db.Column(db.Integer, db.ForeignKey('league_cube.id'), nullable=False)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    votes = db.Column(db.Integer, default=0)
+    updated_at = db.Column(db.DateTime, default=utc_now, onupdate=utc_now)
+
+    league = db.relationship('League', backref=db.backref('cube_votes', cascade='all, delete-orphan'))
+    play_date = db.relationship('LeaguePlayDate', backref=db.backref('votes', cascade='all, delete-orphan'))
+    cube = db.relationship('LeagueCube')
+    user = db.relationship('User')
+
+    __table_args__ = (UniqueConstraint('play_date_id', 'cube_id', 'user_id', name='_league_cube_vote_uc'),)
 
 
 class LostFoundItem(db.Model):

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2305,3 +2305,31 @@ html[data-theme="dark"] .tournament-control-box .rounds-form {
     width: auto;
   }
 }
+
+.cube-card-grid {
+  align-items: stretch;
+}
+
+.cube-preview-card {
+  gap: 1rem;
+  overflow: hidden;
+}
+
+.cube-preview-image {
+  width: 100%;
+  max-height: 180px;
+  object-fit: cover;
+  border-radius: 14px;
+  border: 1px solid var(--border);
+  background: var(--surface-muted);
+}
+
+.league-play-date-form {
+  margin-top: 1rem;
+  padding-top: 1rem;
+  border-top: 1px solid var(--border);
+}
+
+.cube-vote-form input[type="number"] {
+  max-width: 5rem;
+}

--- a/app/templates/admin/league_detail.html
+++ b/app/templates/admin/league_detail.html
@@ -12,9 +12,77 @@
     </p>
   </div>
   <div class="page-header__actions">
+    {% if league.is_cube_league %}<a class="btn" href="{{ url_for('league_cube_voting', league_id=league.id) }}">Cube Voting</a>{% endif %}
     <a class="btn ghost" href="{{ url_for('leagues') }}">All Leagues</a>
   </div>
 </section>
+
+
+<section class="panel-card">
+  <div class="section-heading"><div><h3>League Settings</h3><p>Mark cube leagues to enable Cube Cobra previews, play dates, and member voting.</p></div></div>
+  <form method="post" class="modern-form grid-form">
+    <input type="hidden" name="action" value="update_settings">
+    <label class="checkbox-label wide-field"><input type="checkbox" name="is_cube_league" value="1" {% if league.is_cube_league %}checked{% endif %}> Cube league</label>
+    <div class="form-actions wide-field start-actions"><button class="btn" type="submit">Save Settings</button></div>
+  </form>
+</section>
+
+{% if league.is_cube_league %}
+<section class="panel-card">
+  <div class="section-heading"><div><h3>Cube Cobra Library</h3><p>Add Cube Cobra links. WaLTER links back to Cube Cobra and previews the cube title and image when available.</p></div></div>
+  <form method="post" class="modern-form grid-form">
+    <input type="hidden" name="action" value="add_cube">
+    <label class="wide-field">Cube Cobra URL
+      <input type="url" name="cube_url" placeholder="https://cubecobra.com/cube/overview/..." required>
+    </label>
+    <div class="form-actions wide-field start-actions"><button class="btn" type="submit">Add Cube</button></div>
+  </form>
+  {% if cubes %}
+  <div class="league-card-grid cube-card-grid">
+    {% for cube in cubes %}
+    <article class="league-card cube-preview-card">
+      {% if cube.image_url %}<img class="cube-preview-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+      <div>
+        <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
+        <p class="muted-text">Cube Cobra</p>
+      </div>
+    </article>
+    {% endfor %}
+  </div>
+  {% else %}<p class="empty-state">No cubes have been added yet.</p>{% endif %}
+</section>
+
+<section class="panel-card">
+  <div class="section-heading"><div><h3>Play Dates &amp; Voting Ballots</h3><p>Admins choose the play dates and which cubes are available for members to vote on. Members can spend up to 3 votes per date.</p></div></div>
+  <form method="post" class="modern-form grid-form">
+    <input type="hidden" name="action" value="add_play_date">
+    <label>Play date <input type="date" name="play_date" required></label>
+    <label class="checkbox-label"><input type="checkbox" name="is_active" value="1" checked> Open for voting</label>
+    <label class="wide-field">Cubes available for vote
+      <select name="cube_ids" multiple size="6">
+        {% for cube in cubes %}<option value="{{ cube.id }}">{{ cube.title }}</option>{% endfor %}
+      </select>
+    </label>
+    <div class="form-actions wide-field start-actions"><button class="btn" type="submit">Add Play Date</button></div>
+  </form>
+  {% if play_dates %}
+    {% for play_date in play_dates %}
+    <form method="post" class="league-play-date-form">
+      <input type="hidden" name="action" value="update_play_date">
+      <input type="hidden" name="play_date_id" value="{{ play_date.id }}">
+      <h4>{{ play_date.play_date }}{% if not play_date.is_active %} <span class="status-pill warning">closed</span>{% endif %}</h4>
+      <label class="checkbox-label"><input type="checkbox" name="is_active" value="1" {% if play_date.is_active %}checked{% endif %}> Open for voting</label>
+      <label>Cubes available
+        <select name="cube_ids" multiple size="5">
+          {% for cube in cubes %}<option value="{{ cube.id }}" {% if cube.id in available_cube_ids.get(play_date.id, []) %}selected{% endif %}>{{ cube.title }} — {{ cube_vote_totals.get((play_date.id, cube.id), 0) }} votes</option>{% endfor %}
+        </select>
+      </label>
+      <button class="btn ghost" type="submit">Save Ballot</button>
+    </form>
+    {% endfor %}
+  {% else %}<p class="empty-state">No play dates have been configured yet.</p>{% endif %}
+</section>
+{% endif %}
 
 <section class="stats-grid">
   <div class="stat-card"><span>Players</span><strong>{{ leaderboard|length }}</strong></div>

--- a/app/templates/admin/leagues.html
+++ b/app/templates/admin/leagues.html
@@ -25,6 +25,7 @@
     <label>End date
       <input type="date" name="end_date">
     </label>
+    <label class="checkbox-label"><input type="checkbox" name="is_cube_league" value="1"> Cube league</label>
     <label>Import tournament now
       <select name="tournament_id">
         <option value="">Choose later</option>
@@ -67,7 +68,15 @@
           {% endif %}
         </p>
       </div>
-      <a class="btn ghost" href="{{ url_for('league_detail', league_id=league.id) }}">Manage</a>
+      <div class="form-actions start-actions">
+        {% if league.is_cube_league %}<a class="btn ghost" href="{{ url_for('league_cube_voting', league_id=league.id) }}">Cube voting</a>{% endif %}
+        <a class="btn ghost" href="{{ url_for('league_detail', league_id=league.id) }}">Manage</a>
+        {% if current_user.has_permission('tournaments.delete_leagues') %}
+        <form method="post" action="{{ url_for('delete_league', league_id=league.id) }}" onsubmit="return confirm('Delete {{ league.name|e }}? This cannot be undone.');">
+          <button class="btn danger" type="submit">Delete</button>
+        </form>
+        {% endif %}
+      </div>
     </article>
     {% endfor %}
   </div>

--- a/app/templates/league_cubes.html
+++ b/app/templates/league_cubes.html
@@ -1,0 +1,40 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header modern-hero">
+  <div class="page-header__title">
+    <span class="eyebrow">Cube League</span>
+    <h2>{{ league.name }} Cube Voting</h2>
+    <p class="page-description">Vote for the cubes you want to draft on each play date. You may spend up to 3 votes per date.</p>
+  </div>
+</section>
+
+{% if play_dates %}
+<form method="post" class="cube-vote-form">
+  {% for play_date in play_dates %}
+    {% set available = available_cube_ids.get(play_date.id, []) %}
+    <section class="panel-card">
+      <div class="section-heading"><div><h3>{{ play_date.play_date }}</h3><p>{% if play_date.is_active %}Voting open — use up to 3 votes for this date.{% else %}Voting is closed for this date.{% endif %}</p></div></div>
+      {% if available %}
+      <div class="league-card-grid cube-card-grid">
+        {% for cube in cubes if cube.id in available %}
+        <article class="league-card cube-preview-card">
+          {% if cube.image_url %}<img class="cube-preview-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+          <div>
+            <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
+            <p class="muted-text">Total votes: {{ cube_vote_totals.get((play_date.id, cube.id), 0) }}</p>
+            <label>Your votes
+              <input type="number" name="votes_{{ play_date.id }}_{{ cube.id }}" min="0" max="3" value="{{ cube_user_votes.get((play_date.id, cube.id), 0) }}" {% if not play_date.is_active %}disabled{% endif %}>
+            </label>
+          </div>
+        </article>
+        {% endfor %}
+      </div>
+      {% else %}<p class="empty-state">No cubes are available for this date yet.</p>{% endif %}
+    </section>
+  {% endfor %}
+  <div class="form-actions start-actions"><button class="btn" type="submit">Save Votes</button></div>
+</form>
+{% else %}
+<p class="empty-state">No cube play dates have been configured yet.</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/match/report.html
+++ b/app/templates/match/report.html
@@ -1,5 +1,6 @@
 {% extends 'base.html' %}
 {% block content %}
+{% set can_drop_any = current_user.has_permission('tournaments.manage') %}
 <p><a href="{{ url_for('view_tournament', tid=m.round.tournament_id) }}">Back to Tournament</a></p>
 <h2>Report Match</h2>
 <p>Round {{ m.round.number }} — Table {{ m.table_number }}</p>
@@ -17,27 +18,27 @@
       <tr>
         <td>{{ m.player1.user.name }} place</td>
         <td><input type="number" name="p1_place" min="1" max="4" value="{{ m.result.p1_place if m.result else (1 if not m.player2_id else '') }}"></td>
-        <td><label><input type="checkbox" name="drop_p1"> Drop</label></td>
+        <td>{% if can_drop_any or current_user.id == m.player1.user_id %}<label><input type="checkbox" name="drop_p1"> Drop</label>{% endif %}</td>
       </tr>
       {% if m.player2_id %}
       <tr>
         <td>{{ m.player2.user.name }} place</td>
         <td><input type="number" name="p2_place" min="1" max="4" value="{{ m.result.p2_place if m.result else '' }}"></td>
-        <td><label><input type="checkbox" name="drop_p2"> Drop</label></td>
+        <td>{% if can_drop_any or current_user.id == m.player2.user_id %}<label><input type="checkbox" name="drop_p2"> Drop</label>{% endif %}</td>
       </tr>
       {% endif %}
       {% if m.player3_id %}
       <tr>
         <td>{{ m.player3.user.name }} place</td>
         <td><input type="number" name="p3_place" min="1" max="4" value="{{ m.result.p3_place if m.result else '' }}"></td>
-        <td><label><input type="checkbox" name="drop_p3"> Drop</label></td>
+        <td>{% if can_drop_any or current_user.id == m.player3.user_id %}<label><input type="checkbox" name="drop_p3"> Drop</label>{% endif %}</td>
       </tr>
       {% endif %}
       {% if m.player4_id %}
       <tr>
         <td>{{ m.player4.user.name }} place</td>
         <td><input type="number" name="p4_place" min="1" max="4" value="{{ m.result.p4_place if m.result else '' }}"></td>
-        <td><label><input type="checkbox" name="drop_p4"> Drop</label></td>
+        <td>{% if can_drop_any or current_user.id == m.player4.user_id %}<label><input type="checkbox" name="drop_p4"> Drop</label>{% endif %}</td>
       </tr>
       {% endif %}
       <tr>
@@ -67,10 +68,10 @@
           <td><input type="number" name="draws" min="0" value="{{ m.result.draws if m.result else 0 }}"></td>
         </tr>
         <tr>
-          <td colspan="2"><label><input type="checkbox" name="drop_p1"> Drop {{ m.player1.user.name }}</label></td>
+          <td colspan="2">{% if can_drop_any or current_user.id == m.player1.user_id %}<label><input type="checkbox" name="drop_p1"> Drop {{ m.player1.user.name }}</label>{% endif %}</td>
         </tr>
         <tr>
-          <td colspan="2"><label><input type="checkbox" name="drop_p2"> Drop {{ m.player2.user.name }}</label></td>
+          <td colspan="2">{% if can_drop_any or current_user.id == m.player2.user_id %}<label><input type="checkbox" name="drop_p2"> Drop {{ m.player2.user.name }}</label>{% endif %}</td>
         </tr>
         <tr>
           <td colspan="2"><button class="btn" type="submit">Submit Result</button></td>
@@ -84,7 +85,7 @@
     <input type="hidden" name="p1_wins" value="{{ m.result.player1_wins if m.result else 2 }}">
     <input type="hidden" name="p2_wins" value="{{ m.result.player2_wins if m.result else 0 }}">
     <input type="hidden" name="draws" value="{{ m.result.draws if m.result else 0 }}">
-    <p><label><input type="checkbox" name="drop_p1"> Drop {{ m.player1.user.name }}</label></p>
+    {% if can_drop_any or current_user.id == m.player1.user_id %}<p><label><input type="checkbox" name="drop_p1"> Drop {{ m.player1.user.name }}</label></p>{% endif %}
     <button class="btn" type="submit">Submit Result</button>
   </form>
   {% endif %}

--- a/app/templates/register.html
+++ b/app/templates/register.html
@@ -37,10 +37,6 @@
         {% endfor %}
       </select>
     </div>
-    <div class="form-field">
-      <label for="passcode">Tournament Passcode</label>
-      <input id="passcode" name="passcode" maxlength="4" value="{{ prefill_passcode }}">
-    </div>
     <div class="form-actions">
       <button class="btn" type="submit">Create Account</button>
     </div>

--- a/tests/test_leagues.py
+++ b/tests/test_leagues.py
@@ -1,0 +1,118 @@
+from datetime import date
+
+from app.models import (
+    League,
+    LeagueCube,
+    LeagueCubeVote,
+    LeaguePlayDate,
+    LeaguePlayDateCube,
+    LeaguePlayer,
+    Match,
+    Role,
+    Round,
+    SiteLog,
+    Tournament,
+    TournamentPlayer,
+    User,
+)
+
+
+def _user(session, email, name, role_name='user', is_admin=False):
+    role = session.query(Role).filter_by(name=role_name).one()
+    user = User(email=email, name=name, role=role, is_admin=is_admin)
+    user.set_password('secret')
+    session.add(user)
+    session.flush()
+    return user
+
+
+def test_admin_can_delete_league_and_audit_log(client, session):
+    admin = _user(session, 'league-delete-admin@example.com', 'League Admin', 'admin', True)
+    league = League(name='Delete Me', is_cube_league=True)
+    tournament = Tournament(name='League Event', format='Draft', league=league)
+    session.add_all([league, tournament])
+    session.commit()
+
+    assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+    response = client.post(f'/admin/leagues/{league.id}/delete')
+
+    assert response.status_code == 302
+    assert session.get(League, league.id) is None
+    session.refresh(tournament)
+    assert tournament.league_id is None
+    log = session.query(SiteLog).filter_by(action='league_delete').one()
+    assert log.result == 'success'
+    assert f'league_id={league.id}' in log.error
+
+
+def test_cube_league_votes_are_limited_to_three_per_play_date(client, session):
+    player = _user(session, 'cube-voter@example.com', 'Cube Voter')
+    league = League(name='Cube League', is_cube_league=True)
+    session.add(league)
+    session.flush()
+    session.add(LeaguePlayer(league_id=league.id, user_id=player.id))
+    first = LeagueCube(
+        league_id=league.id,
+        cube_cobra_url='https://cubecobra.com/cube/overview/alpha',
+        title='Alpha Cube',
+        image_url='https://cubecobra.com/content/alpha.png',
+    )
+    second = LeagueCube(
+        league_id=league.id,
+        cube_cobra_url='https://cubecobra.com/cube/overview/beta',
+        title='Beta Cube',
+    )
+    play_date = LeaguePlayDate(league_id=league.id, play_date=date(2026, 7, 1), is_active=True)
+    session.add_all([first, second, play_date])
+    session.flush()
+    session.add_all([
+        LeaguePlayDateCube(play_date_id=play_date.id, cube_id=first.id),
+        LeaguePlayDateCube(play_date_id=play_date.id, cube_id=second.id),
+    ])
+    session.commit()
+
+    assert client.post('/login', data={'email': player.email, 'password': 'secret'}).status_code == 302
+    response = client.post(
+        f'/leagues/{league.id}/cubes',
+        data={f'votes_{play_date.id}_{first.id}': '2', f'votes_{play_date.id}_{second.id}': '2'},
+    )
+    assert response.status_code == 302
+    assert session.query(LeagueCubeVote).count() == 0
+
+    response = client.post(
+        f'/leagues/{league.id}/cubes',
+        data={f'votes_{play_date.id}_{first.id}': '2', f'votes_{play_date.id}_{second.id}': '1'},
+    )
+    assert response.status_code == 302
+    votes = session.query(LeagueCubeVote).order_by(LeagueCubeVote.cube_id).all()
+    assert [vote.votes for vote in votes] == [2, 1]
+
+
+def test_player_cannot_drop_opponent_when_reporting_match(client, session):
+    player_one = _user(session, 'player-one@example.com', 'Player One')
+    player_two = _user(session, 'player-two@example.com', 'Player Two')
+    tournament = Tournament(name='Drop Test', format='Constructed')
+    session.add(tournament)
+    session.flush()
+    tp_one = TournamentPlayer(tournament_id=tournament.id, user_id=player_one.id)
+    tp_two = TournamentPlayer(tournament_id=tournament.id, user_id=player_two.id)
+    session.add_all([tp_one, tp_two])
+    session.flush()
+    round_one = Round(tournament_id=tournament.id, number=1)
+    session.add(round_one)
+    session.flush()
+    match = Match(round_id=round_one.id, player1_id=tp_one.id, player2_id=tp_two.id, table_number=1)
+    session.add(match)
+    session.commit()
+
+    assert client.post('/login', data={'email': player_one.email, 'password': 'secret'}).status_code == 302
+    response = client.post(
+        f'/match/{match.id}',
+        data={'p1_wins': '2', 'p2_wins': '0', 'draws': '0', 'drop_p2': 'on'},
+    )
+
+    assert response.status_code == 302
+    session.refresh(tp_one)
+    session.refresh(tp_two)
+    assert not tp_one.dropped
+    assert not tp_two.dropped

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -164,7 +164,7 @@ def test_mailgun_domain_validation_rejects_url_syntax(app):
             raise AssertionError(f'{domain} should have been rejected')
 
 
-def test_invite_only_registration_requires_tournament_passcode(client, session, app, monkeypatch):
+def test_invite_only_registration_allows_tournament_registration_without_passcode(client, session, app, monkeypatch):
     from app.models import Tournament
 
     app.config['ACCOUNT_CREATION_INVITE_ONLY'] = True
@@ -204,7 +204,6 @@ def test_invite_only_registration_requires_tournament_passcode(client, session, 
         'password': 'secret',
         'password_confirm': 'secret',
         'tournament_id': str(tournament.id),
-        'passcode': '1234',
     })
 
     assert response.status_code == 302


### PR DESCRIPTION
### Motivation
- Provide cube-league features so admins can schedule play dates, import Cube Cobra links with previews, and let members vote on which cubes to play. 
- Allow authorized admins to delete leagues and ensure that deletions are audited. 
- Simplify new account registration by not requiring a tournament passcode for sign-up flows. 
- Prevent players from dropping opponents in match reports unless they are a manager to avoid abuse.

### Description
- Added database models and fields: `LeagueCube`, `LeaguePlayDate`, `LeaguePlayDateCube`, `LeagueCubeVote`, and `League.is_cube_league`, and added the new permission key `tournaments.delete_leagues`. 
- Implemented Cube Cobra helpers `normalize_cube_cobra_url` and `fetch_cube_cobra_metadata` (HTML metadata parser) plus admin UI to add cubes and play dates, ballot configuration, and a member-facing voting page (`/leagues/<id>/cubes`) with up to 3 votes per play date, corresponding templates, and CSS. 
- Added admin flow to delete a league via `/admin/leagues/<id>/delete` which unlinks tournaments, deletes the league, and writes a `league_delete` `SiteLog` entry; updated role-permission sync to ensure default permissions are populated. 
- Relaxed registration logic so new account creation no longer requires validating a tournament passcode (removed the passcode UI requirement), and changed pending registration storage to omit storing the passcode; added server-side and UI changes. 
- Enforced drop permissions in match reporting so only managers or the player themself can request a drop, with UI checkbox restrictions and server-side checks and logging; added tests and templates updates for these behaviors. 
- Added `tests/test_leagues.py` covering league deletion auditing, cube vote limits, and opponent-drop prevention, and updated `tests/test_users.py` to reflect registration behavior.

### Testing
- Compiled modified modules with `python -m py_compile app/app.py app/models.py` and confirmed no syntax errors. 
- Ran targeted tests `pytest -q tests/test_leagues.py` which passed (3 tests). 
- Ran specific regression tests `pytest -q tests/test_db_upgrade.py::test_role_level_column_added` and `pytest -q tests/test_users.py::test_invite_only_registration_allows_tournament_registration_without_passcode` which both passed. 
- Ran the full test suite with `pytest -q` and all tests passed (`80 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2771d57ff483209c399f31fbd1f116)

## Summary by Sourcery

Introduce cube-focused league support with Cube Cobra integration, add audited league deletion, relax tournament passcode requirements during registration, and tighten match drop permissions.

New Features:
- Add cube league mode with Cube Cobra-backed cube library, play dates, and member cube voting.
- Add member-facing cube voting page per league with per-play-date vote limits and totals display.

Enhancements:
- Normalize Cube Cobra URLs and fetch HTML metadata to power cube previews in the admin and voting UIs.
- Extend league admin UI to configure cube leagues, manage Cube Cobra links, and define play-date ballots.
- Ensure default role permissions are populated on startup, including the new tournaments.delete_leagues permission.
- Allow admins with delete permissions to remove leagues, automatically unlinking tournaments and recording a league_delete audit log entry.
- Relax invite-only registration so tournaments can be selected without entering or storing a tournament passcode.
- Restrict match reporting so only managers or the player themself can drop a player, with corresponding UI constraints and logging.

Tests:
- Add league-focused tests covering audited league deletion, cube vote limits, and prevention of dropping opponents in match reports.
- Update user registration tests to cover invite-only signup without tournament passcodes.