### PR TITLE
Add player-facing league pages and compact cube cards; fix cube vote totals

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -3809,12 +3809,27 @@ def create_app():
     def league_vote_context(league):
         play_dates = db.session.query(LeaguePlayDate).filter_by(league_id=league.id).order_by(LeaguePlayDate.play_date).all()
         cubes = db.session.query(LeagueCube).filter_by(league_id=league.id).order_by(LeagueCube.title).all()
-        totals = {}
+        totals = {
+            (play_date_id, cube_id): total or 0
+            for play_date_id, cube_id, total in (
+                db.session.query(
+                    LeagueCubeVote.play_date_id,
+                    LeagueCubeVote.cube_id,
+                    db.func.coalesce(db.func.sum(LeagueCubeVote.votes), 0),
+                )
+                .filter(LeagueCubeVote.league_id == league.id)
+                .group_by(LeagueCubeVote.play_date_id, LeagueCubeVote.cube_id)
+                .all()
+            )
+        }
         user_votes = {}
-        for vote in db.session.query(LeagueCubeVote).filter_by(league_id=league.id).all():
-            totals[(vote.play_date_id, vote.cube_id)] = totals.get((vote.play_date_id, vote.cube_id), 0) + (vote.votes or 0)
-            if current_user.is_authenticated and vote.user_id == current_user.id:
-                user_votes[(vote.play_date_id, vote.cube_id)] = vote.votes or 0
+        if current_user.is_authenticated:
+            user_votes = {
+                (vote.play_date_id, vote.cube_id): vote.votes or 0
+                for vote in db.session.query(LeagueCubeVote)
+                .filter_by(league_id=league.id, user_id=current_user.id)
+                .all()
+            }
         available_by_date = {
             play_date.id: [link.cube_id for link in play_date.available_cubes]
             for play_date in play_dates
@@ -3966,6 +3981,40 @@ def create_app():
         log_site('league_delete', 'success', f'league_id={league_id}; name={name}; tournaments_unlinked={tournament_count}')
         flash(f'Deleted league {name}.', 'success')
         return redirect(url_for('leagues'))
+
+    @app.route('/my-leagues')
+    @login_required
+    def my_leagues():
+        memberships = (
+            db.session.query(LeaguePlayer)
+            .join(League)
+            .filter(LeaguePlayer.user_id == current_user.id)
+            .order_by(League.created_at.desc())
+            .all()
+        )
+        return render_template('my_leagues.html', memberships=memberships)
+
+    @app.route('/leagues/<int:league_id>')
+    @login_required
+    def view_league(league_id):
+        league = db.session.get(League, league_id)
+        if not league:
+            abort(404)
+        if not require_league_member_or_manager(league):
+            abort(403)
+        leaderboard, results, _available_tournaments, _users, league_tournament_ids = build_league_context(league)
+        play_dates, cubes, cube_vote_totals, _cube_user_votes, available_cube_ids = league_vote_context(league)
+        return render_template(
+            'league_view.html',
+            league=league,
+            leaderboard=leaderboard,
+            results=results,
+            league_tournament_ids=league_tournament_ids,
+            play_dates=play_dates,
+            cubes=cubes,
+            cube_vote_totals=cube_vote_totals,
+            available_cube_ids=available_cube_ids,
+        )
 
     @app.route('/leagues/<int:league_id>/cubes', methods=['GET', 'POST'])
     @login_required

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2333,3 +2333,51 @@ html[data-theme="dark"] .tournament-control-box .rounds-form {
 .cube-vote-form input[type="number"] {
   max-width: 5rem;
 }
+
+/* Compact cube previews: keep Cube Cobra artwork and titles from overflowing cards. */
+.cube-card-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.cube-preview-card {
+  display: grid;
+  grid-template-columns: minmax(92px, 120px) minmax(0, 1fr);
+  align-items: start;
+  gap: 0.8rem;
+  padding: 14px;
+}
+
+.cube-preview-image {
+  width: 120px;
+  height: 86px;
+  max-height: none;
+  object-fit: cover;
+  border-radius: 10px;
+}
+
+.cube-preview-body {
+  min-width: 0;
+}
+
+.cube-preview-body h3 {
+  font-size: 1rem;
+  line-height: 1.25;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.cube-preview-body .muted-text,
+.cube-preview-body label {
+  font-size: 0.88rem;
+}
+
+@media (max-width: 520px) {
+  .cube-preview-card {
+    grid-template-columns: 1fr;
+  }
+
+  .cube-preview-image {
+    width: 100%;
+    height: 120px;
+  }
+}

--- a/app/templates/admin/league_detail.html
+++ b/app/templates/admin/league_detail.html
@@ -42,7 +42,7 @@
     {% for cube in cubes %}
     <article class="league-card cube-preview-card">
       {% if cube.image_url %}<img class="cube-preview-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
-      <div>
+      <div class="cube-preview-body">
         <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
         <p class="muted-text">Cube Cobra</p>
       </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -26,6 +26,7 @@
           {% if current_user.is_authenticated %}<li class="nav-item"><a class="nav-link" href="{{ url_for('index') }}">All Tournaments</a></li>{% endif %}
           {% if current_user.is_authenticated %}
           <li class="nav-item"><a class="nav-link" href="{{ url_for('my_tournaments') }}">My Tournaments</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('my_leagues') }}">My Leagues</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('messages_home') }}">Messages <span id="nav-messages-count" class="nav-badge{% if not nav_unread_messages %} hidden{% endif %}">{{ nav_unread_messages }}</span></a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('submit_report') }}">Report Issue</a></li>
           {% if current_user.has_permission('tournaments.manage') %}

