### PR TITLE
Condense league cube voting result cards

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2339,6 +2339,53 @@ html[data-theme="dark"] .tournament-control-box .rounds-form {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.compact-cube-grid {
+  grid-template-columns: repeat(auto-fill, minmax(132px, 1fr));
+  gap: 8px;
+}
+
+.compact-cube-grid .cube-result-card {
+  display: grid;
+  grid-template-columns: 44px minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  min-height: 60px;
+  padding: 8px;
+}
+
+.compact-cube-grid .cube-result-image {
+  width: 44px;
+  height: 44px;
+  border-radius: 8px;
+}
+
+.compact-cube-grid .cube-result-card--text-only {
+  grid-template-columns: minmax(0, 1fr);
+}
+
+.compact-cube-grid .cube-result-body {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.compact-cube-grid .cube-result-body h3 {
+  display: -webkit-box;
+  margin: 0;
+  overflow: hidden;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  font-size: 0.82rem;
+  line-height: 1.15;
+}
+
+.compact-cube-grid .cube-result-votes {
+  color: var(--muted);
+  font-size: 0.72rem;
+  line-height: 1;
+}
+
 .cube-preview-card {
   display: grid;
   grid-template-columns: minmax(92px, 120px) minmax(0, 1fr);

--- a/app/templates/league_view.html
+++ b/app/templates/league_view.html
@@ -65,11 +65,11 @@
       {% if available %}
       <div class="league-card-grid cube-card-grid compact-cube-grid">
         {% for cube in cubes if cube.id in available %}
-        <article class="league-card cube-preview-card">
-          {% if cube.image_url %}<img class="cube-preview-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
-          <div class="cube-preview-body">
+        <article class="league-card cube-preview-card cube-result-card{% if not cube.image_url %} cube-result-card--text-only{% endif %}">
+          {% if cube.image_url %}<img class="cube-preview-image cube-result-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+          <div class="cube-preview-body cube-result-body">
             <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
-            <p class="muted-text">Total votes: {{ cube_vote_totals.get((play_date.id, cube.id), 0) }}</p>
+            <span class="cube-result-votes">{{ cube_vote_totals.get((play_date.id, cube.id), 0) }} votes</span>
           </div>
         </article>
         {% endfor %}


### PR DESCRIPTION
### Motivation
- Make the cube voting results on the player-facing league overview much more compact so many cubes fit on a row while keeping each cube's artwork and title legible. 
- Avoid wasting space for cubes that lack preview artwork by using a text-only compact layout.

### Description
- Updated `app/templates/league_view.html` to render a compact result card for each cube (`cube-result-card`) and to use a text-only modifier when `cube.image_url` is missing. 
- Added compact layout CSS in `app/static/style.css` including `.compact-cube-grid`, `.cube-result-card`, `.cube-result-image`, `.cube-result-body`, and `.cube-result-votes` to produce 44px thumbnails, two-line clamped titles, and a small inline vote label. 
- Replaced the larger vote copy with a concise inline label and ensured the compact grid uses `repeat(auto-fill, minmax(132px, 1fr))` so cards wrap tightly.

### Testing
- Ran `pytest -q` against the test suite. 
- All tests passed: `82 passed` (with warnings) and no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a277fd04db48320aec8418684bee57d)

## Summary by Sourcery

Condense the league overview cube voting results into a more compact card layout that fits more cubes per row while remaining readable.

Enhancements:
- Introduce a compact cube result card layout with tighter grid spacing and smaller thumbnails for league cube voting results.
- Adjust vote display to a concise inline label and clamp cube titles to two lines for improved readability in the compact grid.
- Provide a text-only variant of the cube result card for cubes without preview artwork to avoid wasted space.