### PR TITLE
Enable TLS domain for Walter deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ letsencrypt_email: admin@example.com
 
 To test the ACME/HTTP-01 validation flow without creating or replacing certificate files, set `letsencrypt_dry_run: true` in `config.yaml`. Dry-run mode still requires a real public DNS name that points at the server, installs the temporary HTTP Nginx config needed for validation, runs Certbot with `--dry-run`, and then skips installing the TLS Nginx config because Certbot does not write live certificate files during a dry run.
 
+If Cloudflare shows **Error 525: SSL handshake failed**, verify that `tls_domain` is set to the hostname Cloudflare is proxying (for this deployment, `walter-pair.us`) and re-run `./start-server.sh` on the origin. A 525 means Cloudflare reached the origin but could not complete the TLS handshake, which is expected if the app is only serving the temporary HTTP config or if the certificate-backed HTTPS vhost was never installed. After the startup script installs or renews the Let's Encrypt certificate and renders `nginx/walter-tls.conf`, keep Cloudflare SSL/TLS mode on **Full (strict)** so Cloudflare validates the origin certificate instead of masking certificate problems.
+
 You can still manage the Nginx config manually:
 
 1) Install Nginx with the HTTP config so Certbot can complete HTTP-01 validation:

--- a/config.yaml
+++ b/config.yaml
@@ -9,7 +9,7 @@ flask_port: 5000
 last_table_number: 200
 # Optional production HTTPS settings. When tls_domain is set, start-server.sh
 # checks for a Let's Encrypt certificate and requests or renews it as needed.
-# tls_domain: tournaments.example.com
+tls_domain: walter-pair.us
 # Optional comma-separated certificate/server-name aliases, for example:
 # tls_additional_domains: www.tournaments.example.com
 # letsencrypt_email: admin@example.com


### PR DESCRIPTION
### Motivation

- Ensure the startup automation provisions an HTTPS vhost and Let's Encrypt certificates for the production hostname used by Cloudflare (`walter-pair.us`).
- Clarify troubleshooting for Cloudflare `525: SSL handshake failed` so operators know to verify the origin is serving the certificate-backed HTTPS vhost and to keep Cloudflare in `Full (strict)` mode.

### Description

- Set `tls_domain: walter-pair.us` in `config.yaml` to enable the TLS/Let's Encrypt flow at startup via `start-server.sh`.
- Add Cloudflare 525 troubleshooting guidance to `README.md` explaining the expected cause and recovery steps and recommending `Full (strict)` mode.

### Testing

- Ran the full test suite with `python -m pytest`, which completed successfully (`82 passed`, `207 warnings`).
- Performed a dry-run install of the TLS Nginx config with `./scripts/install_nginx_config.sh --tls-domain walter-pair.us --dry-run --no-reload`, which completed without errors.
- Verified repository consistency with `git diff --check`, which showed no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a29e0f28b9c8320904c11dbc55c7ee0)

## Summary by Sourcery

Configure the Walter deployment to use a production TLS domain and document Cloudflare SSL handshake troubleshooting steps.

Enhancements:
- Set the production TLS domain in config.yaml so the startup flow can provision and install Let's Encrypt-backed HTTPS for walter-pair.us.

Documentation:
- Add guidance to the README for diagnosing Cloudflare 525 SSL handshake errors and confirming the origin serves the certificate-backed HTTPS vhost with Full (strict) mode.