### PR TITLE
Restore cube preview card images

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -62,6 +62,10 @@ PASSWORD_SEED = None
 CURRENT_CONNECTIONS = OrderedDict()
 CUBE_COBRA_IMAGE_MAX_BYTES = 2 * 1024 * 1024
 CUBE_COBRA_FALLBACK_IMAGE_URL = 'https://assets.cubecobra.com/content/sticker.png'
+CUBE_PREVIEW_IMAGE_HOSTS = {
+    'cubecobra.com',
+    'scryfall.io',
+}
 
 MAJOR_60_CARD_FORMATS = [
     'Standard',
@@ -130,6 +134,15 @@ def clean_cube_cobra_title(raw_title):
         title = re.sub(r'\s*[|\-]\s*Cube Cobra(?:\s+List)?\s*$', '', title, flags=re.I)
         title = title.strip()
     return title or 'Cube Cobra Cube'
+
+
+def is_allowed_cube_preview_image_url(image_url):
+    parsed = urllib.parse.urlparse(image_url)
+    host = (parsed.hostname or '').lower()
+    return parsed.scheme == 'https' and any(
+        host == allowed_host or host.endswith(f'.{allowed_host}')
+        for allowed_host in CUBE_PREVIEW_IMAGE_HOSTS
+    )
 
 
 def fetch_cube_cobra_metadata(raw_url):
@@ -1908,11 +1921,7 @@ def create_app():
     @login_required
     def cube_cobra_image():
         image_url = request.args.get('url', '').strip()
-        parsed = urllib.parse.urlparse(image_url)
-        host = (parsed.hostname or '').lower()
-        if parsed.scheme != 'https' or not (
-            host == 'cubecobra.com' or host.endswith('.cubecobra.com')
-        ):
+        if not is_allowed_cube_preview_image_url(image_url):
             abort(404)
         try:
             req = urllib.request.Request(

--- a/tests/test_leagues.py
+++ b/tests/test_leagues.py
@@ -267,6 +267,43 @@ def test_cube_cobra_image_proxy_allows_subdomains(client, session, monkeypatch):
     assert response.data == b'pngdata'
 
 
+def test_cube_cobra_image_proxy_allows_scryfall_card_images(client, session, monkeypatch):
+    import app.app as app_module
+
+    player = _user(session, 'cube-proxy-scryfall@example.com', 'Cube Proxy Scryfall')
+    session.commit()
+
+    class FakeResponse:
+        headers = {'Content-Type': 'image/jpeg', 'Content-Length': '7'}
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return False
+
+        def read(self, size):
+            return b'jpgdata'
+
+    monkeypatch.setattr(
+        app_module.urllib.request,
+        'urlopen',
+        lambda req, timeout: FakeResponse(),
+    )
+
+    assert client.post(
+        '/login',
+        data={'email': player.email, 'password': 'secret'},
+    ).status_code == 302
+    response = client.get(
+        '/cube-cobra-image?url=https://cards.scryfall.io/art_crop/front/0/f/card.jpg'
+    )
+
+    assert response.status_code == 200
+    assert response.content_type == 'image/jpeg'
+    assert response.data == b'jpgdata'
+
+
 def test_cube_cobra_image_proxy_rejects_large_content_length(client, session, monkeypatch):
     import app.app as app_module
 


### PR DESCRIPTION
### Motivation
- Cube preview images sometimes point to Scryfall-hosted card art and were blocked by a strict proxy host check. 
- The change re-enables those previews while keeping the proxy host allowlist approach for safety.

### Description
- Add `CUBE_PREVIEW_IMAGE_HOSTS` and include `'scryfall.io'` alongside `'cubecobra.com'` in `app/app.py`.
- Add helper `is_allowed_cube_preview_image_url(image_url)` to centralize URL allowlist logic in `app/app.py`.
- Update the `/cube-cobra-image` route to use `is_allowed_cube_preview_image_url` rather than only allowing `cubecobra.com`-hosted images.
- Add a regression test `test_cube_cobra_image_proxy_allows_scryfall_card_images` in `tests/test_leagues.py` to cover proxied Scryfall URLs.

### Testing
- Ran `pytest tests/test_leagues.py -q` and the suite completed successfully with `12 passed, 30 warnings`.
- The new regression test validates that `cards.scryfall.io` JPEG images are proxied and served as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ea7b33608320993e09f4760dbe81)

## Summary by Sourcery

Allow Cube preview image proxying for additional trusted hosts and add coverage for Scryfall-hosted images.

Bug Fixes:
- Restore Cube preview card images that are hosted on Scryfall and were previously blocked by strict host validation.

Enhancements:
- Introduce a centralized allowlist configuration and helper for validating Cube preview image URLs across trusted hosts.

Tests:
- Add a regression test ensuring the cube image proxy accepts and serves Scryfall-hosted JPEG card images.