### PR TITLE
Add per-tournament completion controls and mobile/UI improvements

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -147,7 +147,7 @@ def fetch_cube_cobra_metadata(raw_url):
                 )
     except Exception:
         title = title
-    title = re.sub(r'\s*[|\-]\s*Cube Cobra\s*$', '', title, flags=re.I).strip() or 'Cube Cobra Cube'
+    title = re.sub(r'\s*[|\-]\s*Cube Cobra(?:\s+List)?\s*$', '', title, flags=re.I).strip() or 'Cube Cobra Cube'
     if image_url:
         image_url = urllib.parse.urljoin(url, image_url)
     return url, title[:250], image_url
@@ -310,6 +310,10 @@ def create_app():
                 db.session.commit()
             if 'ended_at' not in columns:
                 db.session.execute(text('ALTER TABLE tournament ADD COLUMN ended_at DATETIME'))
+                db.session.commit()
+            if 'manually_completed' not in columns:
+                db.session.execute(text('ALTER TABLE tournament ADD COLUMN manually_completed BOOLEAN DEFAULT 0'))
+                db.session.execute(text('UPDATE tournament SET manually_completed=0 WHERE manually_completed IS NULL'))
                 db.session.commit()
         if 'user' in inspector.get_table_names():
             columns = [c['name'] for c in inspector.get_columns('user')]
@@ -661,7 +665,7 @@ def create_app():
     def tournament_is_complete(tournament):
         players = list(getattr(tournament, 'players', []) or [])
         rounds = sorted(list(getattr(tournament, 'rounds', []) or []), key=lambda r: r.number)
-        if getattr(tournament, 'ended_at', None):
+        if getattr(tournament, 'ended_at', None) or getattr(tournament, 'manually_completed', False):
             return True
         if not rounds:
             return False
@@ -2539,6 +2543,9 @@ def create_app():
                     'draft_time': t.draft_time,
                     'deck_build_time': t.deck_build_time,
                     'start_time': iso_datetime(t.start_time),
+                    'started_at': iso_datetime(t.started_at),
+                    'ended_at': iso_datetime(t.ended_at),
+                    'manually_completed': bool(t.manually_completed),
                     'head_judge_id': t.head_judge_id,
                     'floor_judges': t.floor_judge_ids(),
                     'round_timer_end': iso_datetime(t.round_timer_end),
@@ -2895,6 +2902,9 @@ def create_app():
                 tournament.draft_time = item.get('draft_time')
                 tournament.deck_build_time = item.get('deck_build_time')
                 tournament.start_time = parse_iso_datetime(item.get('start_time'))
+                tournament.started_at = parse_iso_datetime(item.get('started_at'))
+                tournament.ended_at = parse_iso_datetime(item.get('ended_at'))
+                tournament.manually_completed = bool(item.get('manually_completed'))
                 tournament.head_judge = user_map.get(item.get('head_judge_id'))
                 floor_ids = [user_map[uid].id for uid in item.get('floor_judges') or [] if uid in user_map and user_map[uid].id]
                 tournament.floor_judges = json.dumps(floor_ids)
@@ -4708,6 +4718,38 @@ def create_app():
 
         flash(f'Bulk action applied to {count} tournament' + ('s' if count != 1 else '') + '.', 'success')
         return redirect(url_for('index'))
+
+    @app.route('/admin/tournaments/<int:tid>/complete', methods=['POST'])
+    def complete_tournament(tid):
+        require_permission('tournaments.manage')
+        t = db.session.get(Tournament, tid)
+        if not t:
+            abort(404)
+        now = datetime.utcnow()
+        t.manually_completed = True
+        t.ended_at = t.ended_at or now
+        t.round_timer_end = None
+        t.draft_timer_end = None
+        t.deck_timer_end = None
+        db.session.commit()
+        flash('Tournament marked complete.', 'success')
+        log_site('complete_tournament', 'success', f'tournament_id={tid}')
+        log_tournament(tid, 'complete', 'success')
+        return redirect(request.referrer or url_for('index'))
+
+    @app.route('/admin/tournaments/<int:tid>/reopen', methods=['POST'])
+    def reopen_tournament(tid):
+        require_permission('tournaments.manage')
+        t = db.session.get(Tournament, tid)
+        if not t:
+            abort(404)
+        t.manually_completed = False
+        t.ended_at = None
+        db.session.commit()
+        flash('Tournament reopened.', 'success')
+        log_site('reopen_tournament', 'success', f'tournament_id={tid}')
+        log_tournament(tid, 'reopen', 'success')
+        return redirect(request.referrer or url_for('view_tournament', tid=tid))
 
     @app.route('/admin/tournaments/<int:tid>/delete', methods=['POST'])
     def delete_tournament(tid):

