### PR TITLE
Cube Cobra: add preview fallback image and strip repeated "Cube Cobra List:" prefixes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -61,6 +61,7 @@ PASSWORD_KEY = None
 PASSWORD_SEED = None
 CURRENT_CONNECTIONS = OrderedDict()
 CUBE_COBRA_IMAGE_MAX_BYTES = 2 * 1024 * 1024
+CUBE_COBRA_FALLBACK_IMAGE_URL = 'https://assets.cubecobra.com/content/sticker.png'
 
 MAJOR_60_CARD_FORMATS = [
     'Standard',
@@ -122,9 +123,13 @@ def normalize_cube_cobra_url(raw_url):
 
 def clean_cube_cobra_title(raw_title):
     title = (raw_title or '').strip()
-    title = re.sub(r'^\s*Cube Cobra(?:\s+List)?\s*:\s*', '', title, flags=re.I)
-    title = re.sub(r'\s*[|\-]\s*Cube Cobra(?:\s+List)?\s*$', '', title, flags=re.I)
-    return title.strip() or 'Cube Cobra Cube'
+    previous = None
+    while title and title != previous:
+        previous = title
+        title = re.sub(r'^\s*Cube Cobra(?:\s+List)?\s*:\s*', '', title, flags=re.I)
+        title = re.sub(r'\s*[|\-]\s*Cube Cobra(?:\s+List)?\s*$', '', title, flags=re.I)
+        title = title.strip()
+    return title or 'Cube Cobra Cube'
 
 
 def fetch_cube_cobra_metadata(raw_url):
@@ -1739,6 +1744,10 @@ def create_app():
         )
         return {'count': count}
 
+    @app.template_filter('cube_cobra_title')
+    def cube_cobra_title_filter(title):
+        return clean_cube_cobra_title(title)
+
     @app.context_processor
     def inject_navigation_counts():
         unread = 0
@@ -1760,6 +1769,7 @@ def create_app():
             'nav_open_reports': open_reports,
             'nav_registration_mode': registration_mode(),
             'site_theme': site_theme(),
+            'cube_cobra_fallback_image_url': CUBE_COBRA_FALLBACK_IMAGE_URL,
         }
 
     @app.route('/reports', methods=['GET', 'POST'])

--- a/app/templates/admin/league_detail.html
+++ b/app/templates/admin/league_detail.html
@@ -41,9 +41,9 @@
   <div class="league-card-grid cube-card-grid">
     {% for cube in cubes %}
     <article class="league-card cube-preview-card">
-      {% if cube.image_url %}<img class="cube-preview-image" src="{{ url_for('cube_cobra_image', url=cube.image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+      <img class="cube-preview-image" src="{{ url_for('cube_cobra_image', url=cube.image_url or cube_cobra_fallback_image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title|cube_cobra_title }} preview" loading="lazy">
       <div class="cube-preview-body">
-        <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
+        <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title|cube_cobra_title }}</a></h3>
         <p class="muted-text">Cube Cobra</p>
       </div>
     </article>

--- a/app/templates/league_cubes.html
+++ b/app/templates/league_cubes.html
@@ -18,9 +18,9 @@
       <div class="league-card-grid cube-card-grid">
         {% for cube in cubes if cube.id in available %}
         <article class="league-card cube-preview-card">
-          {% if cube.image_url %}<img class="cube-preview-image" src="{{ url_for('cube_cobra_image', url=cube.image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+          <img class="cube-preview-image" src="{{ url_for('cube_cobra_image', url=cube.image_url or cube_cobra_fallback_image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title|cube_cobra_title }} preview" loading="lazy">
           <div class="cube-preview-body">
-            <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
+            <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title|cube_cobra_title }}</a></h3>
             <p class="muted-text">Total votes: {{ cube_vote_totals.get((play_date.id, cube.id), 0) }}</p>
             <label>Your votes
               <input type="number" name="votes_{{ play_date.id }}_{{ cube.id }}" min="0" max="3" value="{{ cube_user_votes.get((play_date.id, cube.id), 0) }}" {% if not play_date.is_active %}disabled{% endif %}>

--- a/app/templates/league_view.html
+++ b/app/templates/league_view.html
@@ -65,10 +65,10 @@
       {% if available %}
       <div class="league-card-grid cube-card-grid compact-cube-grid">
         {% for cube in cubes if cube.id in available %}
