### PR TITLE
Harden TLS Nginx configuration

### DIFF
--- a/nginx/snippets/security-headers.conf
+++ b/nginx/snippets/security-headers.conf
@@ -1,0 +1,6 @@
+add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-Frame-Options "DENY" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+add_header Permissions-Policy "camera=(), microphone=(), geolocation=(), payment=(), usb=()" always;
+add_header Content-Security-Policy "default-src 'self'; img-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; upgrade-insecure-requests" always;

--- a/nginx/walter-tls.conf
+++ b/nginx/walter-tls.conf
@@ -8,6 +8,9 @@
 # Log Cloudflare's original client IP first when present, while retaining the
 # proxy address and forwarded chain for audits. This file is included from the
 # Nginx http context, where log_format is valid.
+server_tokens off;
+limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/m;
+
 log_format walter_real_ip '$http_cf_connecting_ip - $remote_addr - $remote_user [$time_local] '
                           '"$request" $status $body_bytes_sent "$http_referer" '
                           '"$http_user_agent" "$http_x_forwarded_for"';
@@ -66,11 +69,48 @@ server {
     ssl_session_cache shared:WalterTLS:10m;
     ssl_session_tickets off;
 
-    add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
-    add_header X-Content-Type-Options nosniff always;
+    include snippets/security-headers.conf;
 
     location = /wp-admin/install.php {
         return 403;
+    }
+
+    location = /login {
+        limit_req zone=auth_limit burst=10 nodelay;
+
+        proxy_pass http://walter_app;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
+    }
+
+    location = /register {
+        limit_req zone=auth_limit burst=5 nodelay;
+
+        proxy_pass http://walter_app;
+        proxy_http_version 1.1;
+
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header CF-Connecting-IP $http_cf_connecting_ip;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto https;
+        proxy_set_header X-Forwarded-Host $host;
+        proxy_set_header X-Forwarded-Port 443;
+
+        proxy_connect_timeout 60s;
+        proxy_send_timeout 60s;
+        proxy_read_timeout 60s;
     }
 
     location / {

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -7,6 +7,7 @@ REPO_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEFAULT_CONFIG="$REPO_DIR/nginx/walter.conf"
 DEFAULT_TLS_CONFIG="$REPO_DIR/nginx/walter-tls.conf"
 DEFAULT_APP_CONFIG="$REPO_DIR/config.yaml"
+SECURITY_HEADERS_SOURCE="$REPO_DIR/nginx/snippets/security-headers.conf"
 
 CONFIG_FILE="$DEFAULT_CONFIG"
 SITE_NAME="walter"
@@ -328,12 +329,21 @@ cleanup_generated_files() {
 }
 trap cleanup_generated_files EXIT
 
+install_security_headers_snippet() {
+  if [[ ! -f "$SECURITY_HEADERS_SOURCE" ]]; then
+    log "Security headers snippet not found: $SECURITY_HEADERS_SOURCE" >&2
+    exit 1
+  fi
+
+  log "Installing Walter security headers snippet to /etc/nginx/snippets/security-headers.conf"
+  run_root mkdir -p /etc/nginx/snippets
+  run_root install -m 0644 "$SECURITY_HEADERS_SOURCE" /etc/nginx/snippets/security-headers.conf
+}
+
 remove_legacy_nginx_hardening() {
   log "Removing legacy Walter Nginx hardening directives from /etc/nginx/conf.d/walter-hardening.conf"
   run_root rm -f /etc/nginx/conf.d/walter-hardening.conf
 
-  log "Removing legacy Walter security headers snippet from /etc/nginx/snippets/security-headers.conf"
-  run_root rm -f /etc/nginx/snippets/security-headers.conf
 }
 
 disable_packaged_default_site() {
@@ -361,6 +371,7 @@ disable_packaged_default_site() {
 load_app_config
 render_config
 remove_legacy_nginx_hardening
+install_security_headers_snippet
 
 if [[ -n "$TLS_DOMAIN" ]]; then
   log "Ensuring ACME challenge webroot exists at $ACME_WEBROOT"


### PR DESCRIPTION
### Motivation
- Improve TLS and HTTP hardening for the Walter reverse-proxy by disabling server identification, adding safe security headers, and protecting authentication endpoints with rate limits.
- Ensure the installer can deploy the security headers snippet so the TLS config `include` cannot break Nginx due to a missing file.

### Description
- Add `nginx/snippets/security-headers.conf` containing the requested safe headers: `Strict-Transport-Security`, `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy`, `Permissions-Policy`, and `Content-Security-Policy`.
- Update `nginx/walter-tls.conf` to set `server_tokens off;`, declare `limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/m;`, and replace inline headers with `include snippets/security-headers.conf;`.
- Add exact `location = /login` and `location = /register` blocks that apply `limit_req zone=auth_limit` (bursts 10 and 5 respectively) and preserve the existing upstream/proxy header and timeout configuration.
- Update `scripts/install_nginx_config.sh` to provide `SECURITY_HEADERS_SOURCE`, install the snippet to `/etc/nginx/snippets/security-headers.conf` via a new `install_security_headers_snippet` function, and call it before validating/reloading Nginx.

### Testing
- Ran a syntax check of the installer with `bash -n scripts/install_nginx_config.sh`, which succeeded.
- Ran the installer in dry-run mode with `./scripts/install_nginx_config.sh --tls-domain example.com --cert-dir <tmp-cert-dir> --dry-run --no-reload`, which simulated installation successfully.
- Rendered the TLS template into a temporary prefix and ran `nginx -t -p <tmp-nginx-prefix> -c <tmp-nginx-conf>`, and the Nginx configuration test was successful.
- Verified the installer dry-run including snippet installation path with a temporary cert directory, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31df3b72d083208f7d45692aa2af6e)

## Summary by Sourcery

Harden the Walter Nginx TLS reverse-proxy configuration with shared security headers and rate limiting on authentication endpoints, and ensure the installer deploys the required snippet file.

New Features:
- Introduce a reusable Nginx security headers snippet that centralizes standard HTTP security headers for the TLS site.
- Add request rate limiting for the /login and /register endpoints to protect authentication against abuse.

Enhancements:
- Hide Nginx version details in TLS configuration by disabling server tokens.
- Update the installer to deploy the security headers snippet into the Nginx snippets directory and rely on it instead of legacy hardening files.

Chores:
- Remove automatic deletion of the security headers snippet from legacy hardening cleanup while keeping legacy hardening config removal in place.