### PR TITLE
Add admin API key management and REST API endpoints

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -403,6 +403,7 @@ def create_app():
             Venue,
             Vendor,
             ArtistProfile,
+            ApiKey,
             SiteLog,
             TournamentLog,
         )  # lazy import to avoid circular reference
@@ -418,6 +419,10 @@ def create_app():
                 db.session.commit()
             if 'lock_reason' not in columns:
                 db.session.execute(text('ALTER TABLE user ADD COLUMN lock_reason TEXT'))
+                db.session.commit()
+            if 'color_mode' not in columns:
+                db.session.execute(text("ALTER TABLE user ADD COLUMN color_mode VARCHAR(10) DEFAULT 'light'"))
+                db.session.execute(text("UPDATE user SET color_mode='light' WHERE color_mode IS NULL"))
                 db.session.commit()
 
         BadLoginAttempt.__table__.create(bind=db.engine, checkfirst=True)
@@ -457,6 +462,7 @@ def create_app():
         Venue.__table__.create(bind=db.engine, checkfirst=True)
         Vendor.__table__.create(bind=db.engine, checkfirst=True)
         ArtistProfile.__table__.create(bind=db.engine, checkfirst=True)
+        ApiKey.__table__.create(bind=db.engine, checkfirst=True)
 
         logs_engine = db.engines['logs']
         SiteLog.__table__.create(bind=logs_engine, checkfirst=True)
@@ -575,7 +581,9 @@ def create_app():
         Venue,
         Vendor,
         ArtistProfile,
+        ApiKey,
         all_permission_keys,
+        utc_now,
     )
     from .pairing import pair_round, recommended_rounds, compute_standings, player_points, draft_seating_tables, seeded_cut_pairs
 
@@ -911,6 +919,10 @@ def create_app():
         return 'invite_only' if app.config.get('ACCOUNT_CREATION_INVITE_ONLY', False) else 'open'
 
     def site_theme():
+        if current_user.is_authenticated:
+            theme = getattr(current_user, 'color_mode', None)
+            if theme in {'light', 'dark'}:
+                return theme
         theme = get_site_setting('site_theme', 'light')
         if theme in {'light', 'dark'}:
             return theme
@@ -1756,6 +1768,215 @@ def create_app():
             .count()
         )
         return {'count': count}