--- a/app/templates/league_cubes.html
+++ b/app/templates/league_cubes.html
@@ -19,7 +19,7 @@
         {% for cube in cubes if cube.id in available %}
         <article class="league-card cube-preview-card">
           {% if cube.image_url %}<img class="cube-preview-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
-          <div>
+          <div class="cube-preview-body">
             <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
             <p class="muted-text">Total votes: {{ cube_vote_totals.get((play_date.id, cube.id), 0) }}</p>
             <label>Your votes

--- a/app/templates/league_view.html
+++ b/app/templates/league_view.html
@@ -1,0 +1,83 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header modern-hero">
+  <div class="page-header__title">
+    <span class="eyebrow">League</span>
+    <h2>{{ league.name }}</h2>
+    <p class="page-description">
+      {% if league.start_date or league.end_date %}
+      {{ league.start_date or 'Open' }} → {{ league.end_date or 'Open' }} ·
+      {% endif %}
+      Best 75% attendance scoring: match win 3, draw 1, loss 0.
+    </p>
+  </div>
+  <div class="page-header__actions">
+    {% if league.is_cube_league %}<a class="btn" href="{{ url_for('league_cube_voting', league_id=league.id) }}">Cube Voting</a>{% endif %}
+    <a class="btn ghost" href="{{ url_for('my_leagues') }}">My Leagues</a>
+  </div>
+</section>
+
+<section class="stats-grid">
+  <div class="stat-card"><span>Players</span><strong>{{ leaderboard|length }}</strong></div>
+  <div class="stat-card"><span>Tournaments</span><strong>{{ league_tournament_ids|length }}</strong></div>
+  <div class="stat-card"><span>Imported results</span><strong>{{ results|length }}</strong></div>
+</section>
+
+<section class="panel-card">
+  <div class="section-heading">
+    <div>
+      <h3>Leaderboard</h3>
+      <p>Only each player's highest-scoring 75% of tournament appearances are counted.</p>
+    </div>
+  </div>
+  {% if leaderboard %}
+  <table class="table league-table">
+    <thead>
+      <tr><th>Rank</th><th>Player</th><th>League points</th><th>Counted</th><th>Played</th><th>Record counted</th><th>Raw points</th></tr>
+    </thead>
+    <tbody>
+      {% for row in leaderboard %}
+      <tr>
+        <td>{{ loop.index }}</td>
+        <td>{{ row.player.name }}</td>
+        <td><strong>{{ row.league_points }}</strong></td>
+        <td>{{ row.counted_count }}</td>
+        <td>{{ row.played }}</td>
+        <td>{{ row.wins }}-{{ row.draws }}-{{ row.losses }}</td>
+        <td>{{ row.raw_points }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-state">No standings have been imported for this league yet.</p>
+  {% endif %}
+</section>
+
+{% if league.is_cube_league %}
+<section class="panel-card">
+  <div class="section-heading"><div><h3>Cube Voting Results</h3><p>Vote totals are shown by play date. Members can cast or edit their votes from Cube Voting.</p></div></div>
+  {% if play_dates %}
+    {% for play_date in play_dates %}
+    {% set available = available_cube_ids.get(play_date.id, []) %}
+    <div class="league-play-date-form">
+      <h4>{{ play_date.play_date }}{% if not play_date.is_active %} <span class="status-pill warning">closed</span>{% endif %}</h4>
+      {% if available %}
+      <div class="league-card-grid cube-card-grid compact-cube-grid">
+        {% for cube in cubes if cube.id in available %}
+        <article class="league-card cube-preview-card">
+          {% if cube.image_url %}<img class="cube-preview-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+          <div class="cube-preview-body">
+            <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
+            <p class="muted-text">Total votes: {{ cube_vote_totals.get((play_date.id, cube.id), 0) }}</p>
+          </div>
+        </article>
+        {% endfor %}
+      </div>
+      {% else %}<p class="empty-state compact-empty">No cubes are available for this date yet.</p>{% endif %}
+    </div>
+    {% endfor %}
+  {% else %}<p class="empty-state">No cube play dates have been configured yet.</p>{% endif %}
+</section>
+{% endif %}
+{% endblock %}

--- a/app/templates/my_leagues.html
+++ b/app/templates/my_leagues.html
@@ -1,0 +1,41 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header modern-hero">
+  <div class="page-header__title">
+    <span class="eyebrow">Player Dashboard</span>
+    <h2>My Leagues</h2>
+    <p class="page-description">Leagues where you are listed as a member. League management remains restricted to tournament staff.</p>
+  </div>
+</section>
+
+{% if memberships %}
+<div class="league-card-grid">
+  {% for membership in memberships %}
+  {% set league = membership.league %}
+  <article class="league-card">
+    <div>
+      <h3><a href="{{ url_for('view_league', league_id=league.id) }}">{{ league.name }}</a></h3>
+      <p class="muted-text">
+        {% if league.start_date or league.end_date %}
+          {{ league.start_date or 'Open' }} → {{ league.end_date or 'Open' }}
+        {% else %}
+          Open schedule
+        {% endif %}
+        {% if league.is_cube_league %} · Cube league{% endif %}
+      </p>
+      <p class="muted-text">Member since {{ membership.created_at.date() if membership.created_at else 'unknown' }}</p>
+    </div>
+    <div class="card-actions compact-actions">
+      <a class="btn ghost" href="{{ url_for('view_league', league_id=league.id) }}">View League</a>
+      {% if league.is_cube_league %}<a class="btn" href="{{ url_for('league_cube_voting', league_id=league.id) }}">Cube Voting</a>{% endif %}
+    </div>
+  </article>
+  {% endfor %}
+</div>
+{% else %}
+<div class="card">
+  <p class="page-description">You are not a member of any leagues yet.</p>
+  <a class="btn" href="{{ url_for('index') }}">Browse Tournaments</a>
+</div>
+{% endif %}
+{% endblock %}

--- a/tests/test_leagues.py
+++ b/tests/test_leagues.py
@@ -116,3 +116,78 @@ def test_player_cannot_drop_opponent_when_reporting_match(client, session):
     session.refresh(tp_two)
     assert not tp_one.dropped
     assert not tp_two.dropped
+
+
+def test_player_can_view_member_leagues_without_manage_controls(client, session):
+    member = _user(session, 'league-member@example.com', 'League Member')
+    other = _user(session, 'league-other@example.com', 'League Other')
+    league = League(name='Members Only League', is_cube_league=True)
+    hidden = League(name='Hidden League')
+    session.add_all([league, hidden])
+    session.flush()
+    session.add(LeaguePlayer(league_id=league.id, user_id=member.id))
+    session.commit()
+
+    assert client.post('/login', data={'email': member.email, 'password': 'secret'}).status_code == 302
+    response = client.get('/my-leagues')
+    assert response.status_code == 200
+    assert b'Members Only League' in response.data
+    assert b'Hidden League' not in response.data
+
+    response = client.get(f'/leagues/{league.id}')
+    assert response.status_code == 200
+    assert b'League Settings' not in response.data
+    assert b'Assign Players' not in response.data
+    assert b'Import Tournament' not in response.data
+    assert b'Cube Voting' in response.data
+
+    client.get('/logout')
+    assert client.post('/login', data={'email': other.email, 'password': 'secret'}).status_code == 302
+    assert client.get(f'/leagues/{league.id}').status_code == 403
+
+
+def test_cube_league_vote_totals_update_when_votes_change(client, session):
+    player = _user(session, 'cube-updater@example.com', 'Cube Updater')
+    league = League(name='Update Vote League', is_cube_league=True)
+    session.add(league)
+    session.flush()
+    session.add(LeaguePlayer(league_id=league.id, user_id=player.id))
+    first = LeagueCube(
+        league_id=league.id,
+        cube_cobra_url='https://cubecobra.com/cube/overview/first',
+        title='First Cube',
+    )
+    second = LeagueCube(
+        league_id=league.id,
+        cube_cobra_url='https://cubecobra.com/cube/overview/second',
+        title='Second Cube',
+    )
+    play_date = LeaguePlayDate(league_id=league.id, play_date=date(2026, 8, 1), is_active=True)
+    session.add_all([first, second, play_date])
+    session.flush()
+    session.add_all([
+        LeaguePlayDateCube(play_date_id=play_date.id, cube_id=first.id),
+        LeaguePlayDateCube(play_date_id=play_date.id, cube_id=second.id),
+    ])
+    session.commit()
+
+    assert client.post('/login', data={'email': player.email, 'password': 'secret'}).status_code == 302
+    response = client.post(
+        f'/leagues/{league.id}/cubes',
+        data={f'votes_{play_date.id}_{first.id}': '2', f'votes_{play_date.id}_{second.id}': '1'},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b'Total votes: 2' in response.data
+    assert b'Total votes: 1' in response.data
+
+    response = client.post(
+        f'/leagues/{league.id}/cubes',
+        data={f'votes_{play_date.id}_{first.id}': '0', f'votes_{play_date.id}_{second.id}': '3'},
+        follow_redirects=True,
+    )
+    assert response.status_code == 200
+    assert b'Total votes: 0' in response.data
+    assert b'Total votes: 3' in response.data
+    votes = session.query(LeagueCubeVote).order_by(LeagueCubeVote.cube_id).all()
+    assert [(vote.cube_id, vote.votes) for vote in votes] == [(second.id, 3)]


### PR DESCRIPTION
### Motivation
- Allow players to see leagues they are a member of from the player menu while preventing them from changing league management settings. 
- Make cube preview cards more compact so artwork and long titles do not overflow. 
- Fix cube vote totals so counted votes update immediately after a player changes their votes.

### Description
- Added player navigation and read-only league views by introducing `@app.route('/my-leagues')` (`my_leagues`) and `@app.route('/leagues/<int:league_id>')` (`view_league`) that only render for members or managers and do not expose admin management controls. New templates: `app/templates/my_leagues.html` and `app/templates/league_view.html`. `base.html` now includes a `My Leagues` link for authenticated users. 
- Kept league management and rights modifications on admin routes only; member-facing pages render leaderboard, stats, and cube voting links but no forms to change league settings or players. 
- Fixed vote aggregation by changing `league_vote_context` to compute `totals` with a grouped aggregate query (using `db.func.sum` and `db.func.coalesce`) and to load per-user votes with a scoped query for the current user. This ensures displayed `Total votes:` reflects stored votes after updates. 
- Compact cube preview UI: updated templates to wrap cube text in a `.cube-preview-body` element and added compact CSS in `app/static/style.css` (`.cube-preview-card`, `.cube-preview-image`, `.cube-preview-body`) so images and titles are smaller and long titles wrap properly; applied to `league_cubes.html` and `admin/league_detail.html`. 
- Tests: added regression tests to `tests/test_leagues.py` covering member visibility/no-manage-controls (`test_player_can_view_member_leagues_without_manage_controls`) and vote-total updates after changing votes (`test_cube_league_vote_totals_update_when_votes_change`).

### Testing
- Ran `pytest -q tests/test_leagues.py`, which passed. 
- Ran full suite `pytest -q`, which completed with all tests passing (`82 passed`). 
- Confirmed the new pages render and that cube voting updates totals through integration-style tests; no browser/screenshot tools were available in the environment for visual captures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2778091cb88320920c901c9e1f86ac)

## Summary by Sourcery

Add player-facing league pages with read-only views, improve cube preview layout, and ensure cube vote totals reflect updated votes immediately.

New Features:
- Expose a My Leagues navigation entry and page listing leagues where the current user is a member.
- Add a player-facing league detail page showing leaderboard standings and cube voting results without management controls.

Bug Fixes:
- Correct cube vote aggregation so total vote counts are derived from grouped sums and update immediately after vote changes.

Enhancements:
- Make cube preview cards more compact and responsive so artwork and long titles no longer overflow in admin and league cube views.

Tests:
- Add league tests covering member access to leagues without management controls and regression coverage for updating cube vote totals when votes change.