--- a/app/models.py
+++ b/app/models.py
@@ -337,6 +337,7 @@ class Tournament(db.Model):
     start_time = db.Column(db.DateTime, nullable=True)
     started_at = db.Column(db.DateTime, nullable=True)
     ended_at = db.Column(db.DateTime, nullable=True)
+    manually_completed = db.Column(db.Boolean, default=False)
     # Judge assignments
     head_judge_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
     floor_judges = db.Column(db.Text, default='[]')  # store list of user ids as JSON

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -213,6 +213,9 @@ img {
   transform: translateY(-10px);
   transition: opacity 0.18s ease, transform 0.18s ease;
   z-index: 20;
+  max-height: min(70vh, 520px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .dropdown-menu.open {
@@ -1122,6 +1125,11 @@ ul.flashes {
   margin-bottom: 24px;
 }
 
+.inline-form {
+  display: inline-flex;
+  margin: 0;
+}
+
 .inline-form-divider {
   text-align:center;
   margin:12px 0;
@@ -1203,6 +1211,9 @@ ul.flashes {
     padding: 20px;
     box-shadow: var(--shadow-soft);
     display: none;
+    max-height: calc(100vh - var(--nav-height) - 32px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
   .app-nav.open {
     display: block;
@@ -1234,6 +1245,9 @@ ul.flashes {
     background: rgba(15, 23, 42, 0.95);
     display: none;
     gap: 8px;
+    max-height: min(55vh, 420px);
+    overflow-y: auto;
+    overscroll-behavior: contain;
   }
   .nav-item.open .dropdown-menu {
     display: flex;

--- a/app/templates/admin/ended_tournaments.html
+++ b/app/templates/admin/ended_tournaments.html
@@ -15,7 +15,10 @@
       {% for t in tournaments %}
       <tr>
         <td>{{ t.name }}</td><td>{{ t.format }}</td><td>{{ player_counts[t.id] }}</td><td>{{ t.ended_at }}</td>
-        <td><a class="btn ghost" href="{{ url_for('view_tournament', tid=t.id) }}">Open</a></td>
+        <td>
+          <a class="btn ghost" href="{{ url_for('view_tournament', tid=t.id) }}">Open</a>
+          <form method="post" action="{{ url_for('reopen_tournament', tid=t.id) }}" class="inline-form" onsubmit="return confirm('Reopen this tournament?');"><button class="btn secondary" type="submit">Reopen</button></form>
+        </td>
       </tr>
       {% endfor %}
     </tbody>

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -11,14 +11,6 @@
     <a class="btn secondary" href="{{ url_for('register') }}">Create Account</a>
   </div>
 </section>
-<section class="panel-card">
-  <div class="section-heading">
-    <div>
-      <h3>Tournament information is private</h3>
-      <p>Active tournaments are only shown after you log in.</p>
-    </div>
-  </div>
-</section>
 {% else %}
 <section class="page-header">
   <div class="page-header__title">
@@ -37,6 +29,7 @@
 {% if can_manage_tournaments %}
   {% for t in tournaments %}
   <form id="delete-tournament-form-{{ t.id }}" method="post" action="{{ url_for('delete_tournament', tid=t.id) }}" onsubmit="return confirm('Delete this tournament?');"></form>
+  <form id="complete-tournament-form-{{ t.id }}" method="post" action="{{ url_for('complete_tournament', tid=t.id) }}" onsubmit="return confirm('Mark this tournament complete?');"></form>
   {% endfor %}
 {% endif %}
 {% if can_bulk_edit %}
@@ -83,6 +76,7 @@
       {% if can_manage_tournaments %}
       <div class="card-actions">
         <a class="btn secondary" href="{{ url_for('edit_tournament', tid=t.id) }}">Edit</a>
+        <button form="complete-tournament-form-{{ t.id }}" class="btn" type="submit">Mark Complete</button>
         <button form="delete-tournament-form-{{ t.id }}" class="btn danger" type="submit">Delete</button>
       </div>
       {% endif %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -11,6 +11,13 @@
     <a class="btn ghost" href="{{ url_for('assign_judges', tid=t.id) }}">Assign Judges</a>
     {% endif %}
     {% if show_passcode %}<span class="metric-pill">Passcode {{ t.passcode }}</span>{% endif %}
+    {% if current_user.is_authenticated and current_user.has_permission('tournaments.manage') %}
+      {% if t.ended_at or t.manually_completed %}
+      <form method="post" action="{{ url_for('reopen_tournament', tid=t.id) }}" onsubmit="return confirm('Reopen this tournament?');"><button class="btn ghost" type="submit">Reopen</button></form>
+      {% else %}
+      <form method="post" action="{{ url_for('complete_tournament', tid=t.id) }}" onsubmit="return confirm('Mark this tournament complete?');"><button class="btn" type="submit">Mark Complete</button></form>
+      {% endif %}
+    {% endif %}
   </div>
 </section>
 

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -413,7 +413,7 @@ def test_anonymous_home_hides_tournaments(client, session):
 
     assert response.status_code == 200
     assert b'Private Event' not in response.data
-    assert b'Tournament information is private' in response.data
+    assert b'Tournament information is private' not in response.data
 
 
 def test_authenticated_home_shows_tournaments(client, session):


### PR DESCRIPTION
### Motivation
- Provide a way for managers to mark individual tournaments complete (and reopen them) without deleting them. 
- Remove an unnecessary anonymous-home privacy banner to simplify the login screen. 
- Improve mobile navigation by allowing vertical scrolling inside submenu dropdowns like Tournament Tools and Admin. 
- Ensure Cube Cobra links display the cube name (strip trailing “Cube Cobra List”) rather than the longer label.

### Description
- Added a `manually_completed` boolean to `Tournament` and automatic DB upgrade handling to add and populate the column during app startup. 
- Updated completion detection in `tournament_is_complete` to honor the `manually_completed` flag and added `complete`/`reopen` manager routes at `POST /admin/tournaments/<tid>/complete` and `POST /admin/tournaments/<tid>/reopen`. 
- Added per-tournament `Mark Complete` buttons on the active tournaments list and a `Mark Complete` / `Reopen` control on the tournament detail page, and a `Reopen` action on the ended tournaments admin list. 
- Removed the “Tournament information is private” info panel from the anonymous home page and updated the corresponding test expectation. 
- Export/import JSON now includes `started_at`, `ended_at`, and `manually_completed` for tournaments so completion state round-trips. 
- CSS updates to `.dropdown-menu` and `.app-nav` to set `max-height`, `overflow-y: auto`, and `overscroll-behavior: contain` for vertical scrolling on mobile, and added `.inline-form` styling used by row-level reopen forms. 
- Adjusted Cube Cobra metadata parsing to strip trailing variants like `Cube Cobra List` so cube links show the cleaned cube title.

### Testing
- Ran `python -m compileall app` successfully. 
- Ran the full test suite with `pytest -q` and all tests passed (`82 passed`) with warnings about deprecations recorded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31c76487048320a6f2d661add31651)

## Summary by Sourcery

Add per-tournament completion controls, improve mobile navigation for dropdown menus, and simplify the anonymous home page while enhancing Cube Cobra title handling and tournament backup data.

New Features:
- Allow managers to manually mark tournaments complete or reopen them via new admin routes and UI controls on active, detail, and ended tournament views.
- Include tournament started/ended timestamps and manual completion state in export/import JSON payloads so completion status round-trips across backups.

Enhancements:
- Treat manually completed tournaments as complete in completion detection logic alongside ended tournaments.
- Improve Cube Cobra link titles by stripping trailing variants such as "Cube Cobra" and "Cube Cobra List" for cleaner display text.
- Enhance mobile usability of navigation and dropdown menus by limiting their height and enabling internal vertical scrolling with appropriate overscroll behavior.
- Support inline form layout for row-level actions such as reopening tournaments from the ended tournaments admin list.

Tests:
- Update anonymous-home tests to match the removal of the tournament privacy panel while preserving verification that tournaments remain hidden for anonymous users.