+
+    def _json_error(message, status=400):
+        response = jsonify({'error': message})
+        response.status_code = status
+        return response
+
+    def _api_log(action, result, error=None):
+        _safe_log_site(f'api.{action}', result, error)
+
+    def _api_current_user():
+        auth = request.headers.get('Authorization', '')
+        token = ''
+        if auth.lower().startswith('bearer '):
+            token = auth.split(None, 1)[1].strip()
+        token = token or request.headers.get('X-API-Key', '').strip()
+        if not token:
+            return None, None
+        api_key = db.session.query(ApiKey).filter_by(key_hash=ApiKey.hash_token(token), revoked_at=None).first()
+        if not api_key or not api_key.user:
+            return None, None
+        api_key.last_used_at = utc_now()
+        db.session.commit()
+        return api_key.user, api_key
+
+    def require_api_permission(perm):
+        user, api_key = _api_current_user()
+        if not user:
+            _api_log('auth', 'failure', 'missing or invalid api key')
+            abort(401)
+        if not user.has_permission(perm):
+            _api_log('auth', 'failure', perm)
+            abort(403)
+        return user, api_key
+
+    def user_payload(user):
+        return {'id': user.id, 'name': user.name, 'email': user.email or '', 'role': user.role.name if user.role else None, 'is_admin': bool(user.is_admin)}
+
+    def tournament_payload(t):
+        return {'id': t.id, 'name': t.name, 'format': t.format, 'structure': t.structure, 'start_time': t.start_time.isoformat() if t.start_time else None, 'league_id': t.league_id, 'venue_id': t.venue_id}
+
+    def league_payload(league):
+        return {'id': league.id, 'name': league.name, 'start_date': league.start_date.isoformat() if league.start_date else None, 'end_date': league.end_date.isoformat() if league.end_date else None, 'is_cube_league': bool(league.is_cube_league)}
+
+    @app.route('/settings', methods=['GET', 'POST'])
+    @login_required
+    def user_settings():
+        new_api_key = None
+        if request.method == 'POST':
+            action = request.form.get('action')
+            if action == 'appearance':
+                color_mode = request.form.get('color_mode', 'light')
+                if color_mode not in {'light', 'dark'}:
+                    color_mode = 'light'
+                current_user.color_mode = color_mode
+                db.session.commit()
+                flash('Settings saved.', 'success')
+                return redirect(url_for('user_settings'))
+            if action == 'api_key':
+                if not current_user.has_permission('admin.api_keys'):
+                    log_site('api_key_create', 'failure', 'missing admin.api_keys')
+                    abort(403)
+                name = (request.form.get('name') or 'API key').strip()[:120]
+                token = ApiKey.create_token()
+                db.session.add(ApiKey.from_token(token, current_user, name, created_by=current_user))
+                db.session.commit()
+                log_site('api_key_create', 'success', f'api_key_name={name}')
+                new_api_key = token
+        keys = db.session.query(ApiKey).filter_by(user_id=current_user.id).order_by(ApiKey.created_at.desc()).all()
+        return render_template('user_settings.html', api_keys=keys, new_api_key=new_api_key, selected_color_mode=site_theme())
+
+    @app.route('/settings/api-keys/<int:key_id>/revoke', methods=['POST'])
+    @login_required
+    def revoke_api_key(key_id):
+        key = db.session.get(ApiKey, key_id)
+        if not key or key.user_id != current_user.id:
+            abort(404)
+        key.revoked_at = utc_now()
+        db.session.commit()
+        log_site('api_key_revoke', 'success', f'api_key_id={key.id}')
+        flash('API key revoked.', 'success')
+        return redirect(url_for('user_settings'))
+
+    @app.route('/api/v1/users', methods=['GET', 'POST'])
+    def api_users():
+        api_user, _ = require_api_permission('users.manage')
+        if request.method == 'POST':
+            data = request.get_json(silent=True) or {}
+            name = (data.get('name') or '').strip()
+            email = (data.get('email') or '').strip().lower() or None
+            if not name:
+                return _json_error('name is required')
+            user = User(name=name, email=email)
+            if data.get('password'):
+                user.set_password(data['password'])
+            db.session.add(user)
+            db.session.commit()
+            _api_log('users.create', 'success', f'user_id={user.id}; api_user_id={api_user.id}')
+            return jsonify(user_payload(user)), 201
+        users = db.session.query(User).order_by(User.name).all()
+        _api_log('users.list', 'success')
+        return jsonify({'users': [user_payload(u) for u in users]})
+
+    @app.route('/api/v1/tournaments', methods=['GET', 'POST'])
+    def api_tournaments():
+        api_user, _ = require_api_permission('tournaments.manage')
+        if request.method == 'POST':
+            data = request.get_json(silent=True) or {}
+            name = (data.get('name') or '').strip()
+            fmt = (data.get('format') or 'Commander').strip()
+            if not name:
+                return _json_error('name is required')
+            tournament = Tournament(name=name, format=fmt, structure=data.get('structure') or 'swiss')
+            db.session.add(tournament)
+            db.session.commit()
+            _api_log('tournaments.create', 'success', f'tournament_id={tournament.id}; api_user_id={api_user.id}')
+            return jsonify(tournament_payload(tournament)), 201
+        tournaments = db.session.query(Tournament).order_by(Tournament.created_at.desc()).all()
+        _api_log('tournaments.list', 'success')
+        return jsonify({'tournaments': [tournament_payload(t) for t in tournaments]})
+
+    @app.route('/api/v1/leagues', methods=['GET', 'POST'])
+    def api_leagues():
+        api_user, _ = require_api_permission('tournaments.manage')
+        if request.method == 'POST':
+            data = request.get_json(silent=True) or {}
+            name = (data.get('name') or '').strip()
+            if not name:
+                return _json_error('name is required')
+            league = League(name=name, is_cube_league=bool(data.get('is_cube_league')))
+            db.session.add(league)
+            db.session.commit()
+            _api_log('leagues.create', 'success', f'league_id={league.id}; api_user_id={api_user.id}')
+            return jsonify(league_payload(league)), 201
+        leagues = db.session.query(League).order_by(League.name).all()
+        _api_log('leagues.list', 'success')
+        return jsonify({'leagues': [league_payload(l) for l in leagues]})
+
+    @app.route('/api/v1/users/<int:user_id>', methods=['GET', 'PATCH', 'DELETE'])
+    def api_user_detail(user_id):
+        api_user, _ = require_api_permission('users.manage')
+        user = db.session.get(User, user_id)
+        if not user:
+            return _json_error('not found', 404)
+        if request.method == 'PATCH':
+            data = request.get_json(silent=True) or {}
+            if 'name' in data:
+                user.name = (data.get('name') or user.name).strip()
+            if 'email' in data:
+                user.email = (data.get('email') or '').strip().lower() or None
+            if data.get('password'):
+                user.set_password(data['password'])
+            db.session.commit()
+            _api_log('users.update', 'success', f'user_id={user.id}; api_user_id={api_user.id}')
+        elif request.method == 'DELETE':
+            deleted_id = user.id
+            db.session.delete(user)
+            db.session.commit()
+            _api_log('users.delete', 'success', f'user_id={deleted_id}; api_user_id={api_user.id}')
+            return jsonify({'deleted': True})
+        else:
+            _api_log('users.get', 'success', f'user_id={user.id}')
+        return jsonify(user_payload(user))
+
+    @app.route('/api/v1/tournaments/<int:tournament_id>', methods=['GET', 'PATCH', 'DELETE'])
+    def api_tournament_detail(tournament_id):
+        api_user, _ = require_api_permission('tournaments.manage')
+        tournament = db.session.get(Tournament, tournament_id)
+        if not tournament:
+            return _json_error('not found', 404)
+        if request.method == 'PATCH':
+            data = request.get_json(silent=True) or {}
+            for field in ('name', 'format', 'structure'):
+                if field in data and data[field]:
+                    setattr(tournament, field, str(data[field]).strip())
+            db.session.commit()
+            _api_log('tournaments.update', 'success', f'tournament_id={tournament.id}; api_user_id={api_user.id}')
+        elif request.method == 'DELETE':
+            deleted_id = tournament.id
+            db.session.delete(tournament)
+            db.session.commit()
+            _api_log('tournaments.delete', 'success', f'tournament_id={deleted_id}; api_user_id={api_user.id}')
+            return jsonify({'deleted': True})
+        else:
+            _api_log('tournaments.get', 'success', f'tournament_id={tournament.id}')
+        return jsonify(tournament_payload(tournament))
+
+    @app.route('/api/v1/leagues/<int:league_id>', methods=['GET', 'PATCH', 'DELETE'])
+    def api_league_detail(league_id):
+        api_user, _ = require_api_permission('tournaments.manage')
+        league = db.session.get(League, league_id)
+        if not league:
+            return _json_error('not found', 404)
+        if request.method == 'PATCH':
+            data = request.get_json(silent=True) or {}
+            if 'name' in data and data['name']:
+                league.name = str(data['name']).strip()
+            if 'is_cube_league' in data:
+                league.is_cube_league = bool(data['is_cube_league'])
+            db.session.commit()
+            _api_log('leagues.update', 'success', f'league_id={league.id}; api_user_id={api_user.id}')
+        elif request.method == 'DELETE':
+            deleted_id = league.id
+            db.session.delete(league)
+            db.session.commit()
+            _api_log('leagues.delete', 'success', f'league_id={deleted_id}; api_user_id={api_user.id}')
+            return jsonify({'deleted': True})
+        else:
+            _api_log('leagues.get', 'success', f'league_id={league.id}')
+        return jsonify(league_payload(league))
 
     @app.template_filter('cube_cobra_title')
     def cube_cobra_title_filter(title):
