### PR TITLE
Fix Cube Cobra previews in dark mode

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -119,6 +119,13 @@ def normalize_cube_cobra_url(raw_url):
     return urllib.parse.urlunparse(('https', parsed.netloc, parsed.path, '', parsed.query, ''))
 
 
+def clean_cube_cobra_title(raw_title):
+    title = (raw_title or '').strip()
+    title = re.sub(r'^\s*Cube Cobra(?:\s+List)?\s*:\s*', '', title, flags=re.I)
+    title = re.sub(r'\s*[|\-]\s*Cube Cobra(?:\s+List)?\s*$', '', title, flags=re.I)
+    return title.strip() or 'Cube Cobra Cube'
+
+
 def fetch_cube_cobra_metadata(raw_url):
     url = normalize_cube_cobra_url(raw_url)
     title = 'Cube Cobra Cube'
@@ -147,7 +154,7 @@ def fetch_cube_cobra_metadata(raw_url):
                 )
     except Exception:
         title = title
-    title = re.sub(r'\s*[|\-]\s*Cube Cobra(?:\s+List)?\s*$', '', title, flags=re.I).strip() or 'Cube Cobra Cube'
+    title = clean_cube_cobra_title(title)
     if image_url:
         image_url = urllib.parse.urljoin(url, image_url)
     return url, title[:250], image_url
@@ -1884,6 +1891,30 @@ def create_app():
         log_site('lost_found_update', 'success', f'id={item_id}')
         flash('Lost & Found entry updated.', 'success')
         return redirect(url_for('lost_and_found', venue_id=venue.id))
+
+
+    @app.route('/cube-cobra-image')
+    @login_required
+    def cube_cobra_image():
+        image_url = request.args.get('url', '').strip()
+        parsed = urllib.parse.urlparse(image_url)
+        host = (parsed.netloc or '').lower()
+        if host.startswith('www.'):
+            host = host[4:]
+        if parsed.scheme != 'https' or host != 'cubecobra.com':
+            abort(404)
+        try:
+            req = urllib.request.Request(
+                image_url,
+                headers={'User-Agent': 'WaLTER cube preview bot/1.0'},
+            )
+            with urllib.request.urlopen(req, timeout=8) as response:
+                content_type = response.headers.get('Content-Type', 'application/octet-stream').split(';', 1)[0].strip().lower()
+                if not content_type.startswith('image/'):
+                    abort(404)
+                return Response(response.read(2 * 1024 * 1024), content_type=content_type)
+        except Exception:
+            abort(404)
 
     @app.route('/media/<path:filename>')
     @login_required

--- a/app/templates/admin/league_detail.html
+++ b/app/templates/admin/league_detail.html
@@ -41,7 +41,7 @@
   <div class="league-card-grid cube-card-grid">
     {% for cube in cubes %}
     <article class="league-card cube-preview-card">
