### PR TITLE
Harden nginx TLS configuration, add security headers, and extend installer for TLS aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ After editing `config.yaml`, restart the app so the new settings are loaded:
 - Linux/macOS: `./restart-server.sh`
 - Windows PowerShell: `./restart-server.ps1`
 
-On Linux, `start-server.sh` installs the HTTP Nginx site automatically when `tls_domain` is blank so other computers on the LAN can browse to `http://<server-lan-ip>/` without connecting directly to the Waitress port. The installer copies the config to `/etc/nginx/sites-available` and enables it via `/etc/nginx/sites-enabled` on Debian/Ubuntu-style systems. On systems that use `/etc/nginx/conf.d`, it installs `walter.conf` there instead. It also disables the packaged default Nginx site so requests to the server IP show Walter instead of the "Welcome to nginx!" page. Use `./scripts/install_nginx_config.sh --help` to see options such as `--dry-run`, `--config`, `--site-name`, `--no-reload`, and `--keep-default-site`.
+On Linux, `start-server.sh` installs the HTTP Nginx site automatically when `tls_domain` is blank so other computers on the LAN can browse to `http://<server-lan-ip>/` without connecting directly to the Waitress port. The installer copies the config to `/etc/nginx/sites-available` and enables it via `/etc/nginx/sites-enabled` on Debian/Ubuntu-style systems. On systems that use `/etc/nginx/conf.d`, it installs `walter.conf` there instead. It also disables the packaged default Nginx site so requests to the server IP show Walter instead of the "Welcome to nginx!" page. The installer writes `nginx/walter-hardening.conf` to Nginx's `conf.d` directory to disable version tokens and writes the shared security-header snippet to `/etc/nginx/snippets/security-headers.conf`. Use `./scripts/install_nginx_config.sh --help` to see options such as `--dry-run`, `--config`, `--site-name`, `--no-reload`, and `--keep-default-site`.
 
 If LAN clients still cannot reach the app, browse to the server's LAN address on port 80 (for example, `http://192.168.1.25/`) and make sure host firewall rules allow inbound HTTP. If you see the default Nginx welcome page after installing, re-run `./scripts/install_nginx_config.sh` and confirm that Nginx reloaded successfully. If you see a `502 Bad Gateway` page instead, make sure the Waitress host and port in `config.yaml` match the upstream address in `nginx/walter.conf`; the rendered config expects Waitress at the `flask_ip` and `flask_port` values from `config.yaml`.
 
