### PR TITLE
Rename Discord authorization slash command to connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,8 +93,8 @@ bot_announce_ready: true
 For the included read-only Discord bot, create an administrator API key from
 Settings, set `bot_runtime_script: "discord_bot.py"`, set `bot_api_key` to that
 one-time key value, and set `bot_token` to the Discord bot token. The bot
-registers slash commands for listing tournaments, standings, and latest-round
-pairings. If `bot_channel_id` is set, it posts a startup message to that channel so you can verify the bot can write to the chat; set `bot_announce_ready: false` to suppress that message. If `bot_channel_id` and `bot_poll_tournament_id` are set, it also polls for newly paired rounds and posts pairings to that channel.
+registers slash commands for listing tournaments, standings, latest-round
+pairings, connecting Walter accounts with `/connect`, and reporting pairing results. If `bot_channel_id` is set, it posts a startup message to that channel so you can verify the bot can write to the chat; set `bot_announce_ready: false` to suppress that message. If `bot_channel_id` and `bot_poll_tournament_id` are set, it also polls for newly paired rounds and posts pairings to that channel.
 
 ## Account verification and invites
 

--- a/app/app.py
+++ b/app/app.py
@@ -1892,7 +1892,7 @@ def create_app():
                     new_discord_pass = secrets.token_urlsafe(8)
                     current_user.set_discord_authorization_token(new_discord_pass)
                     current_user.discord_user_id = None
-                    flash('Discord connection pass generated. Use it with /authorize in Discord.', 'success')
+                    flash('Discord connection pass generated. Use it with /connect in Discord.', 'success')
                 else:
                     flash('Discord settings saved.', 'success')
                 db.session.commit()

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -24,7 +24,7 @@
 
 <section class="panel-card">
   <h3>Discord Bot Connection</h3>
-  <p class="muted">Add your Discord username, then generate a one-time pass and use it with <strong>/authorize</strong> in Discord before reporting tournament pairings with the bot.</p>
+  <p class="muted">Add your Discord username, then generate a one-time pass and use it with <strong>/connect</strong> in Discord before reporting tournament pairings with the bot.</p>
   {% if new_discord_pass %}
     <div class="flash success">
       Copy this one-time Discord pass now. It will not be shown again:<br>

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -268,9 +268,9 @@ async def pairings(interaction: discord.Interaction, tournament_id: int):
         await interaction.followup.send(str(exc), ephemeral=True)
 
 
-@bot.tree.command(name='authorize', description='Connect this Discord account to your Walter user with a one-time pass.')
+@bot.tree.command(name='connect', description='Connect this Discord account to your Walter user with a one-time pass.')
 @app_commands.describe(one_time_pass='One-time pass generated from your Walter user settings page')
-async def authorize(interaction: discord.Interaction, one_time_pass: str):
+async def connect(interaction: discord.Interaction, one_time_pass: str):
     await interaction.response.defer(thinking=True, ephemeral=True)
     username = interaction.user.name
     try:

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -1,0 +1,8 @@
+import discord_bot
+
+
+def test_discord_bot_registers_connect_command_instead_of_authorize():
+    command_names = {command.name for command in discord_bot.bot.tree.get_commands()}
+
+    assert 'connect' in command_names
+    assert 'authorize' not in command_names


### PR DESCRIPTION
### Motivation
- Make the Discord account-linking slash command clearer and more consistent by renaming the user-facing command from `authorize` to `connect`. 
- Keep the existing backend authorization API intact while changing only the bot-facing command and user-facing text. 

### Description
- Renamed the bot slash command decorator and handler from `@bot.tree.command(name='authorize', ...)` / `authorize` to `@bot.tree.command(name='connect', ...)` / `connect` in `discord_bot.py`. 
- Updated the one-time pass flash message in `app/app.py` to reference `/connect` instead of `/authorize`. 
- Updated the User Settings copy in `app/templates/user_settings.html` and the README (`README.md`) to instruct users to use `/connect`. 
- Added a regression test `tests/test_discord_bot.py` that asserts the bot registers `connect` and does not register `authorize`. 

### Testing
- Ran `pytest -q tests/test_discord_bot.py tests/test_api.py` and the tests passed (all tests in those runs succeeded). 
- The new regression test confirms `connect` is registered and `authorize` is not, and existing API-related tests continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a346f1257248320869bb8bad67a1626)

## Summary by Sourcery

Rename the Discord bot slash command for linking Walter accounts and update references across the app and docs.

New Features:
- Document the Discord bot’s account-linking `/connect` command in the README.

Enhancements:
- Rename the Discord bot account-linking slash command from `/authorize` to `/connect` and align UI copy and flash messaging accordingly.

Tests:
- Add a regression test ensuring the Discord bot registers the `connect` command and no longer registers `authorize`.