### PR TITLE
Fix vendored Discord bot import

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -10,8 +10,14 @@ from __future__ import annotations
 
 import asyncio
 import os
+import sys
+from pathlib import Path
 from typing import Any
 from urllib import error, request
+
+VENDORED_DISCORD_PATH = Path(__file__).resolve().parent / 'walter-bot'
+if VENDORED_DISCORD_PATH.is_dir():
+    sys.path.insert(0, str(VENDORED_DISCORD_PATH))
 
 import discord
 from discord import app_commands


### PR DESCRIPTION
### Motivation
- Make the included read-only Discord bot runnable using the repository's vendored `walter-bot` package so a separate `discord.py` installation is not required.
- Avoid import-time failures when the vendored package is present but not installed into the environment.

### Description
- Import `sys` and `Path` and compute `VENDORED_DISCORD_PATH = Path(__file__).resolve().parent / 'walter-bot'`.
- Prepend the vendored directory to `sys.path` when it exists, before `import discord` so the bundled `discord` package is used.
- Change is limited to `discord_bot.py` and is guarded by `is_dir()` to avoid affecting other environments.

### Testing
- Ran `python -m compileall discord_bot.py` and it completed successfully.
- Ran `python -c "import discord_bot; assert 'walter-bot/discord' in discord_bot.discord.__file__.replace('\\\\','/'); print(discord_bot.discord.__file__)"` and the assertion passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a345ec88de88320a03d678c8762fc8e)

## Summary by Sourcery

Ensure the bundled Discord bot uses the vendored walter-bot Discord package when available to avoid requiring a separate discord.py installation and to prevent import-time failures when the vendored package is present but not installed into the environment.

New Features:
- Enable the read-only Discord bot to run using the repository's vendored walter-bot Discord package when present.

Bug Fixes:
- Prevent import-time failures when the vendored walter-bot package directory exists but is not installed into the Python environment.