### PR TITLE
Install aiohttp fallback in start-server scripts

### DIFF
--- a/start-server.ps1
+++ b/start-server.ps1
@@ -171,6 +171,15 @@ $env:MTG_LOG_DB_PATH = $LogDatabasePath
 Write-Host "Installing dependencies..."
 python -m pip install -r "$PSScriptRoot/requirements.txt" | Out-Null
 
+# The vendored discord.py package is imported directly by discord_bot.py, so
+# make sure its third-party runtime dependency is present even if an existing
+# environment was created before aiohttp was added to requirements.txt.
+python -c "import aiohttp" 2>$null
+if($LASTEXITCODE -ne 0){
+    Write-Host "Installing missing Discord bot dependency aiohttp..."
+    python -m pip install 'aiohttp>=3.7.4,<4' | Out-Null
+}
+
 if($BotInstallEnabled){
     $botInstallTarget = $BotInstallPath
     if(-not [string]::IsNullOrEmpty($BotInstallExtras)){ $botInstallTarget = "$botInstallTarget[$BotInstallExtras]" }

--- a/start-server.sh
+++ b/start-server.sh
@@ -587,6 +587,17 @@ export MTG_LOG_DB_PATH="$LOG_DB_FILE"
 printf 'Installing dependencies...\n'
 "$PYTHON_BIN" -m pip install -r "$REQUIREMENTS_FILE" >/dev/null
 
+# The vendored discord.py package is imported directly by discord_bot.py, so
+# make sure its third-party runtime dependency is present even if an existing
+# virtualenv was created before aiohttp was added to requirements.txt.
+if ! "$PYTHON_BIN" - <<'PY' >/dev/null 2>&1
+import aiohttp  # noqa: F401
+PY
+then
+  printf 'Installing missing Discord bot dependency aiohttp...\n'
+  "$PYTHON_BIN" -m pip install 'aiohttp>=3.7.4,<4' >/dev/null
+fi
+
 if is_truthy "$BOT_INSTALL_ENABLED"; then
   bot_install_target="$BOT_INSTALL_PATH"
   if [[ -n "$BOT_INSTALL_EXTRAS" ]]; then


### PR DESCRIPTION
### Motivation
- Ensure the vendored `discord.py` import in `discord_bot.py` does not fail with `ModuleNotFoundError: No module named 'aiohttp'` when an existing environment was created before `aiohttp` was added to `requirements.txt`.

### Description
- Add a post-`requirements.txt` import check in `start-server.sh` and `start-server.ps1` that attempts `import aiohttp` and, if it fails, installs `aiohttp>=3.7.4,<4` via `pip` so the Discord bot runtime dependency is present.

### Testing
- Ran `bash -n start-server.sh` and a small Python check that verifies the new `aiohttp` fallback lines are present in both `start-server.sh` and `start-server.ps1`, and both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a346064e39c832094af34ace850daec)

## Summary by Sourcery

Ensure the start-server scripts always provide the aiohttp runtime dependency required by the Discord bot, even for preexisting environments.

New Features:
- Add an automatic aiohttp installation check to the Unix start-server script to satisfy the Discord bot dependency when missing.
- Add an automatic aiohttp installation check to the Windows start-server PowerShell script to satisfy the Discord bot dependency when missing.