### PR TITLE
Handle missing audioop in vendored Discord player

### DIFF
--- a/walter-bot/discord/player.py
+++ b/walter-bot/discord/player.py
@@ -27,7 +27,10 @@ from __future__ import annotations
 import threading
 import subprocess
 import warnings
-import audioop
+try:
+    import audioop
+except ModuleNotFoundError:  # pragma: no cover - depends on Python version/runtime deps
+    audioop = None
 import asyncio
 import logging
 import shlex
@@ -54,6 +57,22 @@ if TYPE_CHECKING:
 AT = TypeVar('AT', bound='AudioSource')
 
 _log = logging.getLogger(__name__)
+
+
+def _mul_pcm16(data: bytes, factor: float) -> bytes:
+    """Scale little-endian signed 16-bit PCM samples without audioop."""
+
+    if len(data) % 2:
+        raise ValueError('not a whole number of frames')
+
+    output = bytearray(len(data))
+    for index in range(0, len(data), 2):
+        sample = int.from_bytes(data[index:index + 2], 'little', signed=True)
+        scaled = int(sample * factor)
+        scaled = max(-32768, min(32767, scaled))
+        output[index:index + 2] = scaled.to_bytes(2, 'little', signed=True)
+    return bytes(output)
+
 
 __all__ = (
     'AudioSource',
@@ -754,6 +773,8 @@ class PCMVolumeTransformer(AudioSource, Generic[AT]):
 
     def read(self) -> bytes:
         ret = self.original.read()
+        if audioop is None:
+            return _mul_pcm16(ret, min(self._volume, 2.0))
         return audioop.mul(ret, 2, min(self._volume, 2.0))
 
 


### PR DESCRIPTION
### Motivation
- The vendored Discord `player` module could fail to import on Python runtimes that no longer provide the deprecated `audioop` module, breaking bot startup. 
- Provide a small, safe fallback so `PCMVolumeTransformer` continues to work even when `audioop` is unavailable.

### Description
- Wrap the `audioop` import in a `try/except ModuleNotFoundError` and set `audioop = None` when missing. 
- Add a `_mul_pcm16(data, factor)` helper that scales little-endian signed 16-bit PCM samples without `audioop`. 
- Use the `_mul_pcm16` fallback inside `PCMVolumeTransformer.read` whenever `audioop is None` and otherwise defer to `audioop.mul`.

### Testing
- Successfully ran `python -m py_compile discord_bot.py walter-bot/discord/player.py`. 
- Executed an import/runtime check with a short Python snippet that imports the vendored `discord` package and asserts `_mul_pcm16((1000).to_bytes(2, 'little', signed=True), 2.0) == (2000).to_bytes(2, 'little', signed=True)`, which passed. 
- Ran `git diff --check` to validate there are no whitespace or diff issues, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34614646708320a767080cdc404808)

## Summary by Sourcery

Handle the absence of the deprecated audioop module so the Discord PCM volume transformer continues to work on runtimes where audioop is unavailable.

Bug Fixes:
- Prevent Discord audio player startup failures on Python runtimes that do not provide the audioop module by falling back to a pure-Python PCM scaler.

Enhancements:
- Add a pure-Python helper to scale 16-bit PCM audio samples and route PCMVolumeTransformer through it when audioop is missing.