### PR TITLE
Start configured Discord bot automatically

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,9 +69,13 @@ The TLS template lives at `nginx/walter-tls.conf`. It serves HTTPS on port 443 o
 
 ## Walter bot configuration
 
-Discord application values such as the application ID, public key, client ID, OAuth secret, permissions integer, and target channel should be configured through `config.yaml` only when the bot runtime needs them. The startup scripts export these values to the bot process as environment variables. For production, prefer environment overrides or a secret manager for `bot_token` and `bot_secret_key`.
+Discord application values such as the application ID, public key, client ID, OAuth secret, permissions integer, and target channel should be configured through `config.yaml` only when the bot runtime needs them. The startup scripts export these values to the bot process as environment variables. When `bot_runtime_enabled` is `auto`, `start-server.sh` and `start-server.ps1` start the bot after Waitress whenever exactly one of `bot_runtime_module` or `bot_runtime_script` is configured. Set `bot_runtime_enabled` to `false` to disable startup even when a runtime target is configured. For production, prefer environment overrides or a secret manager for `bot_token` and `bot_secret_key`.
 
 ```yaml
+bot_runtime_enabled: auto
+bot_runtime_module: ""
+bot_runtime_script: ""
+bot_runtime_args: ""
 bot_token: ""
 bot_appid: ""
 bot_pubkey: ""

--- a/config.yaml
+++ b/config.yaml
@@ -41,10 +41,11 @@ bot_install_editable: true
 # Optional package extras without brackets, for example: voice,speed
 bot_install_extras: ""
 
-# Optional Walter bot runtime settings. Enable this to start a bot process after
-# Waitress starts. Configure exactly one of bot_runtime_module or
-# bot_runtime_script, then place any extra CLI flags in bot_runtime_args.
-bot_runtime_enabled: false
+# Optional Walter bot runtime settings. Set bot_runtime_enabled to auto to
+# start a bot process whenever bot_runtime_module or bot_runtime_script is
+# configured. Configure exactly one runtime target, then place any extra CLI
+# flags in bot_runtime_args. Set bot_runtime_enabled to false to disable it.
+bot_runtime_enabled: auto
 bot_runtime_module: ""
 bot_runtime_script: ""
 bot_runtime_args: ""

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -98,7 +98,7 @@ if([string]::IsNullOrEmpty($PasswordResetTtlMinutes)){ $PasswordResetTtlMinutes 
 if($null -eq $BotInstallEnabled){ $BotInstallEnabled = $false }
 if([string]::IsNullOrEmpty($BotInstallPath)){ $BotInstallPath = "walter-bot" }
 if($null -eq $BotInstallEditable){ $BotInstallEditable = $true }
-if($null -eq $BotRuntimeEnabled){ $BotRuntimeEnabled = $false }
+if($null -eq $BotRuntimeEnabled){ $BotRuntimeEnabled = "auto" }
 if([string]::IsNullOrEmpty($BotRuntimeLogFile)){ $BotRuntimeLogFile = "walter-bot.log" }
 if([string]::IsNullOrEmpty($BotRuntimeErrorLogFile)){ $BotRuntimeErrorLogFile = "walter-bot.err.log" }
 
@@ -178,6 +178,14 @@ python -m flask --app app.app db-init
 Write-Host "Creating default admin user..."
 python -m flask --app app.app create-admin --email $newadmin.UserName --password $newadmin.GetNetworkCredential().Password
 
+function Test-BotRuntimeShouldStart {
+    $mode = [string]$BotRuntimeEnabled
+    if([string]::IsNullOrWhiteSpace($mode) -or $mode.ToLowerInvariant() -eq "auto"){
+        return (-not [string]::IsNullOrEmpty($BotRuntimeModule) -or -not [string]::IsNullOrEmpty($BotRuntimeScript))
+    }
+    return ($mode.ToLowerInvariant() -in @("1", "true", "yes", "y", "on"))
+}
+
 Write-Host "Starting Waitress server..."
 $waitressLog = Join-Path $PSScriptRoot "waitress-server.log"
 $waitressErrorLog = Join-Path $PSScriptRoot "waitress-server.err.log"
@@ -185,7 +193,7 @@ $waitressArgs = @("-m", "waitress", "--host=$FlaskIP", "--port=$FlaskPort", "app
 Start-Process -NoNewWindow -FilePath "python" -ArgumentList $waitressArgs -RedirectStandardOutput $waitressLog -RedirectStandardError $waitressErrorLog
 Write-Host "Waitress server started. Logs: $waitressLog; errors: $waitressErrorLog"
 
-if($BotRuntimeEnabled){
+if(Test-BotRuntimeShouldStart){
     if(-not [string]::IsNullOrEmpty($BotRuntimeModule) -and -not [string]::IsNullOrEmpty($BotRuntimeScript)){
         Write-Error "Only one of bot_runtime_module or bot_runtime_script may be configured."
         exit 1

--- a/start-server.sh
+++ b/start-server.sh
@@ -514,7 +514,7 @@ BOT_INSTALL_ENABLED="${BOT_INSTALL_ENABLED:-false}"
 BOT_INSTALL_PATH="${BOT_INSTALL_PATH:-walter-bot}"
 BOT_INSTALL_EDITABLE="${BOT_INSTALL_EDITABLE:-true}"
 BOT_INSTALL_EXTRAS="${BOT_INSTALL_EXTRAS:-}"
-BOT_RUNTIME_ENABLED="${BOT_RUNTIME_ENABLED:-false}"
+BOT_RUNTIME_ENABLED="${BOT_RUNTIME_ENABLED:-auto}"
 BOT_RUNTIME_MODULE="${BOT_RUNTIME_MODULE:-}"
 BOT_RUNTIME_SCRIPT="${BOT_RUNTIME_SCRIPT:-}"
 BOT_RUNTIME_ARGS="${BOT_RUNTIME_ARGS:-}"
@@ -652,6 +652,19 @@ for pid in sorted(pids):
         pass
 PY
 
+should_start_bot_runtime() {
+  local mode="${BOT_RUNTIME_ENABLED,,}"
+
+  case "$mode" in
+    auto|"")
+      [[ -n "$BOT_RUNTIME_MODULE" || -n "$BOT_RUNTIME_SCRIPT" ]]
+      ;;
+    *)
+      is_truthy "$BOT_RUNTIME_ENABLED"
+      ;;
+  esac
+}
+
 printf 'Initializing database...\n'
 "$PYTHON_BIN" -m flask --app app.app db-init
 
@@ -663,7 +676,7 @@ nohup "$PYTHON_BIN" -m waitress --host="$FLASK_IP" --port="$FLASK_PORT" app.app:
 WAITRESS_PID=$!
 printf 'Waitress server started with PID %s. Logs: %s\n' "$WAITRESS_PID" "$SCRIPT_DIR/waitress-server.log"
 
-if is_truthy "$BOT_RUNTIME_ENABLED"; then
+if should_start_bot_runtime; then
   if [[ -n "$BOT_RUNTIME_MODULE" && -n "$BOT_RUNTIME_SCRIPT" ]]; then
     echo "Only one of bot_runtime_module or bot_runtime_script may be configured." >&2
     exit 1


### PR DESCRIPTION
### Motivation
- Make the bundled server startup scripts able to auto-start the bundled Discord bot whenever a runtime target is configured, so users don't need to flip a separate boolean to run the bot.
- Keep explicit `true`/`false` behavior possible while providing a convenient default for the shipped sample config.

### Description
- Change default sample config to set `bot_runtime_enabled: auto` and keep `bot_runtime_module`, `bot_runtime_script`, and `bot_runtime_args` present in `config.yaml`.
- Add `should_start_bot_runtime()` to `start-server.sh` and call it in place of the previous truthy check so `auto` starts the bot only when `BOT_RUNTIME_MODULE` or `BOT_RUNTIME_SCRIPT` is configured while preserving explicit truthy values.
- Add `Test-BotRuntimeShouldStart` function to `start-server.ps1` and use it to mirror the same `auto` behavior in the PowerShell startup path.
- Update `README.md` to document the new `bot_runtime_enabled: auto` behavior and show the runtime-related config keys in the example snippet.

### Testing
- Ran `bash -n start-server.sh` to validate shell syntax and it succeeded.
- Ran a small Python YAML check to assert `config.yaml` now contains `bot_runtime_enabled: 'auto'` and it succeeded (`config yaml ok`).
- Ran `git diff --check` and repository checks passed.
- PowerShell syntax check with `pwsh` was attempted but skipped because `pwsh` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3454abfbdc8320909e917ccc7fa00a)

## Summary by Sourcery

Default the Discord bot runtime to an auto-start mode and update startup scripts and documentation to reflect the new behavior.

New Features:
- Introduce an auto mode for the Discord bot runtime that starts the bot whenever a runtime module or script is configured.

Enhancements:
- Update shell and PowerShell startup scripts to use helper functions that decide whether to start the bot based on the new auto mode and existing truthy checks.
- Adjust the sample configuration to use bot_runtime_enabled: auto while keeping runtime-related keys present for easier setup.
- Document the new bot auto-start behavior and runtime configuration keys in the README.