### PR TITLE
Add bot Discord config exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,21 @@ You can still manage the Nginx config manually:
 
 The TLS template lives at `nginx/walter-tls.conf`. It serves HTTPS on port 443 only for configured hostnames, redirects HTTP traffic to the canonical `tls_domain`, rejects TLS handshakes for unknown/default hostnames, leaves `/.well-known/acme-challenge/` available on port 80 for Let's Encrypt renewals, enables TLS 1.2 and TLS 1.3, and uses origin cipher/curve settings that match Cloudflare's current origin connection behavior. TLS 1.2 includes `ECDHE-ECDSA-AES128-GCM-SHA256`, `ECDHE-ECDSA-CHACHA20-POLY1305`, `ECDHE-RSA-AES128-GCM-SHA256`, `ECDHE-RSA-CHACHA20-POLY1305`, `ECDHE-ECDSA-AES256-GCM-SHA384`, and `ECDHE-RSA-AES256-GCM-SHA384`; TLS 1.3 uses the OpenSSL defaults so compatible AES-GCM and ChaCha20-Poly1305 suites remain available. If your certificate lives somewhere other than `/etc/letsencrypt/live/<domain>`, pass `--cert-dir /path/to/live/certdir`; if your ACME challenge webroot differs, pass `--acme-webroot /path/to/webroot`. To include aliases such as `www.tournaments.example.com`, set `tls_additional_domains` in `config.yaml` or pass `--tls-additional-domains www.tournaments.example.com` to the installer; the certificate request and Nginx `server_name` list must match.
 
+
+## Walter bot configuration
+
+Discord application values such as the application ID, public key, client ID, OAuth secret, permissions integer, and target channel should be configured through `config.yaml` only when the bot runtime needs them. The startup scripts export these values to the bot process as environment variables. For production, prefer environment overrides or a secret manager for `bot_token` and `bot_secret_key`.
+
+```yaml
+bot_token: ""
+bot_appid: ""
+bot_pubkey: ""
+bot_client_id: ""
+bot_secret_key: ""
+bot_permissions_int: ""
+bot_channel_id: ""
+```
+
 ## Account verification and invites
 
 Public account registration sends a one-time 6-digit verification PIN through Mailgun before creating the user account. Set these values in `config.yaml` before enabling public self-service registration:

--- a/config.yaml
+++ b/config.yaml
@@ -53,3 +53,12 @@ bot_runtime_error_log_file: walter-bot.err.log
 # Prefer setting this through a secret manager or environment override in
 # production; start-server.* exports it as BOT_TOKEN for the bot process.
 bot_token: ""
+# Optional Discord application/runtime values exported for the bot process.
+# Keep secret values out of source control in production by overriding them
+# through environment variables or a secret manager.
+bot_appid: ""
+bot_pubkey: ""
+bot_client_id: ""
+bot_secret_key: ""
+bot_permissions_int: ""
+bot_channel_id: ""

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -72,6 +72,12 @@ $BotRuntimeArgs = $cfg.bot_runtime_args
 $BotRuntimeLogFile = $cfg.bot_runtime_log_file
 $BotRuntimeErrorLogFile = $cfg.bot_runtime_error_log_file
 $BotToken = $cfg.bot_token
+$BotAppId = $cfg.bot_appid
+$BotPubKey = $cfg.bot_pubkey
+$BotClientId = $cfg.bot_client_id
+$BotSecretKey = $cfg.bot_secret_key
+$BotPermissionsInt = $cfg.bot_permissions_int
+$BotChannelId = $cfg.bot_channel_id
 $newadmin = New-Object System.Management.Automation.PSCredential($cfg.admin_email, (ConvertTo-SecureString $cfg.admin_pass -AsPlainText -Force))
 
 ######enable testing###########
@@ -130,6 +136,12 @@ $env:ACCOUNT_LOCKOUT_ATTEMPTS = $AccountLockoutAttempts
 $env:IP_BLACKLIST_ATTEMPTS = $IpBlacklistAttempts
 $env:PASSWORD_RESET_TTL_MINUTES = $PasswordResetTtlMinutes
 $env:BOT_TOKEN = $BotToken
