### PR TITLE
Fix duplicate Nginx server_tokens directive

### DIFF
--- a/nginx/walter-tls.conf
+++ b/nginx/walter-tls.conf
@@ -7,8 +7,9 @@
 
 # Log Cloudflare's original client IP first when present, while retaining the
 # proxy address and forwarded chain for audits. This file is included from the
-# Nginx http context, where log_format is valid.
-server_tokens off;
+# Nginx http context, where log_format and limit_req_zone are valid.
+# Leave server_tokens in the main Nginx configuration because repeating it in
+# an included site file can make `nginx -t` fail with a duplicate directive.
 limit_req_zone $binary_remote_addr zone=auth_limit:10m rate=5r/m;
 
 log_format walter_real_ip '$http_cf_connecting_ip - $remote_addr - $remote_user [$time_local] '


### PR DESCRIPTION
### Motivation
- Prevent `nginx -t` failures caused by a duplicated `server_tokens` directive when the site template is installed on systems that already set `server_tokens` in the main Nginx configuration.

### Description
- Removed the site-level `server_tokens off;` from `nginx/walter-tls.conf` and updated the surrounding comment to instruct that `server_tokens` should remain in the main Nginx config while keeping HTTP-context directives like `limit_req_zone` and `log_format` in the template.

### Testing
- Ran `bash -n scripts/install_nginx_config.sh` which returned without syntax errors.
- Ran `./scripts/install_nginx_config.sh --dry-run --tls-domain walter-pair.us --cert-dir /etc/letsencrypt/live/walter-pair.us --acme-webroot /var/www/letsencrypt --app-config config.yaml --no-reload` which completed the dry-run successfully.
- Verified occurrences with `rg -n "server_tokens" nginx scripts README.md` which showed only the intended references.
- Ran `git diff --check` which reported no whitespace or diff problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31e10a53dc83209f94c991618c1173)

## Summary by Sourcery

Bug Fixes:
- Remove the server_tokens directive from the walter-tls.conf site-level config to rely on the main Nginx configuration instead.