### PR TITLE
Add Discord pairing reporting authorization

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -424,6 +424,15 @@ def create_app():
                 db.session.execute(text("ALTER TABLE user ADD COLUMN color_mode VARCHAR(10) DEFAULT 'light'"))
                 db.session.execute(text("UPDATE user SET color_mode='light' WHERE color_mode IS NULL"))
                 db.session.commit()
+            if 'discord_username' not in columns:
+                db.session.execute(text('ALTER TABLE user ADD COLUMN discord_username VARCHAR(120)'))
+                db.session.commit()
+            if 'discord_user_id' not in columns:
+                db.session.execute(text('ALTER TABLE user ADD COLUMN discord_user_id VARCHAR(32)'))
+                db.session.commit()
+            if 'discord_authorization_token_hash' not in columns:
+                db.session.execute(text('ALTER TABLE user ADD COLUMN discord_authorization_token_hash VARCHAR(64)'))
+                db.session.commit()
 
         BadLoginAttempt.__table__.create(bind=db.engine, checkfirst=True)
         inspector = inspect(db.engine)
@@ -1805,6 +1814,9 @@ def create_app():
     def user_payload(user):
         return {'id': user.id, 'name': user.name, 'email': user.email or '', 'role': user.role.name if user.role else None, 'is_admin': bool(user.is_admin)}
 
+    def _normalize_discord_username(value):
+        return (value or '').strip().lstrip('@')
+
     def tournament_payload(t):
         return {'id': t.id, 'name': t.name, 'format': t.format, 'structure': t.structure, 'start_time': t.start_time.isoformat() if t.start_time else None, 'league_id': t.league_id, 'venue_id': t.venue_id}
 
@@ -1860,6 +1872,7 @@ def create_app():
     @login_required
     def user_settings():
         new_api_key = None
+        new_discord_pass = None
         if request.method == 'POST':
             action = request.form.get('action')
             if action == 'appearance':
@@ -1870,6 +1883,20 @@ def create_app():
                 db.session.commit()
                 flash('Settings saved.', 'success')
                 return redirect(url_for('user_settings'))
+            if action == 'discord_connection':
+                discord_username = _normalize_discord_username(request.form.get('discord_username'))
+                if len(discord_username) > 120:
+                    discord_username = discord_username[:120]
+                current_user.discord_username = discord_username or None
+                if request.form.get('generate_discord_pass') == '1':
+                    new_discord_pass = secrets.token_urlsafe(8)
+                    current_user.set_discord_authorization_token(new_discord_pass)
+                    current_user.discord_user_id = None
+                    flash('Discord connection pass generated. Use it with /authorize in Discord.', 'success')
+                else:
+                    flash('Discord settings saved.', 'success')
+                db.session.commit()
+                log_site('discord_settings_update', 'success', f'user_id={current_user.id}')
             if action == 'api_key':
                 if not current_user.has_permission('admin.api_keys'):
                     log_site('api_key_create', 'failure', 'missing admin.api_keys')
@@ -1881,7 +1908,13 @@ def create_app():
                 log_site('api_key_create', 'success', f'api_key_name={name}')
                 new_api_key = token
         keys = db.session.query(ApiKey).filter_by(user_id=current_user.id).order_by(ApiKey.created_at.desc()).all()
-        return render_template('user_settings.html', api_keys=keys, new_api_key=new_api_key, selected_color_mode=site_theme())
+        return render_template(
+            'user_settings.html',
+            api_keys=keys,
+            new_api_key=new_api_key,
+            new_discord_pass=new_discord_pass,
+            selected_color_mode=site_theme(),
+        )
 
     @app.route('/settings/api-keys/<int:key_id>/revoke', methods=['POST'])
     @login_required
@@ -2048,6 +2081,87 @@ def create_app():
             'tournament': tournament_payload(tournament),
             'round': round_payload(round_obj),
         })