@@ -4424,19 +4645,21 @@ def create_app():
                 mode = request.form.get('registration_mode', 'open')
                 if mode not in {'open', 'invite_only', 'closed'}:
                     mode = 'open'
-                theme = request.form.get('site_theme', 'light')
-                if theme not in {'light', 'dark'}:
-                    theme = 'light'
+                theme = request.form.get('site_theme')
+                if theme is not None:
+                    if theme not in {'light', 'dark'}:
+                        theme = 'light'
+                    set_site_setting('site_theme', theme)
+                    current_user.color_mode = theme
                 set_site_setting('registration_mode', mode)
-                set_site_setting('site_theme', theme)
                 db.session.commit()
-                log_site('site_settings_update', 'success', f'registration_mode={mode}; site_theme={theme}')
+                details = f'registration_mode={mode}' + (f'; site_theme={theme}' if theme is not None else '')
+                log_site('site_settings_update', 'success', details)
                 flash('Site settings saved.', 'success')
             return redirect(url_for('site_settings'))
         return render_template(
             'admin/site_settings.html',
             registration_mode=registration_mode(),
-            selected_site_theme=site_theme(),
         )
 
     @app.route('/admin/registration-invites', methods=['GET', 'POST'])

--- a/app/models.py
+++ b/app/models.py
@@ -6,6 +6,7 @@ import uuid
 import os
 import json
 import secrets