@@ -38,6 +38,8 @@ Example `config.yaml` options:
 
 ```yaml
 tls_domain: tournaments.example.com
+# Optional: also serve aliases covered by the same certificate.
+# tls_additional_domains: www.tournaments.example.com
 letsencrypt_email: admin@example.com
 # Optional overrides:
 # letsencrypt_renewal_days: 30
@@ -60,7 +62,7 @@ You can still manage the Nginx config manually:
 3) Install the TLS config rendered for your production domain:
    - `./scripts/install_nginx_config.sh --tls-domain tournaments.example.com`
 
-The TLS template lives at `nginx/walter-tls.conf`. It serves HTTPS on port 443, redirects normal HTTP traffic to HTTPS, leaves `/.well-known/acme-challenge/` available on port 80 for Let's Encrypt renewals, enables TLS 1.2 and TLS 1.3, and restricts both TLS versions to FIPS-suitable AES-GCM cipher suites. TLS 1.2 is limited to `ECDHE-ECDSA-AES256-GCM-SHA384`, `ECDHE-RSA-AES256-GCM-SHA384`, `ECDHE-ECDSA-AES128-GCM-SHA256`, and `ECDHE-RSA-AES128-GCM-SHA256`; TLS 1.3 is limited to `TLS_AES_256_GCM_SHA384` and `TLS_AES_128_GCM_SHA256`. If your certificate lives somewhere other than `/etc/letsencrypt/live/<domain>`, pass `--cert-dir /path/to/live/certdir`; if your ACME challenge webroot differs, pass `--acme-webroot /path/to/webroot`.
+The TLS template lives at `nginx/walter-tls.conf`. It serves HTTPS on port 443 only for configured hostnames, redirects HTTP traffic to the canonical `tls_domain`, rejects TLS handshakes for unknown/default hostnames, leaves `/.well-known/acme-challenge/` available on port 80 for Let's Encrypt renewals, includes security headers from `nginx/snippets/security-headers.conf`, enables TLS 1.2 and TLS 1.3, and restricts both TLS versions to FIPS-suitable AES-GCM cipher suites. TLS 1.2 is limited to `ECDHE-ECDSA-AES256-GCM-SHA384`, `ECDHE-RSA-AES256-GCM-SHA384`, `ECDHE-ECDSA-AES128-GCM-SHA256`, and `ECDHE-RSA-AES128-GCM-SHA256`; TLS 1.3 is limited to `TLS_AES_256_GCM_SHA384` and `TLS_AES_128_GCM_SHA256`. If your certificate lives somewhere other than `/etc/letsencrypt/live/<domain>`, pass `--cert-dir /path/to/live/certdir`; if your ACME challenge webroot differs, pass `--acme-webroot /path/to/webroot`. To include aliases such as `www.tournaments.example.com`, set `tls_additional_domains` in `config.yaml` or pass `--tls-additional-domains www.tournaments.example.com` to the installer; the certificate request and Nginx `server_name` list must match.
 
 ## Account verification and invites
 

--- a/config.yaml
+++ b/config.yaml
@@ -10,6 +10,8 @@ last_table_number: 200
 # Optional production HTTPS settings. When tls_domain is set, start-server.sh
 # checks for a Let's Encrypt certificate and requests or renews it as needed.
 # tls_domain: tournaments.example.com
+# Optional comma-separated certificate/server-name aliases, for example:
+# tls_additional_domains: www.tournaments.example.com
 # letsencrypt_email: admin@example.com
 # letsencrypt_renewal_days: 30
 # letsencrypt_dry_run: false

--- a/nginx/snippets/security-headers.conf
+++ b/nginx/snippets/security-headers.conf
@@ -1,0 +1,9 @@
+# Browser security headers for the Walter HTTPS virtual host.
+# Installed by scripts/install_nginx_config.sh as
+# /etc/nginx/snippets/security-headers.conf.
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests" always;

--- a/nginx/walter-hardening.conf
+++ b/nginx/walter-hardening.conf
@@ -1,0 +1,10 @@
+# Walter global Nginx hardening directives.
+# This file is installed into /etc/nginx/conf.d, which is included from the
+# http {} block by the packaged Nginx configuration on Debian/Ubuntu and most
+# other Linux distributions.
+server_tokens off;
+
+# To remove the Server header entirely on builds with the headers-more module,
+# install the module and uncomment the next directive:
+#   apt install -y libnginx-mod-http-headers-more-filter
+# more_clear_headers Server;

--- a/nginx/walter-tls.conf
+++ b/nginx/walter-tls.conf
@@ -1,8 +1,8 @@
 # Nginx reverse proxy for the Walter Flask/Waitress application with HTTPS.
 #
 # This file is a template used by scripts/install_nginx_config.sh --tls-domain.
-# The installer replaces __WALTER_DOMAIN__, __WALTER_CERT_DIR__,
-# __WALTER_ACME_WEBROOT__, __WALTER_FLASK_IP__, and
+# The installer replaces __WALTER_DOMAIN__, __WALTER_SERVER_NAMES__,
+# __WALTER_CERT_DIR__, __WALTER_ACME_WEBROOT__, __WALTER_FLASK_IP__, and
 # __WALTER_FLASK_PORT__. Do not commit certificate material to this repo.
 
 upstream walter_app {
@@ -11,10 +11,33 @@ upstream walter_app {
 }
 
 server {
+    # Unknown HTTP hostnames should never reach the app. Redirect them to the
+    # canonical production hostname instead of reflecting the request Host.
+    listen 80 default_server;
+    listen [::]:80 default_server;
+
+    server_name _;
+
+    location / {
+        return 301 https://__WALTER_DOMAIN__$request_uri;
+    }
+}
+
+server {
+    # Reject TLS handshakes for unknown SNI hostnames so the app and default
+    # certificate are not exposed through the VPS reverse hostname or IP.
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+
+    server_name _;
+    ssl_reject_handshake on;
+}
+
+server {
     listen 80;
     listen [::]:80;
 
-    server_name __WALTER_DOMAIN__;
+    server_name __WALTER_SERVER_NAMES__;
 
     # Certbot webroot HTTP-01 challenge directory. Keep this available on port
     # 80 so Let's Encrypt renewals can complete before HTTP traffic is
@@ -25,7 +48,7 @@ server {
     }
 
     location / {
-        return 301 https://$host$request_uri;
+        return 301 https://__WALTER_DOMAIN__$request_uri;
     }
 }
 
@@ -33,7 +56,7 @@ server {
     listen 443 ssl http2;
     listen [::]:443 ssl http2;
 
-    server_name __WALTER_DOMAIN__;
+    server_name __WALTER_SERVER_NAMES__;
 
     client_max_body_size 25m;
 
@@ -59,8 +82,7 @@ server {
     ssl_session_cache shared:WalterTLS:10m;
     ssl_session_tickets off;
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Content-Type-Options nosniff always;
+    include snippets/security-headers.conf;
 
     location / {
         proxy_pass http://walter_app;
@@ -72,6 +94,10 @@ server {
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-Host $host;
         proxy_set_header X-Forwarded-Port 443;
+
+        limit_except GET POST {
+            deny all;
+        }
 
         proxy_connect_timeout 60s;
         proxy_send_timeout 60s;

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -6,6 +6,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEFAULT_CONFIG="$REPO_DIR/nginx/walter.conf"
 DEFAULT_TLS_CONFIG="$REPO_DIR/nginx/walter-tls.conf"
+DEFAULT_SECURITY_HEADERS="$REPO_DIR/nginx/snippets/security-headers.conf"
+DEFAULT_HARDENING_CONFIG="$REPO_DIR/nginx/walter-hardening.conf"
 DEFAULT_APP_CONFIG="$REPO_DIR/config.yaml"
 
 CONFIG_FILE="$DEFAULT_CONFIG"
@@ -14,6 +16,8 @@ DRY_RUN=0
 RELOAD_NGINX=1
 DISABLE_DEFAULT_SITE=1
 TLS_DOMAIN=""
+TLS_ADDITIONAL_DOMAINS=""
+SERVER_NAMES=""
 CERT_DIR=""
 ACME_WEBROOT="/var/www/letsencrypt"
 APP_CONFIG="$DEFAULT_APP_CONFIG"
@@ -33,6 +37,8 @@ Copies the Walter Nginx config into the correct Linux Nginx location:
 Options:
   -c, --config PATH     Source Nginx config to install (default: $DEFAULT_CONFIG)
       --tls-domain NAME  Render and install the TLS 1.2/1.3 Let's Encrypt config for NAME
+      --tls-additional-domains NAMES
+                        Comma-separated extra names on the certificate, such as www.example.com
       --cert-dir PATH    Let's Encrypt live cert directory (default: /etc/letsencrypt/live/NAME)
       --acme-webroot PATH
                         Webroot for HTTP-01 challenges (default: $ACME_WEBROOT)
@@ -117,6 +123,15 @@ while [[ $# -gt 0 ]]; do
       TLS_DOMAIN="$2"
       shift 2
       ;;
+    --tls-additional-domains)
+      if [[ $# -lt 2 || -z "${2:-}" ]]; then
+        log "Missing value for $1" >&2
+        usage >&2
+        exit 1
+      fi
+      TLS_ADDITIONAL_DOMAINS="$2"
+      shift 2
+      ;;
     --cert-dir)
       if [[ $# -lt 2 || -z "${2:-}" ]]; then
         log "Missing value for $1" >&2
@@ -169,15 +184,45 @@ while [[ $# -gt 0 ]]; do
 done
 
 
+trim_whitespace() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+validate_dns_name() {
+  local label="$1"
+  local name="$2"
+
+  if [[ -z "$name" || "$name" == *"/"* || "$name" == *[[:space:]]* ]]; then
+    log "$label must be a DNS name, not a path or value with spaces: $name" >&2
+    exit 1
+  fi
+}
+
+build_server_names() {
+  local raw extra
+  validate_dns_name "TLS domain" "$TLS_DOMAIN"
+  SERVER_NAMES="$TLS_DOMAIN"
+
+  if [[ -n "$TLS_ADDITIONAL_DOMAINS" ]]; then
+    IFS=',' read -ra raw <<< "$TLS_ADDITIONAL_DOMAINS"
+    for extra in "${raw[@]}"; do
+      extra="$(trim_whitespace "$extra")"
+      [[ -z "$extra" ]] && continue
+      validate_dns_name "Additional TLS domain" "$extra"
+      SERVER_NAMES+=" $extra"
+    done
+  fi
+}
+
 if [[ -n "$TLS_DOMAIN" ]]; then
   if [[ "$CONFIG_EXPLICIT" -eq 0 ]]; then
     CONFIG_FILE="$DEFAULT_TLS_CONFIG"
   fi
 
-  if [[ "$TLS_DOMAIN" == *"/"* || "$TLS_DOMAIN" == *" "* ]]; then
-    log "TLS domain must be a DNS name, not a path or value with spaces: $TLS_DOMAIN" >&2
-    exit 1
-  fi
+  build_server_names
 
   CERT_DIR="${CERT_DIR:-/etc/letsencrypt/live/$TLS_DOMAIN}"
 
@@ -258,8 +303,9 @@ escape_sed_replacement() {
 }
 
 render_config() {
-  local escaped_domain escaped_cert_dir escaped_acme_webroot escaped_flask_ip escaped_flask_port
+  local escaped_domain escaped_server_names escaped_cert_dir escaped_acme_webroot escaped_flask_ip escaped_flask_port
   escaped_domain="$(escape_sed_replacement "$TLS_DOMAIN")"
+  escaped_server_names="$(escape_sed_replacement "${SERVER_NAMES:-$TLS_DOMAIN}")"
   escaped_cert_dir="$(escape_sed_replacement "$CERT_DIR")"
   escaped_acme_webroot="$(escape_sed_replacement "$ACME_WEBROOT")"
   escaped_flask_ip="$(escape_sed_replacement "$FLASK_IP")"
@@ -268,6 +314,7 @@ render_config() {
   GENERATED_CONFIG="$(mktemp)"
   sed \
     -e "s/__WALTER_DOMAIN__/$escaped_domain/g" \
+    -e "s/__WALTER_SERVER_NAMES__/$escaped_server_names/g" \
     -e "s/__WALTER_CERT_DIR__/$escaped_cert_dir/g" \
     -e "s/__WALTER_ACME_WEBROOT__/$escaped_acme_webroot/g" \
     -e "s/__WALTER_FLASK_IP__/$escaped_flask_ip/g" \
@@ -282,6 +329,27 @@ cleanup_generated_config() {
   fi
 }
 trap cleanup_generated_config EXIT
+
+
+install_nginx_support_files() {
+  if [[ ! -f "$DEFAULT_HARDENING_CONFIG" ]]; then
+    log "Nginx hardening config not found: $DEFAULT_HARDENING_CONFIG" >&2
+    exit 1
+  fi
+
+  if [[ ! -f "$DEFAULT_SECURITY_HEADERS" ]]; then
+    log "Nginx security headers snippet not found: $DEFAULT_SECURITY_HEADERS" >&2
+    exit 1
+  fi
+
+  log "Installing Walter Nginx hardening directives to /etc/nginx/conf.d/walter-hardening.conf"
+  run_root mkdir -p /etc/nginx/conf.d
+  run_root install -m 0644 "$DEFAULT_HARDENING_CONFIG" /etc/nginx/conf.d/walter-hardening.conf
+
+  log "Installing Walter security headers snippet to /etc/nginx/snippets/security-headers.conf"
+  run_root mkdir -p /etc/nginx/snippets
+  run_root install -m 0644 "$DEFAULT_SECURITY_HEADERS" /etc/nginx/snippets/security-headers.conf
+}
 
 disable_packaged_default_site() {
   if [[ "$DISABLE_DEFAULT_SITE" -ne 1 ]]; then
@@ -307,6 +375,7 @@ disable_packaged_default_site() {
 
 load_app_config
 render_config
+install_nginx_support_files
 
 if [[ -n "$TLS_DOMAIN" ]]; then
   log "Ensuring ACME challenge webroot exists at $ACME_WEBROOT"

--- a/start-server.sh
+++ b/start-server.sh
@@ -217,6 +217,48 @@ install_http_nginx_config() {
   ensure_nginx_running
 }
 
+
+trim_whitespace() {
+  local value="$1"
+  value="${value#"${value%%[![:space:]]*}"}"
+  value="${value%"${value##*[![:space:]]}"}"
+  printf '%s' "$value"
+}
+
+validate_tls_additional_domains() {
+  local raw extra
+
+  if [[ -z "${TLS_ADDITIONAL_DOMAINS:-}" ]]; then
+    return 0
+  fi
+
+  IFS=',' read -ra raw <<< "$TLS_ADDITIONAL_DOMAINS"
+  for extra in "${raw[@]}"; do
+    extra="$(trim_whitespace "$extra")"
+    [[ -z "$extra" ]] && continue
+    if [[ "$extra" == *"/"* || "$extra" == *[[:space:]]* ]]; then
+      echo "tls_additional_domains entries must be DNS names, not paths or values with spaces: $extra" >&2
+      exit 1
+    fi
+  done
+}
+
+append_tls_additional_domain_args() {
+  local -n target_args=$1
+  local raw extra
+
+  if [[ -z "${TLS_ADDITIONAL_DOMAINS:-}" ]]; then
+    return 0
+  fi
+
+  IFS=',' read -ra raw <<< "$TLS_ADDITIONAL_DOMAINS"
+  for extra in "${raw[@]}"; do
+    extra="$(trim_whitespace "$extra")"
+    [[ -z "$extra" ]] && continue
+    target_args+=(-d "$extra")
+  done
+}
+
 ensure_letsencrypt_certificate() {
   if [[ "${OSTYPE:-}" != linux* ]]; then
     return 0
@@ -233,6 +275,7 @@ ensure_letsencrypt_certificate() {
   fi
 
   validate_letsencrypt_settings
+  validate_tls_additional_domains
   install_certbot
 
   local cert_dir="${TLS_CERT_DIR:-/etc/letsencrypt/live/$TLS_DOMAIN}"
@@ -241,6 +284,7 @@ ensure_letsencrypt_certificate() {
   local dry_run=0
   local fullchain="$cert_dir/fullchain.pem"
   local certbot_args=(certonly --webroot -w "$acme_webroot" -d "$TLS_DOMAIN" --non-interactive --agree-tos --keep-until-expiring)
+  append_tls_additional_domain_args certbot_args
 
   if is_truthy "${LETSENCRYPT_DRY_RUN:-false}"; then
     dry_run=1
@@ -284,7 +328,11 @@ ensure_letsencrypt_certificate() {
   fi
 
   echo "Installing TLS Nginx config for $TLS_DOMAIN..."
-  "$NGINX_INSTALL_SCRIPT" --tls-domain "$TLS_DOMAIN" --cert-dir "$cert_dir" --acme-webroot "$acme_webroot" --app-config "$CONFIG_FILE"
+  local nginx_tls_args=(--tls-domain "$TLS_DOMAIN" --cert-dir "$cert_dir" --acme-webroot "$acme_webroot" --app-config "$CONFIG_FILE")
+  if [[ -n "${TLS_ADDITIONAL_DOMAINS:-}" ]]; then
+    nginx_tls_args+=(--tls-additional-domains "$TLS_ADDITIONAL_DOMAINS")
+  fi
+  "$NGINX_INSTALL_SCRIPT" "${nginx_tls_args[@]}"
   ensure_nginx_running
 }
 
@@ -395,6 +443,7 @@ keys = [
     'flask_port',
     'tls_domain',
     'tls_cert_dir',
+    'tls_additional_domains',
     'letsencrypt_email',
     'letsencrypt_renewal_days',
     'letsencrypt_dry_run',


### PR DESCRIPTION
### Motivation
- Prevent hostname/default-vhost leakage by rejecting unknown TLS handshakes and redirecting unknown HTTP hostnames to the canonical domain. 
- Reduce information leakage by disabling nginx version tokens and providing a path to remove the `Server` header. 
- Improve browser-side defenses by adding commonly-recommended security headers (HSTS, CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy, etc.). 
- Make the Nginx installer/startup flow support additional certificate aliases (eg. `www` names) and automatically install the hardening/snippet files so production installs are safer by default.

### Description
- Reworked the TLS template `nginx/walter-tls.conf` to add a default HTTP server that redirects unknown hosts to the canonical `__WALTER_DOMAIN__` and a default SSL server that sets `ssl_reject_handshake on` to reject unknown SNI hostnames, updated the real vhosts to use a rendered `server_name` list, and added a `limit_except GET POST` in the HTTPS proxy block. 
- Added `nginx/snippets/security-headers.conf` containing `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and a basic `Content-Security-Policy`, and included that snippet from the TLS vhost. 
- Added `nginx/walter-hardening.conf` with `server_tokens off` and a commented guidance line for `more_clear_headers Server;` (headers-more module) to allow removing the `Server` header. 
- Extended `scripts/install_nginx_config.sh` to install the hardening and security-header snippets into `/etc/nginx/conf.d` and `/etc/nginx/snippets`, to accept `--tls-additional-domains` and build a rendered `__WALTER_SERVER_NAMES__` value, and to fail fast on malformed names. 
- Updated `start-server.sh` to expose and validate `tls_additional_domains`, include additional `-d` args for Certbot requests, and pass aliases through to the installer; also added `tls_additional_domains` to the YAML keys read by the script. 
- Documentation and sample config updates: added `tls_additional_domains` comments to `config.yaml` and described the hardening and alias behavior in `README.md`.