-      {% if cube.image_url %}<img class="cube-preview-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+      {% if cube.image_url %}<img class="cube-preview-image" src="{{ url_for('cube_cobra_image', url=cube.image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
       <div class="cube-preview-body">
         <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
         <p class="muted-text">Cube Cobra</p>

--- a/app/templates/league_cubes.html
+++ b/app/templates/league_cubes.html
@@ -18,7 +18,7 @@
       <div class="league-card-grid cube-card-grid">
         {% for cube in cubes if cube.id in available %}
         <article class="league-card cube-preview-card">
-          {% if cube.image_url %}<img class="cube-preview-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+          {% if cube.image_url %}<img class="cube-preview-image" src="{{ url_for('cube_cobra_image', url=cube.image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
           <div class="cube-preview-body">
             <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
             <p class="muted-text">Total votes: {{ cube_vote_totals.get((play_date.id, cube.id), 0) }}</p>

--- a/app/templates/league_view.html
+++ b/app/templates/league_view.html
@@ -66,7 +66,7 @@
       <div class="league-card-grid cube-card-grid compact-cube-grid">
         {% for cube in cubes if cube.id in available %}
         <article class="league-card cube-preview-card cube-result-card{% if not cube.image_url %} cube-result-card--text-only{% endif %}">
-          {% if cube.image_url %}<img class="cube-preview-image cube-result-image" src="{{ cube.image_url }}" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+          {% if cube.image_url %}<img class="cube-preview-image cube-result-image" src="{{ url_for('cube_cobra_image', url=cube.image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
           <div class="cube-preview-body cube-result-body">
             <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
             <span class="cube-result-votes">{{ cube_vote_totals.get((play_date.id, cube.id), 0) }} votes</span>

--- a/tests/test_leagues.py
+++ b/tests/test_leagues.py
@@ -191,3 +191,36 @@ def test_cube_league_vote_totals_update_when_votes_change(client, session):
     assert b'Total votes: 3' in response.data
     votes = session.query(LeagueCubeVote).order_by(LeagueCubeVote.cube_id).all()
     assert [(vote.cube_id, vote.votes) for vote in votes] == [(second.id, 3)]
+
+
+def test_cube_cobra_titles_drop_list_prefix():
+    from app.app import clean_cube_cobra_title
+
+    assert clean_cube_cobra_title('Cube Cobra List: FirstCube') == 'FirstCube'
+    assert clean_cube_cobra_title('Food Fight - Cube Cobra List') == 'Food Fight'
+
+
+def test_cube_cobra_images_use_local_proxy(client, session):
+    player = _user(session, 'cube-image@example.com', 'Cube Image')
+    league = League(name='Image League', is_cube_league=True)
+    session.add(league)
+    session.flush()
+    session.add(LeaguePlayer(league_id=league.id, user_id=player.id))
+    cube = LeagueCube(
+        league_id=league.id,
+        cube_cobra_url='https://cubecobra.com/cube/overview/alpha',
+        title='Alpha Cube',
+        image_url='https://cubecobra.com/content/alpha.png',
+    )
+    play_date = LeaguePlayDate(league_id=league.id, play_date=date(2026, 7, 1), is_active=True)
+    session.add_all([cube, play_date])
+    session.flush()
+    session.add(LeaguePlayDateCube(play_date_id=play_date.id, cube_id=cube.id))
+    session.commit()
+
+    assert client.post('/login', data={'email': player.email, 'password': 'secret'}).status_code == 302
+    response = client.get(f'/leagues/{league.id}/cubes')
+
+    assert response.status_code == 200
+    assert b'/cube-cobra-image?url=https://cubecobra.com/content/alpha.png' in response.data
+    assert b'referrerpolicy="no-referrer"' in response.data


### PR DESCRIPTION
### Motivation

- Cube preview images from CubeCobra were not rendering correctly in dark mode and CubeCobra metadata titles sometimes included a leading `Cube Cobra List:` prefix that should not be shown.

### Description

- Add `clean_cube_cobra_title` to strip a leading `Cube Cobra List:` prefix and the existing trailing `Cube Cobra` suffix and apply it from `fetch_cube_cobra_metadata` so stored/displayed titles are clean.
- Add an authenticated local image proxy route `@app.route('/cube-cobra-image')` that validates HTTPS CubeCobra hosts and streams image responses to avoid direct third-party image rendering issues in dark mode.
- Update cube preview templates to use `url_for('cube_cobra_image', url=cube.image_url)` and add `referrerpolicy="no-referrer"` so preview images are loaded via the local proxy instead of directly from CubeCobra.
- Add two tests to `tests/test_leagues.py`: `test_cube_cobra_titles_drop_list_prefix` and `test_cube_cobra_images_use_local_proxy` to cover title cleanup and proxied image rendering.

### Testing

- Ran `pytest -q tests/test_leagues.py` and the targeted tests passed (file-level run succeeded).
- Ran the full test suite with `pytest -q` and all tests passed (`85 passed`) with only warnings reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31e3603b7c8320b8211425a047391b)

## Summary by Sourcery

Improve Cube Cobra cube previews and metadata handling, including secure image loading and cleaner titles.

Bug Fixes:
- Ensure Cube Cobra titles drop the optional leading 'Cube Cobra List:' prefix and trailing 'Cube Cobra' suffix so stored and displayed cube names are clean.
- Serve Cube Cobra preview images via an authenticated local proxy endpoint to avoid dark-mode rendering and third-party loading issues.

Enhancements:
- Update cube preview templates to load Cube Cobra images through the local proxy with a no-referrer policy for improved privacy and consistency.

Tests:
- Add unit test coverage for Cube Cobra title cleaning logic.
- Add integration-style test to verify cube preview pages use the proxied Cube Cobra image URLs with the expected attributes.