+$env:BOT_APPID = $BotAppId
+$env:BOT_PUBKEY = $BotPubKey
+$env:BOT_CLIENT_ID = $BotClientId
+$env:BOT_SECRET_KEY = $BotSecretKey
+$env:BOT_PERMISSIONS_INT = $BotPermissionsInt
+$env:BOT_CHANNEL_ID = $BotChannelId
 
 $timestamp = Get-Date -Format "yyyyMMddHHmmss"
 

--- a/start-server.sh
+++ b/start-server.sh
@@ -468,6 +468,12 @@ keys = [
     'bot_runtime_log_file',
     'bot_runtime_error_log_file',
     'bot_token',
+    'bot_appid',
+    'bot_pubkey',
+    'bot_client_id',
+    'bot_secret_key',
+    'bot_permissions_int',
+    'bot_channel_id',
 ]
 
 for key in keys:
@@ -515,6 +521,12 @@ BOT_RUNTIME_ARGS="${BOT_RUNTIME_ARGS:-}"
 BOT_RUNTIME_LOG_FILE="${BOT_RUNTIME_LOG_FILE:-walter-bot.log}"
 BOT_RUNTIME_ERROR_LOG_FILE="${BOT_RUNTIME_ERROR_LOG_FILE:-walter-bot.err.log}"
 BOT_TOKEN="${BOT_TOKEN:-}"
+BOT_APPID="${BOT_APPID:-}"
+BOT_PUBKEY="${BOT_PUBKEY:-}"
+BOT_CLIENT_ID="${BOT_CLIENT_ID:-}"
+BOT_SECRET_KEY="${BOT_SECRET_KEY:-}"
+BOT_PERMISSIONS_INT="${BOT_PERMISSIONS_INT:-}"
+BOT_CHANNEL_ID="${BOT_CHANNEL_ID:-}"
 
 cd "$SCRIPT_DIR"
 
@@ -532,6 +544,12 @@ export ACCOUNT_LOCKOUT_ATTEMPTS
 export IP_BLACKLIST_ATTEMPTS
 export PASSWORD_RESET_TTL_MINUTES
 export BOT_TOKEN
+export BOT_APPID
+export BOT_PUBKEY
+export BOT_CLIENT_ID
+export BOT_SECRET_KEY
+export BOT_PERMISSIONS_INT
+export BOT_CHANNEL_ID
 
 ensure_letsencrypt_certificate
 


### PR DESCRIPTION
### Motivation

- Make Discord application/runtime values available to the bundled bot process when the bot runtime is enabled so the bot can be configured without hard-coding values. 
- Allow startup scripts to export those values as environment variables so the bot runtime can read them securely from the environment. 
- Encourage production usage of environment overrides or a secret manager for sensitive values instead of committing secrets to source.

### Description

- Added optional bot keys to `config.yaml`: `bot_appid`, `bot_pubkey`, `bot_client_id`, `bot_secret_key`, `bot_permissions_int`, and `bot_channel_id`. 
- Updated `start-server.sh` to read those keys from the rendered config output and export them as `BOT_APPID`, `BOT_PUBKEY`, `BOT_CLIENT_ID`, `BOT_SECRET_KEY`, `BOT_PERMISSIONS_INT`, and `BOT_CHANNEL_ID`. 
- Updated `start-server.ps1` to load the same keys from `config.yaml` and set the corresponding environment variables for Windows: `$env:BOT_APPID`, `$env:BOT_PUBKEY`, `$env:BOT_CLIENT_ID`, `$env:BOT_SECRET_KEY`, `$env:BOT_PERMISSIONS_INT`, and `$env:BOT_CHANNEL_ID`. 
- Documented the new bot configuration block and recommended secret management in `README.md` under a new "Walter bot configuration" section.

### Testing

- Ran `bash -n start-server.sh` to validate shell script syntax and it succeeded. 
- Ran a Python validation that loads `config.yaml` and asserts the new bot keys are present, and it succeeded. 
- Attempted a PowerShell tokenization syntax check for `start-server.ps1`, but `pwsh` was not available in the environment so that check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3452e7e8b48320881ef1248dfcbada)

## Summary by Sourcery

Add configurable Discord bot application values and expose them to the bot runtime via environment variables.

New Features:
- Introduce optional Discord bot configuration keys in config.yaml for application and runtime values.
- Export configured Discord bot values as environment variables in Unix and Windows startup scripts for the bot process to consume.

Documentation:
- Document Discord bot configuration options and recommended secret management practices in the README.