+
+    @app.route('/api/v1/discord/authorize', methods=['POST'])
+    def api_discord_authorize():
+        require_api_permission('tournaments.manage')
+        data = request.get_json(silent=True) or {}
+        discord_user_id = str(data.get('discord_user_id') or '').strip()
+        discord_username = _normalize_discord_username(data.get('discord_username'))
+        one_time_pass = str(data.get('one_time_pass') or '').strip()
+        if not discord_user_id or not one_time_pass:
+            return _json_error('discord_user_id and one_time_pass are required')
+        user = None
+        for candidate in db.session.query(User).filter(User.discord_authorization_token_hash.isnot(None)).all():
+            if candidate.check_discord_authorization_token(one_time_pass):
+                user = candidate
+                break
+        if not user:
+            _api_log('discord.authorize', 'failure', 'invalid pass')
+            return _json_error('invalid or expired one-time pass', 403)
+        if not user.discord_username:
+            return _json_error('add your Discord username in Walter user settings before authorizing', 403)
+        if discord_username and user.discord_username.lower() != discord_username.lower():
+            return _json_error('Discord username does not match Walter user settings', 403)
+        existing = db.session.query(User).filter(User.discord_user_id == discord_user_id, User.id != user.id).first()
+        if existing:
+            return _json_error('Discord account is already connected to another Walter user', 409)
+        user.discord_user_id = discord_user_id
+        user.discord_authorization_token_hash = None
+        db.session.commit()
+        _api_log('discord.authorize', 'success', f'user_id={user.id}')
+        return jsonify({'authorized': True, 'user': user_payload(user)})
+
+    @app.route('/api/v1/discord/report-pairing', methods=['POST'])
+    def api_discord_report_pairing():
+        require_api_permission('tournaments.manage')
+        data = request.get_json(silent=True) or {}
+        discord_user_id = str(data.get('discord_user_id') or '').strip()
+        tournament_id = data.get('tournament_id')
+        table_number = data.get('table_number')
+        if not discord_user_id or tournament_id is None or table_number is None:
+            return _json_error('discord_user_id, tournament_id, and table_number are required')
+        user = db.session.query(User).filter_by(discord_user_id=discord_user_id).first()
+        if not user or not user.discord_username:
+            return _json_error('Discord account is not authorized with a Walter user that has a Discord username', 403)
+        tournament = db.session.get(Tournament, int(tournament_id))
+        if not tournament:
+            return _json_error('tournament not found', 404)
+        round_obj = (
+            db.session.query(Round)
+            .filter_by(tournament_id=tournament.id)
+            .order_by(Round.number.desc())
+            .first()
+        )
+        if not round_obj:
+            return _json_error('no active round found', 404)
+        match = db.session.query(Match).filter_by(round_id=round_obj.id, table_number=int(table_number)).first()
+        if not match:
+            return _json_error('table not found in the latest round', 404)
+        participant_ids = {
+            player.user_id for player in (match.player1, match.player2, match.player3, match.player4) if player
+        }
+        if user.id not in participant_ids:
+            return _json_error('only a player in this pairing can report it from Discord', 403)
+        next_round = db.session.query(Round).filter(Round.tournament_id == tournament.id, Round.number > round_obj.number).first()
+        if next_round:
+            return _json_error('cannot modify result after next round has been paired', 409)
+        if tournament.format.lower() == 'commander':
+            return _json_error('Commander pairing reports are not supported from Discord yet', 400)
+        try:
+            p1_wins = int(data.get('player1_wins', 0))
+            p2_wins = int(data.get('player2_wins', 0))
+            draws = int(data.get('draws', 0))
+        except (TypeError, ValueError):
+            return _json_error('wins and draws must be whole numbers')
+        if min(p1_wins, p2_wins, draws) < 0:
+            return _json_error('wins and draws cannot be negative')
+        match.result = MatchResult(player1_wins=p1_wins, player2_wins=p2_wins, draws=draws)
+        match.completed = True
+        db.session.commit()
+        log_tournament(tournament.id, 'discord_report', 'success', f'user_id={user.id}; match_id={match.id}')
+        _api_log('discord.report_pairing', 'success', f'tournament_id={tournament.id}; match_id={match.id}; user_id={user.id}')
+        return jsonify({'reported': True, 'match': match_payload(match), 'round': round_payload(round_obj)})
 
     @app.route('/api/v1/leagues/<int:league_id>', methods=['GET', 'PATCH', 'DELETE'])
     def api_league_detail(league_id):

--- a/app/models.py
+++ b/app/models.py
@@ -128,6 +128,24 @@ class User(db.Model, UserMixin):
     locked_at = db.Column(db.DateTime, nullable=True)
     lock_reason = db.Column(db.Text, nullable=True)
     color_mode = db.Column(db.String(10), nullable=False, default='light')
