### PR TITLE
Fix Cube Cobra image proxy validation

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -47,7 +47,7 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives.kdf.hkdf import HKDF
 from cryptography.hazmat.primitives import hmac as crypto_hmac
-from werkzeug.exceptions import MethodNotAllowed, NotFound
+from werkzeug.exceptions import HTTPException, MethodNotAllowed, NotFound
 from werkzeug.routing import RequestRedirect
 from werkzeug.utils import safe_join, secure_filename
 from PIL import Image, ImageOps
@@ -60,6 +60,7 @@ login_manager = LoginManager()
 PASSWORD_KEY = None
 PASSWORD_SEED = None
 CURRENT_CONNECTIONS = OrderedDict()
+CUBE_COBRA_IMAGE_MAX_BYTES = 2 * 1024 * 1024
 
 MAJOR_60_CARD_FORMATS = [
     'Standard',
@@ -1898,10 +1899,10 @@ def create_app():
     def cube_cobra_image():
         image_url = request.args.get('url', '').strip()
         parsed = urllib.parse.urlparse(image_url)
-        host = (parsed.netloc or '').lower()
-        if host.startswith('www.'):
-            host = host[4:]
-        if parsed.scheme != 'https' or host != 'cubecobra.com':
+        host = (parsed.hostname or '').lower()
+        if parsed.scheme != 'https' or not (
+            host == 'cubecobra.com' or host.endswith('.cubecobra.com')
+        ):
             abort(404)
         try:
             req = urllib.request.Request(
@@ -1909,10 +1910,23 @@ def create_app():
                 headers={'User-Agent': 'WaLTER cube preview bot/1.0'},
             )
             with urllib.request.urlopen(req, timeout=8) as response:
-                content_type = response.headers.get('Content-Type', 'application/octet-stream').split(';', 1)[0].strip().lower()
+                content_type = (
+                    response.headers.get('Content-Type', 'application/octet-stream')
+                    .split(';', 1)[0]
+                    .strip()
+                    .lower()
+                )
                 if not content_type.startswith('image/'):
                     abort(404)
-                return Response(response.read(2 * 1024 * 1024), content_type=content_type)
+                content_length = response.headers.get('Content-Length')
+                if content_length and int(content_length) > CUBE_COBRA_IMAGE_MAX_BYTES:
+                    abort(413)
+                body = response.read(CUBE_COBRA_IMAGE_MAX_BYTES + 1)
+                if len(body) > CUBE_COBRA_IMAGE_MAX_BYTES:
+                    abort(413)
+                return Response(body, content_type=content_type)
+        except HTTPException:
+            raise
         except Exception:
             abort(404)
 

--- a/tests/test_leagues.py
+++ b/tests/test_leagues.py
@@ -71,7 +71,10 @@ def test_cube_league_votes_are_limited_to_three_per_play_date(client, session):
     ])
     session.commit()
 
-    assert client.post('/login', data={'email': player.email, 'password': 'secret'}).status_code == 302
+    assert client.post(
+        '/login',
+        data={'email': player.email, 'password': 'secret'},
+    ).status_code == 302
     response = client.post(
         f'/leagues/{league.id}/cubes',
         data={f'votes_{play_date.id}_{first.id}': '2', f'votes_{play_date.id}_{second.id}': '2'},
@@ -171,7 +174,10 @@ def test_cube_league_vote_totals_update_when_votes_change(client, session):
     ])
     session.commit()
 
