### PR TITLE
Restart Discord bot runtime before server startup

### DIFF
--- a/start-server.ps1
+++ b/start-server.ps1
@@ -82,6 +82,7 @@ $BotClientId = $cfg.bot_client_id
 $BotSecretKey = $cfg.bot_secret_key
 $BotPermissionsInt = $cfg.bot_permissions_int
 $BotChannelId = $cfg.bot_channel_id
+$BotAnnounceReady = $cfg.bot_announce_ready
 $newadmin = New-Object System.Management.Automation.PSCredential($cfg.admin_email, (ConvertTo-SecureString $cfg.admin_pass -AsPlainText -Force))
 
 ######enable testing###########
@@ -107,6 +108,7 @@ if([string]::IsNullOrEmpty($BotRuntimeLogFile)){ $BotRuntimeLogFile = "walter-bo
 if([string]::IsNullOrEmpty($BotRuntimeErrorLogFile)){ $BotRuntimeErrorLogFile = "walter-bot.err.log" }
 if([string]::IsNullOrEmpty($BotApiBaseUrl)){ $BotApiBaseUrl = "http://127.0.0.1:$FlaskPort" }
 if([string]::IsNullOrEmpty($BotPollIntervalSeconds)){ $BotPollIntervalSeconds = 30 }
+if($null -eq $BotAnnounceReady){ $BotAnnounceReady = $true }
 
 #check if Flask/Waitress is already running and stop it if necessary
 $flaskpid = try{
@@ -152,6 +154,7 @@ $env:BOT_CLIENT_ID = $BotClientId
 $env:BOT_SECRET_KEY = $BotSecretKey
 $env:BOT_PERMISSIONS_INT = $BotPermissionsInt
 $env:BOT_CHANNEL_ID = $BotChannelId
+$env:BOT_ANNOUNCE_READY = $BotAnnounceReady
 
 $timestamp = Get-Date -Format "yyyyMMddHHmmss"
 
@@ -190,6 +193,26 @@ if($BotInstallEnabled){
         python -m pip install $botInstallTarget | Out-Null
     }
 }
+
+
+function Stop-ExistingBotRuntime {
+    if([string]::IsNullOrEmpty($BotRuntimeModule) -and [string]::IsNullOrEmpty($BotRuntimeScript)){ return }
+
+    Write-Host "Stopping existing Walter bot runtime if present..."
+    $scriptName = if([string]::IsNullOrEmpty($BotRuntimeScript)){ "" } else { [System.IO.Path]::GetFileName($BotRuntimeScript) }
+    Get-CimInstance Win32_Process -Filter "Name = 'python.exe' OR Name = 'python3.exe'" | ForEach-Object {
+        $cmd = $_.CommandLine
+        if([string]::IsNullOrEmpty($cmd)){ return }
+        $matchesModule = (-not [string]::IsNullOrEmpty($BotRuntimeModule)) -and ($cmd -match [regex]::Escape("-m $BotRuntimeModule") -or $cmd -match [regex]::Escape($BotRuntimeModule))
+        $matchesScript = (-not [string]::IsNullOrEmpty($BotRuntimeScript)) -and ($cmd -match [regex]::Escape($BotRuntimeScript) -or $cmd -match [regex]::Escape($scriptName))
+        if($matchesModule -or $matchesScript){
+            Write-Host "Stopping Walter bot process $($_.ProcessId)"
+            Stop-Process -Id $_.ProcessId -Force -Confirm:$false -ErrorAction SilentlyContinue
+        }
+    }
+}
+
+Stop-ExistingBotRuntime
 
 Write-Host "Initializing database..."
 python -m flask --app app.app db-init

--- a/start-server.sh
+++ b/start-server.sh
@@ -678,6 +678,76 @@ for pid in sorted(pids):
         pass
 PY
 
+stop_existing_bot_runtime() {
+  [[ -n "$BOT_RUNTIME_MODULE" || -n "$BOT_RUNTIME_SCRIPT" ]] || return 0
+
+  printf 'Stopping existing Walter bot runtime if present...\n'
+  "$PYTHON_BIN" - "$BOT_RUNTIME_MODULE" "$BOT_RUNTIME_SCRIPT" <<'PY'
+import os
+import sys
+import time
+
+import psutil
+
+bot_module = sys.argv[1]
+bot_script = sys.argv[2]
+current_pid = os.getpid()
+script_basename = os.path.basename(bot_script) if bot_script else ''
+pids = set()
+
+for proc in psutil.process_iter(['pid', 'name', 'cmdline']):
+    try:
+        pid = proc.info['pid']
+        if pid == current_pid:
+            continue
+        cmdline = proc.info.get('cmdline') or []
+        if not cmdline:
+            continue
+        command_text = ' '.join(cmdline)
+        matches_module = bool(bot_module) and (
+            f'-m {bot_module}' in command_text or bot_module in cmdline
+        )
+        matches_script = bool(bot_script) and (
+            bot_script in cmdline or script_basename in [os.path.basename(arg) for arg in cmdline]
+        )
+        if matches_module or matches_script:
+            pids.add(pid)
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        continue
+
+for pid in sorted(pids):
+    try:
+        proc = psutil.Process(pid)
+        print(f'Terminating Walter bot process {pid} ({proc.name()})')
+        proc.terminate()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
+
+deadline = time.time() + 5
+while time.time() < deadline:
+    alive = []
+    for pid in pids:
+        try:
+            proc = psutil.Process(pid)
+            if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+                alive.append(proc)
+        except psutil.NoSuchProcess:
+            pass
+    if not alive:
+        break
+    time.sleep(0.2)
+
+for pid in sorted(pids):
+    try:
+        proc = psutil.Process(pid)
+        if proc.is_running() and proc.status() != psutil.STATUS_ZOMBIE:
+            print(f'Force killing Walter bot process {pid} ({proc.name()})')
+            proc.kill()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
+PY
+}
+
 should_start_bot_runtime() {
   local mode="${BOT_RUNTIME_ENABLED,,}"
 
@@ -690,6 +760,8 @@ should_start_bot_runtime() {
       ;;
   esac
 }
+
+stop_existing_bot_runtime
 
 printf 'Initializing database...\n'
 "$PYTHON_BIN" -m flask --app app.app db-init


### PR DESCRIPTION
### Motivation
- Stale Walter bot Python processes could keep an old slash-command set active (omitting `/connect`), so a fresh runtime must be started to publish the updated commands.
- The Windows startup flow did not pass through `bot_announce_ready`, creating inconsistent announce behavior between platforms.

### Description
- Add a Linux-side `stop_existing_bot_runtime()` helper in `start-server.sh` that locates Python processes matching the configured bot module or script and cleanly terminates them before starting the server runtime.
- Add a PowerShell `Stop-ExistingBotRuntime` function to `start-server.ps1` with equivalent behavior to stop any matching Walter bot processes on Windows.
- Pass `BOT_ANNOUNCE_READY` through the PowerShell startup environment and ensure it has a default when unset, to match the existing Linux behavior.
- Invoke the new stop routines before initializing the database / launching Waitress so a new bot process can start and publish the correct slash commands.

### Testing
- Compiled `discord_bot.py` with `python -m py_compile discord_bot.py` (succeeded).
- Ran unit test `pytest -q tests/test_discord_bot.py` (1 passed, 1 warning).
- Performed shell syntax check `bash -n start-server.sh` (succeeded) and `git diff --check` (no issues).
- PowerShell syntax/token check was not run in this environment because `pwsh` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347090ce0c83208f35d1e409d29e16)

## Summary by Sourcery

Ensure any existing Walter Discord bot runtime is stopped before starting the server so a fresh bot instance can register the correct commands and behave consistently across platforms.

Enhancements:
- Add a Linux helper in the startup script to detect and terminate existing Walter bot Python processes prior to server initialization.
- Add a Windows PowerShell function to locate and stop existing Walter bot processes before initializing Flask/Waitress.
- Propagate and default the BOT_ANNOUNCE_READY setting in the Windows startup script to align bot ready-announcement behavior with Linux.