### PR TITLE
Merge Discord bot requirements into root requirements and remove bot requirements file

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ psutil==5.9.8
 PyYAML==6.0.1
 Pillow==12.2.0
 waitress==3.0.2
+aiohttp>=3.7.4,<4
+audioop-lts; python_version>='3.13'

--- a/walter-bot/pyproject.toml
+++ b/walter-bot/pyproject.toml
@@ -26,14 +26,15 @@ classifiers = [
     "Topic :: Utilities",
     "Typing :: Typed",
 ]
-dynamic = ["version", "dependencies"]
+dynamic = ["version"]
+dependencies = [
+    "aiohttp>=3.7.4,<4",
+    "audioop-lts; python_version>='3.13'",
+]
 
 [project.urls]
 Documentation = "https://discordpy.readthedocs.io/en/latest/"
 "Issue tracker" = "https://github.com/Rapptz/discord.py/issues"
-
-[tool.setuptools.dynamic]
-dependencies = { file = "requirements.txt" }
 
 [project.optional-dependencies]
 voice = [

--- a/walter-bot/requirements.txt
+++ b/walter-bot/requirements.txt
@@ -1,2 +1,0 @@
-aiohttp>=3.7.4,<4
-audioop-lts; python_version>='3.13'


### PR DESCRIPTION
### Motivation
- Centralize runtime dependencies by merging the Discord bot requirements into the main project `requirements.txt` to avoid duplication and simplify installs. 
- Ensure the bot package metadata no longer points to a separate requirements file so packaging info remains valid after removal. 

### Description
- Added `aiohttp>=3.7.4,<4` and `audioop-lts; python_version>='3.13'` to the root `requirements.txt`.
- Removed `walter-bot/requirements.txt` from the repository.
- Updated `walter-bot/pyproject.toml` to inline the bot dependencies under `project.dependencies` and removed the `tool.setuptools.dynamic` reference to the deleted requirements file.
- Committed the changes as a single change set titled "Merge bot requirements into main requirements." 

### Testing
- Ran `git diff --check` to ensure no whitespace or merge conflicts, and it completed successfully.
- Parsed `walter-bot/pyproject.toml` with `tomllib.load(...)` in a short Python script to verify `project.dependencies` contains the inlined bot dependencies, which succeeded.
- Verified `walter-bot/requirements.txt` was removed and the root `requirements.txt` contains the bot dependencies using small Python assertions, which succeeded.
- A direct invocation `python -m tomllib walter-bot/pyproject.toml` was attempted and failed because `tomllib` is not executable that way, and was replaced by the successful `tomllib.load(...)` check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344e40d2a08320b42e256be2f6aebe)