+    discord_username = db.Column(db.String(120), nullable=True)
+    discord_user_id = db.Column(db.String(32), unique=True, nullable=True)
+    discord_authorization_token_hash = db.Column(db.String(64), nullable=True)
+
+    @staticmethod
+    def hash_discord_authorization_token(token):
+        return hashlib.sha256(token.encode()).hexdigest()
+
+    def set_discord_authorization_token(self, token):
+        self.discord_authorization_token_hash = self.hash_discord_authorization_token(token)
+
+    def check_discord_authorization_token(self, token):
+        if not self.discord_authorization_token_hash:
+            return False
+        return secrets.compare_digest(
+            self.discord_authorization_token_hash,
+            self.hash_discord_authorization_token(token),
+        )
 
     def set_password(self, pw, *, unlock=True):
         self.salt = 'werkzeug'

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -23,6 +23,35 @@
 </section>
 
 <section class="panel-card">
+  <h3>Discord Bot Connection</h3>
+  <p class="muted">Add your Discord username, then generate a one-time pass and use it with <strong>/authorize</strong> in Discord before reporting tournament pairings with the bot.</p>
+  {% if new_discord_pass %}
+    <div class="flash success">
+      Copy this one-time Discord pass now. It will not be shown again:<br>
+      <code>{{ new_discord_pass }}</code>
+    </div>
+  {% endif %}
+  <form method="post" class="stacked-form">
+    <input type="hidden" name="action" value="discord_connection">
+    <label>Discord username
+      <input type="text" name="discord_username" maxlength="120" value="{{ current_user.discord_username or '' }}" placeholder="discord_username">
+    </label>
+    <p class="muted">
+      Status:
+      {% if current_user.discord_user_id %}
+        Connected to Discord user ID <code>{{ current_user.discord_user_id }}</code>.
+      {% else %}
+        Not connected.
+      {% endif %}
+    </p>
+    <div class="form-actions">
+      <button class="btn" type="submit">Save Discord Username</button>
+      <button class="btn btn-secondary" type="submit" name="generate_discord_pass" value="1">Generate One-Time Pass</button>
+    </div>
+  </form>
+</section>
+
+<section class="panel-card">
   <h3>API Keys</h3>
   {% if current_user.has_permission('admin.api_keys') %}
     {% if new_api_key %}

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -1,4 +1,4 @@
-"""Read-only Discord bot for Walter tournament updates.
+"""Discord bot for Walter tournament updates and player result reporting.
 
 The bot talks to the Walter site through the API key exported by the startup
 scripts. It only calls read endpoints and exposes slash commands for standings
@@ -44,6 +44,9 @@ class WalterApiClient:
     async def get_json(self, path: str) -> dict[str, Any]:
         return await asyncio.to_thread(self._get_json_sync, path)
 