-    assert client.post('/login', data={'email': player.email, 'password': 'secret'}).status_code == 302
+    assert client.post(
+        '/login',
+        data={'email': player.email, 'password': 'secret'},
+    ).status_code == 302
     response = client.post(
         f'/leagues/{league.id}/cubes',
         data={f'votes_{play_date.id}_{first.id}': '2', f'votes_{play_date.id}_{second.id}': '1'},
@@ -200,6 +206,111 @@ def test_cube_cobra_titles_drop_list_prefix():
     assert clean_cube_cobra_title('Food Fight - Cube Cobra List') == 'Food Fight'
 
 
+def test_cube_cobra_image_proxy_allows_subdomains(client, session, monkeypatch):
+    import app.app as app_module
+
+    player = _user(session, 'cube-proxy@example.com', 'Cube Proxy')
+    session.commit()
+
+    class FakeResponse:
+        headers = {'Content-Type': 'image/png', 'Content-Length': '7'}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size):
+            return b'pngdata'
+
+    monkeypatch.setattr(
+        app_module.urllib.request,
+        'urlopen',
+        lambda req, timeout: FakeResponse(),
+    )
+
+    assert client.post(
+        '/login',
+        data={'email': player.email, 'password': 'secret'},
+    ).status_code == 302
+    response = client.get('/cube-cobra-image?url=https://images.cubecobra.com/content/alpha.png')
+
+    assert response.status_code == 200
+    assert response.content_type == 'image/png'
+    assert response.data == b'pngdata'
+
+
+def test_cube_cobra_image_proxy_rejects_large_content_length(client, session, monkeypatch):
+    import app.app as app_module
+
+    player = _user(session, 'cube-proxy-large@example.com', 'Cube Proxy Large')
+    session.commit()
+
+    class FakeResponse:
+        headers = {
+            'Content-Type': 'image/png',
+            'Content-Length': str(app_module.CUBE_COBRA_IMAGE_MAX_BYTES + 1),
+        }
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size):
+            raise AssertionError('large images should be rejected before reading the body')
+
+    monkeypatch.setattr(
+        app_module.urllib.request,
+        'urlopen',
+        lambda req, timeout: FakeResponse(),
+    )
+
+    assert client.post(
+        '/login',
+        data={'email': player.email, 'password': 'secret'},
+    ).status_code == 302
+    response = client.get('/cube-cobra-image?url=https://cubecobra.com/content/large.png')
+
+    assert response.status_code == 413
+
+
+def test_cube_cobra_image_proxy_rejects_large_body_without_content_length(client, session, monkeypatch):
+    import app.app as app_module
+
+    player = _user(session, 'cube-proxy-large-body@example.com', 'Cube Proxy Large Body')
+    session.commit()
+
+    class FakeResponse:
+        headers = {'Content-Type': 'image/png'}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size):
+            assert size == app_module.CUBE_COBRA_IMAGE_MAX_BYTES + 1
+            return b'x' * size
+
+    monkeypatch.setattr(
+        app_module.urllib.request,
+        'urlopen',
+        lambda req, timeout: FakeResponse(),
+    )
+
+    assert client.post(
+        '/login',
+        data={'email': player.email, 'password': 'secret'},
+    ).status_code == 302
+    response = client.get('/cube-cobra-image?url=https://cubecobra.com/content/large-body.png')
+
+    assert response.status_code == 413
+
+
 def test_cube_cobra_images_use_local_proxy(client, session):
     player = _user(session, 'cube-image@example.com', 'Cube Image')
     league = League(name='Image League', is_cube_league=True)
@@ -218,7 +329,10 @@ def test_cube_cobra_images_use_local_proxy(client, session):
     session.add(LeaguePlayDateCube(play_date_id=play_date.id, cube_id=cube.id))
     session.commit()
 
-    assert client.post('/login', data={'email': player.email, 'password': 'secret'}).status_code == 302
+    assert client.post(
+        '/login',
+        data={'email': player.email, 'password': 'secret'},
+    ).status_code == 302
     response = client.get(f'/leagues/{league.id}/cubes')
 
     assert response.status_code == 200


### PR DESCRIPTION
### Motivation
- Relax host validation to allow Cube Cobra subdomains and keep the proxy usable for images served from CDNs or image hosts under `cubecobra.com`.
- Prevent the proxy from returning silently truncated image payloads by enforcing an explicit size limit.

### Description
- Add `CUBE_COBRA_IMAGE_MAX_BYTES` (2 MiB) and use `parsed.hostname` to allow `cubecobra.com` and `*.cubecobra.com` while requiring `https` for proxied images.
- Validate `Content-Type` remains an image and reject oversized responses by checking `Content-Length` and by reading `MAX_BYTES + 1` to detect bodies that exceed the limit, returning `413` for oversized content.
- Re-raise `HTTPException` from the fetch path while converting other fetch errors into `404` to preserve intended HTTP behavior.
- Add unit tests covering subdomain hosts and both oversized-response rejection paths, and reformat a few test assertions for readability.

### Testing
- Ran `pytest tests/test_leagues.py -q` which passed: `10 passed, 26 warnings`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31e4f8911c832093417e86df07169c)

## Summary by Sourcery

Relax Cube Cobra image proxy validation to support subdomains while enforcing strict image type and size limits for proxied content.

Bug Fixes:
- Ensure Cube Cobra image proxy correctly validates hosts using the parsed hostname and supports cubecobra.com subdomains.
- Prevent Cube Cobra image proxy from returning silently truncated images by enforcing a configurable maximum response size and rejecting oversized content with HTTP 413.
- Preserve intended HTTP behavior by re-raising HTTP exceptions from the image fetch path and mapping other fetch failures to HTTP 404.

Enhancements:
- Add a configurable maximum image size constant for Cube Cobra image proxy responses.
- Improve test coverage around Cube Cobra image proxy behavior, including subdomain handling and oversized response rejection paths.
- Reformat several league login test assertions for readability.