+import hashlib
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
@@ -34,6 +35,7 @@ PERMISSION_GROUPS = {
         'login_audit': 'Audit failed login attempts',
         'ip_blacklist': 'Manage blacklisted IP addresses',
         'site_settings': 'Manage site settings and registration invites',
+        'api_keys': 'Create API keys',
     },
 }
 
@@ -125,6 +127,7 @@ class User(db.Model, UserMixin):
     failed_login_count = db.Column(db.Integer, nullable=False, default=0)
     locked_at = db.Column(db.DateTime, nullable=True)
     lock_reason = db.Column(db.Text, nullable=True)
+    color_mode = db.Column(db.String(10), nullable=False, default='light')
 
     def set_password(self, pw, *, unlock=True):
         self.salt = 'werkzeug'
@@ -191,6 +194,39 @@ class User(db.Model, UserMixin):
         if not self.role:
             return False
         return self.role.permissions_dict().get(key, False)
+
+
+class ApiKey(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=False)
+    name = db.Column(db.String(120), nullable=False)
+    key_hash = db.Column(db.String(64), unique=True, nullable=False)
+    prefix = db.Column(db.String(16), nullable=False)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    last_used_at = db.Column(db.DateTime, nullable=True)
+    revoked_at = db.Column(db.DateTime, nullable=True)
+    created_by_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+
+    user = db.relationship('User', foreign_keys=[user_id], backref=db.backref('api_keys', cascade='all, delete-orphan'))
+    created_by = db.relationship('User', foreign_keys=[created_by_id])
+
+    @staticmethod
+    def hash_token(token):
+        return hashlib.sha256(token.encode()).hexdigest()
+
+    @classmethod
+    def create_token(cls):
+        return 'wlt_' + secrets.token_urlsafe(32)
+
+    @classmethod
+    def from_token(cls, token, user, name, created_by=None):
+        return cls(
+            user=user,
+            name=name,
+            key_hash=cls.hash_token(token),
+            prefix=token[:12],
+            created_by=created_by,
+        )
 
 
 class BadLoginAttempt(db.Model):

--- a/app/templates/admin/site_settings.html
+++ b/app/templates/admin/site_settings.html
@@ -4,7 +4,7 @@
   <div class="page-header__title">
     <span class="eyebrow">Admin</span>
     <h2>Site Settings</h2>
-    <p class="page-description">Control public registration access and the site-wide appearance.</p>
+    <p class="page-description">Control public registration access. Color mode is now managed from user settings.</p>
   </div>
 </section>
 
@@ -17,12 +17,6 @@
         <option value="open"{% if registration_mode == 'open' %} selected{% endif %}>Open — anyone can register before login</option>
         <option value="invite_only"{% if registration_mode == 'invite_only' %} selected{% endif %}>Invite only — admin email links required</option>
         <option value="closed"{% if registration_mode == 'closed' %} selected{% endif %}>Closed — no public self registration</option>
-      </select>
-    </label>
-    <label>Color mode
-      <select name="site_theme" required>
-        <option value="light"{% if selected_site_theme == 'light' %} selected{% endif %}>Light — bright default interface</option>
-        <option value="dark"{% if selected_site_theme == 'dark' %} selected{% endif %}>Dark — low-light interface</option>
       </select>
     </label>
     <div class="form-actions"><button class="btn" type="submit">Save Settings</button></div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -29,6 +29,7 @@
           <li class="nav-item"><a class="nav-link" href="{{ url_for('my_leagues') }}">My Leagues</a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('messages_home') }}">Messages <span id="nav-messages-count" class="nav-badge{% if not nav_unread_messages %} hidden{% endif %}">{{ nav_unread_messages }}</span></a></li>
           <li class="nav-item"><a class="nav-link" href="{{ url_for('submit_report') }}">Report Issue</a></li>