+    async def post_json(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        return await asyncio.to_thread(self._post_json_sync, path, payload)
+
     def _get_json_sync(self, path: str) -> dict[str, Any]:
         url = f'{self.base_url}{path}'
         headers = {
@@ -63,6 +66,27 @@ class WalterApiClient:
         except error.URLError as exc:
             raise WalterApiError(f'Could not reach Walter API: {exc.reason}') from exc
 
+    def _post_json_sync(self, path: str, payload: dict[str, Any]) -> dict[str, Any]:
+        import json
+
+        url = f'{self.base_url}{path}'
+        body = json.dumps(payload).encode('utf-8')
+        headers = {
+            'Accept': 'application/json',
+            'Authorization': f'Bearer {self.api_key}',
+            'Content-Type': 'application/json',
+            'User-Agent': 'WalterDiscordBot/1.0',
+        }
+        api_request = request.Request(url, data=body, headers=headers, method='POST')
+        try:
+            with request.urlopen(api_request, timeout=10) as response:
+                return json.loads(response.read().decode('utf-8'))
+        except error.HTTPError as exc:
+            detail = exc.read().decode('utf-8', errors='replace')
+            raise WalterApiError(f'Walter API returned HTTP {exc.code}: {detail}') from exc
+        except error.URLError as exc:
+            raise WalterApiError(f'Could not reach Walter API: {exc.reason}') from exc
+
     async def tournaments(self) -> dict[str, Any]:
         return await self.get_json('/api/v1/tournaments')
 
@@ -71,6 +95,31 @@ class WalterApiClient:
 
     async def latest_round(self, tournament_id: int) -> dict[str, Any]:
         return await self.get_json(f'/api/v1/tournaments/{tournament_id}/rounds/latest')
+
+    async def authorize_discord_user(self, discord_user_id: int, discord_username: str, one_time_pass: str) -> dict[str, Any]:
+        return await self.post_json('/api/v1/discord/authorize', {
+            'discord_user_id': str(discord_user_id),
+            'discord_username': discord_username,
+            'one_time_pass': one_time_pass,
+        })
+
+    async def report_pairing(
+        self,
+        discord_user_id: int,
+        tournament_id: int,
+        table_number: int,
+        player1_wins: int,
+        player2_wins: int,
+        draws: int,
+    ) -> dict[str, Any]:
+        return await self.post_json('/api/v1/discord/report-pairing', {
+            'discord_user_id': str(discord_user_id),
+            'tournament_id': tournament_id,
+            'table_number': table_number,
+            'player1_wins': player1_wins,
+            'player2_wins': player2_wins,
+            'draws': draws,
+        })
 
 
 def _truncate_lines(lines: list[str], limit: int = 1900) -> str:
@@ -215,6 +264,55 @@ async def pairings(interaction: discord.Interaction, tournament_id: int):
     await interaction.response.defer(thinking=True)
     try:
         await interaction.followup.send(format_pairings(await bot.api.latest_round(tournament_id)))
+    except WalterApiError as exc:
+        await interaction.followup.send(str(exc), ephemeral=True)
+
+
+@bot.tree.command(name='authorize', description='Connect this Discord account to your Walter user with a one-time pass.')
+@app_commands.describe(one_time_pass='One-time pass generated from your Walter user settings page')
+async def authorize(interaction: discord.Interaction, one_time_pass: str):
+    await interaction.response.defer(thinking=True, ephemeral=True)
+    username = interaction.user.name
+    try:
+        payload = await bot.api.authorize_discord_user(interaction.user.id, username, one_time_pass)
+        user = payload.get('user') or {}
+        await interaction.followup.send(f"Connected Discord to Walter user **{user.get('name', 'Unknown')}**.", ephemeral=True)
+    except WalterApiError as exc:
+        await interaction.followup.send(str(exc), ephemeral=True)
+
+
+@bot.tree.command(name='report_pairing', description='Report your latest-round tournament pairing result.')
+@app_commands.describe(
+    tournament_id='Walter tournament ID',
+    table_number='Table number from the latest round pairings',
+    player1_wins='Wins for the first-listed player at the table',
+    player2_wins='Wins for the second-listed player at the table',
+    draws='Drawn games in the match',
+)
+async def report_pairing(
+    interaction: discord.Interaction,
+    tournament_id: int,
+    table_number: int,
+    player1_wins: int,
+    player2_wins: int,
+    draws: int = 0,
+):
+    await interaction.response.defer(thinking=True, ephemeral=True)
+    try:
+        payload = await bot.api.report_pairing(
+            interaction.user.id,
+            tournament_id,
+            table_number,
+            player1_wins,
+            player2_wins,
+            draws,
+        )
+        match = payload.get('match') or {}
+        await interaction.followup.send(
+            f"Result reported for table {match.get('table_number', table_number)}: "
+            f"{player1_wins}-{player2_wins}-{draws}.",
+            ephemeral=True,
+        )
     except WalterApiError as exc:
         await interaction.followup.send(str(exc), ephemeral=True)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -115,3 +115,97 @@ def test_api_key_can_read_tournament_standings_and_latest_round(client, session)
     assert len(latest_round['matches']) == 2
     assert latest_round['matches'][0]['table_number'] == 1
     assert len(latest_round['matches'][0]['players']) == 2
+
+
+def _admin_api_token(session):
+    admin_role = session.query(Role).filter_by(name='admin').one()
+    admin = User(email='discord-admin@example.com', name='Discord Admin', role=admin_role, is_admin=True)
+    token = ApiKey.create_token()
+    session.add(admin)
+    session.flush()
+    session.add(ApiKey.from_token(token, admin, 'Discord bot', created_by=admin))
+    return token
+
+
+def test_discord_authorization_requires_username_and_one_time_pass(client, session):
+    token = _admin_api_token(session)
+    user_role = session.query(Role).filter_by(name='user').one()
+    player = User(email='discord-player@example.com', name='Discord Player', role=user_role)
+    one_time_pass = 'abc123pass'
+    player.discord_username = 'walterplayer'
+    player.set_discord_authorization_token(one_time_pass)
+    session.add(player)
+    session.commit()
+
+    response = client.post(
+        '/api/v1/discord/authorize',
+        json={
+            'discord_user_id': '1234567890',
+            'discord_username': 'walterplayer',
+            'one_time_pass': one_time_pass,
+        },
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert response.status_code == 200
+    session.refresh(player)
+    assert player.discord_user_id == '1234567890'
+    assert player.discord_authorization_token_hash is None
+
+
+def test_discord_report_pairing_requires_authorized_participant(client, session):
+    token = _admin_api_token(session)
+    user_role = session.query(Role).filter_by(name='user').one()
+    tournament = Tournament(name='Discord Open', format='Draft')
+    players = []
+    for idx in range(1, 5):
+        user = User(name=f'Discord Player {idx}', email=f'discord{idx}@example.com', role=user_role)
+        if idx == 1:
+            user.discord_username = 'discord1'
+            user.discord_user_id = '111'
+        players.append(user)
+    session.add(tournament)
+    session.add_all(players)
+    session.flush()
+    entries = [TournamentPlayer(tournament_id=tournament.id, user_id=user.id) for user in players]
+    session.add_all(entries)
+    session.flush()
+    round_one = Round(tournament_id=tournament.id, number=1)
+    session.add(round_one)
+    session.flush()
+    matches = pair_round(tournament, round_one, session)
+    session.commit()
+
+    table = next(match.table_number for match in matches if players[0].id in {match.player1.user_id, match.player2.user_id})
+    response = client.post(
+        '/api/v1/discord/report-pairing',
+        json={
+            'discord_user_id': '111',
+            'tournament_id': tournament.id,
+            'table_number': table,
+            'player1_wins': 2,
+            'player2_wins': 1,
+            'draws': 0,
+        },
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert response.status_code == 200
+    reported_match = session.query(Round).filter_by(tournament_id=tournament.id).one().matches[table - 1]
+    assert reported_match.completed is True
+    assert reported_match.result.player1_wins == 2
+    assert reported_match.result.player2_wins == 1
+
+    blocked_response = client.post(
+        '/api/v1/discord/report-pairing',
+        json={
+            'discord_user_id': '999',
+            'tournament_id': tournament.id,
+            'table_number': table,
+            'player1_wins': 2,
+            'player2_wins': 0,
+            'draws': 0,
+        },
+        headers={'Authorization': f'Bearer {token}'},
+    )
+    assert blocked_response.status_code == 403


### PR DESCRIPTION
### Motivation
- Allow tournament participants to report match results from Discord while ensuring the reporter is linked and authorized to a Walter user who has set their Discord username.

### Description
- Add `discord_username`, `discord_user_id`, and `discord_authorization_token_hash` fields to the `User` model plus helper methods `hash_discord_authorization_token`, `set_discord_authorization_token`, and `check_discord_authorization_token` for one-time pass handling.
- Extend the app startup/database migration logic to create the new user columns and add a `_normalize_discord_username` helper and `user_settings` handling to save a Discord username and generate a one-time pass from the UI.
- Implement API endpoints `POST /api/v1/discord/authorize` to consume a one-time pass and bind a Discord user ID to a Walter user, and `POST /api/v1/discord/report-pairing` to allow an authorized participant to report the latest-round pairing for a given table after validation checks.
- Extend the Discord bot client with `post_json`, `authorize_discord_user`, and `report_pairing` methods and add two slash commands: `/authorize` (consume one-time pass) and `/report_pairing` (submit a match result), calling the new APIs.
- Add tests exercising the new flows in `tests/test_api.py` to validate authorization and participant-only pairing reporting.

### Testing
- Compiled modified modules with `python -m py_compile discord_bot.py app/app.py app/models.py` and it succeeded.
- Ran `pytest -q tests/test_api.py` which passed as expected.
- Ran `pytest -q tests` (unit test suite under `tests/`) and it passed (`97 passed`, warnings only).
- Running the full `pytest -q` over the repository fails to collect vendored `walter-bot` tests in this environment because the `discord` package is not available, causing collection errors unrelated to the new API logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a346c2fa188832083a465c67d3b432a)

## Summary by Sourcery

Integrate Discord-based player result reporting by linking Discord accounts to Walter users and exposing new APIs and bot commands for authorized pairing submissions.

New Features:
- Add Discord account linkage fields to users and a one-time pass flow to authorize Discord identities from the web UI.
- Expose API endpoints for Discord user authorization and for reporting latest-round pairing results by authenticated participants.
- Extend the Discord bot with write-capable API interactions and new /authorize and /report_pairing slash commands for players.

Enhancements:
- Update user settings to manage Discord usernames, show connection status, and generate single-use Discord authorization passes.

Tests:
- Add API tests covering Discord authorization and restricting pairing reporting to authorized participants.