-        <article class="league-card cube-preview-card cube-result-card{% if not cube.image_url %} cube-result-card--text-only{% endif %}">
-          {% if cube.image_url %}<img class="cube-preview-image cube-result-image" src="{{ url_for('cube_cobra_image', url=cube.image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title }} preview" loading="lazy">{% endif %}
+        <article class="league-card cube-preview-card cube-result-card">
+          <img class="cube-preview-image cube-result-image" src="{{ url_for('cube_cobra_image', url=cube.image_url or cube_cobra_fallback_image_url) }}" referrerpolicy="no-referrer" alt="{{ cube.title|cube_cobra_title }} preview" loading="lazy">
           <div class="cube-preview-body cube-result-body">
-            <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title }}</a></h3>
+            <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title|cube_cobra_title }}</a></h3>
             <span class="cube-result-votes">{{ cube_vote_totals.get((play_date.id, cube.id), 0) }} votes</span>
           </div>
         </article>

--- a/tests/test_leagues.py
+++ b/tests/test_leagues.py
@@ -204,7 +204,33 @@ def test_cube_cobra_titles_drop_list_prefix():
 
     assert clean_cube_cobra_title('Cube Cobra List: FirstCube') == 'FirstCube'
     assert clean_cube_cobra_title('Food Fight - Cube Cobra List') == 'Food Fight'
+    assert clean_cube_cobra_title('Cube Cobra List: Cube Cobra List: FirstCube') == 'FirstCube'
 
+
+def test_cube_tiles_show_preview_image_and_clean_title(client, session):
+    admin = _user(session, 'cube-tile-admin@example.com', 'Cube Tile Admin', 'admin', True)
+    league = League(name='Tile League', is_cube_league=True)
+    session.add(league)
+    session.flush()
+    session.add(
+        LeagueCube(
+            league_id=league.id,
+            cube_cobra_url='https://cubecobra.com/cube/overview/firstcube',
+            title='Cube Cobra List: Cube Cobra List: FirstCube',
+        )
+    )
+    session.commit()
+
+    assert client.post(
+        '/login',
+        data={'email': admin.email, 'password': 'secret'},
+    ).status_code == 302
+    response = client.get(f'/admin/leagues/{league.id}')
+
+    assert response.status_code == 200
+    assert b'FirstCube</a>' in response.data
+    assert b'Cube Cobra List: FirstCube</a>' not in response.data
+    assert b'/cube-cobra-image?url=https://assets.cubecobra.com/content/sticker.png' in response.data
 
 def test_cube_cobra_image_proxy_allows_subdomains(client, session, monkeypatch):
     import app.app as app_module


### PR DESCRIPTION
### Motivation
- Ensure cube tiles always show a preview image even when a cube-specific image is missing. 
- Prevent saved Cube Cobra titles from displaying redundant "Cube Cobra List:" prefixes on tiles.

### Description
- Add `CUBE_COBRA_FALLBACK_IMAGE_URL` and expose it to templates as `cube_cobra_fallback_image_url` so templates can always request a preview via the existing `/cube-cobra-image` proxy.
- Update `clean_cube_cobra_title` to iteratively strip repeated `Cube Cobra List:` (and trailing `- | Cube Cobra List`) prefixes and return a cleaned name.
- Register a Jinja template filter `cube_cobra_title` that applies the cleaned title when rendering templates.
- Update `admin/league_detail.html`, `league_cubes.html`, and `league_view.html` to always render an `<img>` for cube previews using `cube.image_url or cube_cobra_fallback_image_url` and to use the `cube_cobra_title` filter for displayed titles.
- Add regression coverage in `tests/test_leagues.py` for repeated title prefixes and for the fallback preview image being requested when a cube-specific image is absent.

### Testing
- Ran `pytest tests/test_leagues.py -q` and all tests passed (existing suite including the added regression test).
- Verified the league admin and voting templates output includes the `/cube-cobra-image?url=...` fallback URL and that titles are rendered without duplicate `Cube Cobra List:` prefixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31e6cd10388320935740b157003dba)

## Summary by Sourcery

Ensure Cube Cobra league tiles always show a preview image and display cleaned cube titles without redundant prefixes.

New Features:
- Introduce a global Cube Cobra fallback image URL exposed to templates for use when cube-specific images are unavailable.
- Add a Jinja template filter to render cleaned Cube Cobra titles in league-related templates.

Bug Fixes:
- Normalize Cube Cobra titles by iteratively stripping repeated "Cube Cobra List" prefixes and suffixes to avoid duplicate labeling in UI.

Tests:
- Extend league tests to cover repeated Cube Cobra title prefixes and verify fallback preview images are rendered when cube images are missing.