+          <li class="nav-item"><a class="nav-link" href="{{ url_for('user_settings') }}">Settings</a></li>
           {% if current_user.has_permission('tournaments.manage') %}
           <li class="nav-item has-dropdown">
             <button class="nav-link" type="button" data-dropdown-toggle aria-expanded="false">Tournament Tools</button>

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -1,0 +1,63 @@
+{% extends 'base.html' %}
+{% block content %}
+<section class="page-header">
+  <div class="page-header__title">
+    <span class="eyebrow">Account</span>
+    <h2>User Settings</h2>
+    <p class="page-description">Manage your appearance preferences and administrator API access.</p>
+  </div>
+</section>
+
+<section class="panel-card">
+  <h3>Appearance</h3>
+  <form method="post" class="stacked-form">
+    <input type="hidden" name="action" value="appearance">
+    <label>Color mode
+      <select name="color_mode" required>
+        <option value="light"{% if selected_color_mode == 'light' %} selected{% endif %}>Light — bright default interface</option>
+        <option value="dark"{% if selected_color_mode == 'dark' %} selected{% endif %}>Dark — low-light interface</option>
+      </select>
+    </label>
+    <div class="form-actions"><button class="btn" type="submit">Save Settings</button></div>
+  </form>
+</section>
+
+<section class="panel-card">
+  <h3>API Keys</h3>
+  {% if current_user.has_permission('admin.api_keys') %}
+    {% if new_api_key %}
+      <div class="flash success">
+        Copy this API key now. It will not be shown again:<br>
+        <code>{{ new_api_key }}</code>
+      </div>
+    {% endif %}
+    <form method="post" class="stacked-form">
+      <input type="hidden" name="action" value="api_key">
+      <label>Key name <input type="text" name="name" maxlength="120" placeholder="Automation key"></label>
+      <div class="form-actions"><button class="btn" type="submit">Create API Key</button></div>
+    </form>
+  {% else %}
+    <p class="muted">Only administrators with the API key permission can create API keys.</p>
+  {% endif %}
+
+  <div class="table-wrap">
+    <table>
+      <thead><tr><th>Name</th><th>Prefix</th><th>Created</th><th>Last used</th><th>Status</th><th></th></tr></thead>
+      <tbody>
+        {% for key in api_keys %}
+        <tr>
+          <td>{{ key.name }}</td>
+          <td><code>{{ key.prefix }}</code></td>
+          <td>{{ key.created_at.strftime('%Y-%m-%d %H:%M') if key.created_at else '' }}</td>
+          <td>{{ key.last_used_at.strftime('%Y-%m-%d %H:%M') if key.last_used_at else 'Never' }}</td>
+          <td>{{ 'Revoked' if key.revoked_at else 'Active' }}</td>
+          <td>{% if not key.revoked_at %}<form method="post" action="{{ url_for('revoke_api_key', key_id=key.id) }}"><button class="btn btn-danger" type="submit">Revoke</button></form>{% endif %}</td>
+        </tr>
+        {% else %}
+        <tr><td colspan="6">No API keys yet.</td></tr>
+        {% endfor %}
+      </tbody>
+    </table>
+  </div>
+</section>
+{% endblock %}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,67 @@
+from app.models import ApiKey, League, Role, SiteLog, Tournament, User
+
+
+def test_admin_can_create_api_key_and_call_admin_api(client, session):
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(email='api-admin@example.com', name='API Admin', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    session.add(admin)
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+        response = client.post('/settings', data={'action': 'api_key', 'name': 'Tests'})
+
+    assert response.status_code == 200
+    token = response.get_data(as_text=True).split('<code>')[1].split('</code>')[0]
+    key = session.query(ApiKey).filter_by(user_id=admin.id).one()
+    assert token.startswith('wlt_')
+    assert key.prefix == token[:12]
+    assert session.query(SiteLog).filter_by(action='api_key_create', result='success').count() == 1
+
+    create_response = client.post(
+        '/api/v1/leagues',
+        json={'name': 'API League', 'is_cube_league': True},
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert create_response.status_code == 201
+    assert create_response.get_json()['name'] == 'API League'
+    assert session.query(League).filter_by(name='API League').one().is_cube_league
+    assert session.query(SiteLog).filter_by(action='api.leagues.create', result='success').count() == 1
+
+
+def test_non_admin_cannot_create_api_key(client, session):
+    user_role = session.query(Role).filter_by(name='user').one()
+    user = User(email='api-user@example.com', name='API User', role=user_role)
+    user.set_password('secret')
+    session.add(user)
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+        response = client.post('/settings', data={'action': 'api_key', 'name': 'Nope'})
+
+    assert response.status_code == 403
+    assert session.query(ApiKey).count() == 0
+
+
+def test_api_key_can_create_tournament(client, session):
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(email='api-tourney@example.com', name='API Tourney', role=admin_role, is_admin=True)
+    admin.set_password('secret')
+    token = ApiKey.create_token()
+    session.add(admin)
+    session.flush()
+    session.add(ApiKey.from_token(token, admin, 'Direct', created_by=admin))
+    session.commit()
+
+    response = client.post(
+        '/api/v1/tournaments',
+        json={'name': 'API Tournament', 'format': 'Draft'},
+        headers={'X-API-Key': token},
+    )
+
+    assert response.status_code == 201
+    assert response.get_json()['format'] == 'Draft'
+    assert session.query(Tournament).filter_by(name='API Tournament').one().format == 'Draft'


### PR DESCRIPTION
### Motivation
- Expose basic REST APIs for administrative tasks (users, tournaments, leagues) authenticated by API keys. 
- Limit API key creation to authorized administrators via a new permission and record key creation for auditability. 
- Move per-user color mode out of the global site settings into a user settings page to allow individual appearance preferences.

### Description
- Added a new `ApiKey` model with hashed key storage, prefix, `created_at`/`last_used_at`/`revoked_at`, and helper methods `create_token`, `hash_token`, and `from_token`, and added the `admin.api_keys` permission key in `PERMISSION_GROUPS` (`app/models.py`).
- Added a `color_mode` column to `User` and migrated site theme behavior to prefer a signed-in user’s `color_mode`, while keeping site-level fallback via `SiteSetting` (`app/models.py`, `app/app.py`).
- Implemented API-key auth helpers (`_api_current_user`, `require_api_permission`, `_api_log`, `_json_error`) and API endpoints under `/api/v1/` for listing/creating users, tournaments, and leagues plus detail `GET/PATCH/DELETE` routes; all API actions are logged to site logs (`app/app.py`).
- Added a user settings UI at `/settings` with appearance controls and an API key management UI (create/revoke) and linked it from the main nav; removed color-mode controls from the admin site settings UI (`app/templates/user_settings.html`, `app/templates/admin/site_settings.html`, `app/templates/base.html`).
- Created DB upgrade steps to add the `color_mode` column and create the `ApiKey` table, and updated code to update `ApiKey.last_used_at` on use (`app/app.py`).
- Added regression tests covering admin API key creation permission, API-authenticated league/tournament creation, and logging (`tests/test_api.py`).

### Testing
- Compiled modified modules with `python -m py_compile app/app.py app/models.py` and the compilation succeeded. 
- Ran the new API tests with `pytest -q tests/test_api.py` which passed. 
- Ran the full test suite with `pytest -q`, and all tests passed (`94 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ef79a39c8320a6d8ddd099d4e698)

## Summary by Sourcery

Introduce admin-managed API keys, user-specific appearance settings, and authenticated REST endpoints for core admin resources.

New Features:
- Add persistent API key model with audit fields and prefix-based display for admin-managed programmatic access.
- Expose authenticated REST API endpoints under /api/v1 for managing users, tournaments, and leagues with CRUD operations.
- Provide a user settings page for managing personal color mode and viewing/managing own API keys, linked from the main navigation.

Enhancements:
- Make site theme selection prefer a signed-in user’s stored color mode while retaining a site-level fallback setting.
- Log all admin API key lifecycle events and REST API actions to existing site logs for traceability.
- Update site settings flow so registration is still managed globally while color mode is now controlled per user.

Tests:
- Add regression tests covering admin API key creation and permissions, and API-key-authenticated creation of leagues and tournaments.