### PR TITLE
Prefer Cloudflare original client IP, forward CF header in Nginx, and add tests/logging changes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -823,12 +823,15 @@ def create_app():
         )
 
     def _client_ip():
+        cf_connecting_ip = request.headers.get('CF-Connecting-IP', '')
+        if cf_connecting_ip:
+            return cf_connecting_ip.split(',')[0].strip()
+        real_ip = request.headers.get('X-Real-IP', '')
+        if real_ip:
+            return real_ip.split(',')[0].strip()
         forwarded = request.headers.get('X-Forwarded-For', '')
         if forwarded:
             return forwarded.split(',')[0].strip()
-        real_ip = request.headers.get('X-Real-IP') or request.headers.get('CF-Connecting-IP')
-        if real_ip:
-            return real_ip.split(',')[0].strip()
         return request.remote_addr or 'unknown'
 
     def _browser_fingerprint():

--- a/nginx/walter-tls.conf
+++ b/nginx/walter-tls.conf
@@ -5,6 +5,13 @@
 # __WALTER_ACME_WEBROOT__, __WALTER_FLASK_IP__, and
 # __WALTER_FLASK_PORT__. Do not commit certificate material to this repo.
 
+# Log Cloudflare's original client IP first when present, while retaining the
+# proxy address and forwarded chain for audits. This file is included from the
+# Nginx http context, where log_format is valid.
+log_format walter_real_ip '$http_cf_connecting_ip - $remote_addr - $remote_user [$time_local] '
+                          '"$request" $status $body_bytes_sent "$http_referer" '
+                          '"$http_user_agent" "$http_x_forwarded_for"';
+
 upstream walter_app {
     server __WALTER_FLASK_IP__:__WALTER_FLASK_PORT__;
     keepalive 16;
@@ -37,7 +44,7 @@ server {
 
     client_max_body_size 25m;
 
-    access_log /var/log/nginx/walter.access.log;
+    access_log /var/log/nginx/walter.access.log walter_real_ip;
     error_log /var/log/nginx/walter.error.log;
 
     # Let's Encrypt certificate paths created on the production machine, e.g.:
@@ -62,12 +69,17 @@ server {
     add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
     add_header X-Content-Type-Options nosniff always;
 
+    location = /wp-admin/install.php {
+        return 403;
+    }
+
     location / {
         proxy_pass http://walter_app;
         proxy_http_version 1.1;
 
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto https;
         proxy_set_header X-Forwarded-Host $host;

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -4,7 +4,7 @@ from sqlalchemy import text
 
 from app.app import db
 
-from app.models import User, Role
+from app.models import SiteLog, User, Role
 
 
 def test_user_crud(session):
@@ -230,6 +230,25 @@ def test_account_locks_after_three_bad_passwords(client, session, app):
     assert response.status_code == 200
     assert b'Account locked' in response.data
 
+
+def test_site_logs_and_current_connections_use_cf_connecting_ip(client, session):
+    from app.app import CURRENT_CONNECTIONS
+
+    CURRENT_CONNECTIONS.clear()
+    response = client.post(
+        '/login',
+        data={'email': 'missing-cf@example.com', 'password': 'wrong'},
+        headers={
+            'CF-Connecting-IP': '198.51.100.24',
+            'X-Real-IP': '172.69.151.76',
+            'X-Forwarded-For': '203.0.113.9, 172.69.151.76',
+        },
+    )
+
+    assert response.status_code == 200
+    log = session.query(SiteLog).filter_by(action='login', result='failure').order_by(SiteLog.id.desc()).first()
+    assert log.ip_address == '198.51.100.24'
+    assert any(item['ip_address'] == '198.51.100.24' for item in CURRENT_CONNECTIONS.values())
 
 def test_admin_bad_passwords_blacklist_ip_without_locking_account(client, session, app):
     app.config['ACCOUNT_LOCKOUT_ATTEMPTS'] = 3


### PR DESCRIPTION
### Motivation
- Preserve and use the original client IP when the app is behind Cloudflare so site logs and current-connection tracking reflect the true client address.
- Ensure Nginx records Cloudflare's original IP in access logs and forwards it to the backend for accurate auditing.
- Add a test to prevent regressions and harden the proxy by blocking a common WordPress install endpoint.

### Description
- Update `_client_ip` in `app/app.py` to prioritize the `CF-Connecting-IP` header, then `X-Real-IP`, before falling back to `X-Forwarded-For` and `request.remote_addr`.
- Add `log_format walter_real_ip` to `nginx/walter-tls.conf` and use it for `access_log` so Cloudflare client IP is recorded first, and add `proxy_set_header CF-Connecting-IP $http_cf_connecting_ip` to forward the header to the app.
- Add a `location = /wp-admin/install.php { return 403; }` rule to `nginx/walter-tls.conf` to block that install endpoint.
- Update `tests/test_users.py` to import `SiteLog` and add `test_site_logs_and_current_connections_use_cf_connecting_ip` which asserts that login failures record the `CF-Connecting-IP` and that `CURRENT_CONNECTIONS` contains the Cloudflare IP.

### Testing
- Ran the unit tests in `tests/test_users.py`, including `test_site_logs_and_current_connections_use_cf_connecting_ip`, via `pytest`, and the new test passed.
- Ran the project's test suite via `pytest` and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31d4aadbe483208f517fd849da2a98)

## Summary by Sourcery

Prioritize Cloudflare’s original client IP throughout the stack and add coverage to ensure it is used in logging and connection tracking.

Bug Fixes:
- Ensure the application’s client IP detection prefers Cloudflare’s CF-Connecting-IP header, then X-Real-IP, before other fallbacks.

Enhancements:
- Record Cloudflare’s original client IP in Nginx access logs and forward it to the backend via a dedicated header.
- Block access to the WordPress install endpoint /wp-admin/install.php at the Nginx layer.

Tests:
- Add a regression test verifying that failed login site logs and CURRENT_CONNECTIONS store the CF-Connecting-IP value when provided.