### Testing
- Ran a shell syntax check on the installer: `bash -n scripts/install_nginx_config.sh start-server.sh`, which exited successfully. 
- Performed an installer dry-run render: `./scripts/install_nginx_config.sh --dry-run --no-reload --tls-domain walter-pair.us --tls-additional-domains www.walter-pair.us --cert-dir /etc/letsencrypt/live/walter-pair.us --app-config config.yaml`, which produced the expected installs and rendered `nginx/walter-tls.conf` output for `walter-pair.us`. 
- Ran the full test suite: `python3 -m pytest`, with all tests passing (`82 passed`, warnings reported but no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29dc40015083208753d2f80a358e4d)

## Summary by Sourcery

Harden the Nginx TLS setup, add shared security headers, and extend the TLS installation flow to support certificate aliases and stricter validation.

New Features:
- Support specifying additional TLS certificate hostnames via tls_additional_domains in config.yaml and the --tls-additional-domains flag, propagating them through Certbot and Nginx server_name configuration.

Enhancements:
- Introduce default HTTP and HTTPS Nginx servers that redirect unknown HTTP hosts to the canonical domain and reject unknown TLS SNI handshakes to avoid exposing default vhosts.
- Add a reusable Nginx security-headers snippet for the HTTPS vhost and a global hardening config that disables Nginx version tokens and documents optional Server header removal.
- Tighten the HTTPS proxy by limiting allowed HTTP methods to GET and POST.
- Automatically install the Nginx hardening config and security-headers snippet during TLS config installation.

Documentation:
- Document tls_additional_domains usage and describe the updated TLS behavior, hardening config, and security headers in README and config.yaml comments.

Tests:
- Keep existing tests passing while validating shell scripts via syntax checks and dry-run installer execution.