### PR TITLE
Announce Discord bot readiness in configured channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,14 @@ bot_client_id: ""
 bot_secret_key: ""
 bot_permissions_int: ""
 bot_channel_id: ""
+bot_announce_ready: true
 ```
 
 For the included read-only Discord bot, create an administrator API key from
 Settings, set `bot_runtime_script: "discord_bot.py"`, set `bot_api_key` to that
 one-time key value, and set `bot_token` to the Discord bot token. The bot
 registers slash commands for listing tournaments, standings, and latest-round
-pairings. If `bot_channel_id` and `bot_poll_tournament_id` are set, it also polls
-for newly paired rounds and posts pairings to that channel.
+pairings. If `bot_channel_id` is set, it posts a startup message to that channel so you can verify the bot can write to the chat; set `bot_announce_ready: false` to suppress that message. If `bot_channel_id` and `bot_poll_tournament_id` are set, it also polls for newly paired rounds and posts pairings to that channel.
 
 ## Account verification and invites
 

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -29,6 +29,7 @@ BOT_API_BASE_URL = os.environ.get('BOT_API_BASE_URL', 'http://127.0.0.1:5000').s
 BOT_API_KEY = os.environ.get('BOT_API_KEY', '').strip()
 BOT_POLL_TOURNAMENT_ID = os.environ.get('BOT_POLL_TOURNAMENT_ID', '').strip()
 BOT_POLL_INTERVAL_SECONDS = int(os.environ.get('BOT_POLL_INTERVAL_SECONDS', '30') or 30)
+BOT_ANNOUNCE_READY = os.environ.get('BOT_ANNOUNCE_READY', 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
 
 
 class WalterApiError(RuntimeError):
@@ -124,24 +125,48 @@ class WalterBot(discord.Client):
         self.tree = app_commands.CommandTree(self)
         self.api = WalterApiClient(BOT_API_BASE_URL, BOT_API_KEY)
         self._last_announced_round: int | None = None
+        self._ready_announced = False
 
     async def setup_hook(self):
-        await self.tree.sync()
+        synced_commands = await self.tree.sync()
+        print(f'Synced {len(synced_commands)} Discord slash command(s).')
         if BOT_CHANNEL_ID and BOT_POLL_TOURNAMENT_ID:
             self.loop.create_task(self._poll_pairings())
+        elif BOT_CHANNEL_ID:
+            print('BOT_CHANNEL_ID is configured, but BOT_POLL_TOURNAMENT_ID is not; automatic pairing posts are disabled.')
+        else:
+            print('BOT_CHANNEL_ID is not configured; the bot cannot post messages to a Discord channel.')
 
     async def on_ready(self):
         assert self.user is not None
         print(f'Logged in as {self.user} (ID: {self.user.id})')
+        print(f'Connected to {len(self.guilds)} Discord server(s).')
         print(f'Walter API: {BOT_API_BASE_URL}')
+
+        if BOT_CHANNEL_ID and BOT_ANNOUNCE_READY and not self._ready_announced:
+            channel = await self._get_messageable_channel(BOT_CHANNEL_ID)
+            if channel is not None:
+                await channel.send('Walter bot is online. Use `/tournaments`, `/standings`, or `/pairings` to get tournament updates.')
+                self._ready_announced = True
+
+    async def _get_messageable_channel(self, channel_id: str) -> discord.abc.Messageable | None:
+        try:
+            channel = self.get_channel(int(channel_id))
+            if channel is None:
+                channel = await self.fetch_channel(int(channel_id))
+        except (TypeError, ValueError, discord.DiscordException) as exc:
+            print(f'Could not resolve BOT_CHANNEL_ID={channel_id}: {exc}')
+            return None
+
+        if not isinstance(channel, discord.abc.Messageable):
+            print(f'Configured BOT_CHANNEL_ID={channel_id} is not messageable.')
+            return None
+        return channel
 
     async def _poll_pairings(self):
         await self.wait_until_ready()
-        channel = self.get_channel(int(BOT_CHANNEL_ID))
+        channel = await self._get_messageable_channel(BOT_CHANNEL_ID)
         if channel is None:
-            channel = await self.fetch_channel(int(BOT_CHANNEL_ID))
-        if not isinstance(channel, discord.abc.Messageable):
-            print(f'Configured BOT_CHANNEL_ID={BOT_CHANNEL_ID} is not messageable.')
             return
 
         tournament_id = int(BOT_POLL_TOURNAMENT_ID)

--- a/start-server.sh
+++ b/start-server.sh
@@ -478,6 +478,7 @@ keys = [
     'bot_secret_key',
     'bot_permissions_int',
     'bot_channel_id',
+    'bot_announce_ready',
 ]
 
 for key in keys:
@@ -535,6 +536,7 @@ BOT_CLIENT_ID="${BOT_CLIENT_ID:-}"
 BOT_SECRET_KEY="${BOT_SECRET_KEY:-}"
 BOT_PERMISSIONS_INT="${BOT_PERMISSIONS_INT:-}"
 BOT_CHANNEL_ID="${BOT_CHANNEL_ID:-}"
+BOT_ANNOUNCE_READY="${BOT_ANNOUNCE_READY:-true}"
 
 cd "$SCRIPT_DIR"
 
@@ -562,6 +564,7 @@ export BOT_CLIENT_ID
 export BOT_SECRET_KEY
 export BOT_PERMISSIONS_INT
 export BOT_CHANNEL_ID
+export BOT_ANNOUNCE_READY
 
 ensure_letsencrypt_certificate
 


### PR DESCRIPTION
### Motivation
- Make it obvious in Discord when the read-only bot is present and can write to the configured channel by posting a startup message. 
- Improve diagnostics for common setup issues (missing channel, invalid ID, permission/invite problems) so operators can more quickly identify why the bot appears inactive. 
- Expose the behavior as a configurable option so deployments can opt out of the startup announcement.

### Description
- Add `BOT_ANNOUNCE_READY` (env var) and default wiring via `bot_announce_ready` in `config.yaml`/startup so the option is configurable; changes in `start-server.sh` export the variable. 
- In `discord_bot.py` add a `_get_messageable_channel` helper, use it for both the ready announcement and pairing poll path, and send a startup message in `on_ready` when `BOT_CHANNEL_ID` and `BOT_ANNOUNCE_READY` are set. 
- Log slash-command sync counts and connected guild count in `setup_hook`/`on_ready` and print clearer messages when `BOT_CHANNEL_ID` or `BOT_POLL_TOURNAMENT_ID` are missing to aid debugging. 
- Update `README.md` bot configuration section to document `bot_announce_ready` and the new startup-message behavior.

### Testing
- Ran `python -m py_compile discord_bot.py` and the module compiled successfully. 
- Ran shell syntax check via `bash -n start-server.sh` and the startup script passed the syntax check.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34659c43448320815f6be4f3149d20)

## Summary by Sourcery

Announce the Discord bot’s readiness in the configured channel and improve observability and configurability of its startup and pairing behavior.

New Features:
- Add a configurable BOT_ANNOUNCE_READY option (via environment variable and config) to control whether the Discord bot posts a startup message in the configured channel.
- Send a readiness message to the configured Discord channel when the bot comes online and the feature is enabled.

Enhancements:
- Introduce a shared helper to resolve a messageable Discord channel and reuse it for startup announcements and pairing polls.
- Log the number of synced slash commands, connected guilds, and clearer diagnostics when BOT_CHANNEL_ID or BOT_POLL_TOURNAMENT_ID are missing.

Build:
- Update the startup script to read, default, and export the bot_announce_ready setting into the BOT_ANNOUNCE_READY environment variable.

Documentation:
- Document the bot_announce_ready option and the bot’s startup message behavior in the README.