### PR TITLE
Ensure Discord /connect command syncs to guilds on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,14 @@ bot_secret_key: ""
 bot_permissions_int: ""
 bot_channel_id: ""
 bot_announce_ready: true
+bot_sync_guild_commands: true
 ```
 
 For the included read-only Discord bot, create an administrator API key from
 Settings, set `bot_runtime_script: "discord_bot.py"`, set `bot_api_key` to that
 one-time key value, and set `bot_token` to the Discord bot token. The bot
 registers slash commands for listing tournaments, standings, latest-round
-pairings, connecting Walter accounts with `/connect`, and reporting pairing results. If `bot_channel_id` is set, it posts a startup message to that channel so you can verify the bot can write to the chat; set `bot_announce_ready: false` to suppress that message. If `bot_channel_id` and `bot_poll_tournament_id` are set, it also polls for newly paired rounds and posts pairings to that channel.
+pairings, connecting Walter accounts with `/connect`, and reporting pairing results. By default, the bot also syncs the same commands directly to every connected guild at startup so new commands such as `/connect` appear immediately instead of waiting for Discord global command propagation; set `bot_sync_guild_commands: false` to use global sync only. If `bot_channel_id` is set, it posts a startup message to that channel so you can verify the bot can write to the chat; set `bot_announce_ready: false` to suppress that message. If `bot_channel_id` and `bot_poll_tournament_id` are set, it also polls for newly paired rounds and posts pairings to that channel.
 
 ## Account verification and invites
 

--- a/config.yaml
+++ b/config.yaml
@@ -67,3 +67,4 @@ bot_client_id: ""
 bot_secret_key: ""
 bot_permissions_int: ""
 bot_channel_id: ""
+bot_sync_guild_commands: true

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -30,6 +30,7 @@ BOT_API_KEY = os.environ.get('BOT_API_KEY', '').strip()
 BOT_POLL_TOURNAMENT_ID = os.environ.get('BOT_POLL_TOURNAMENT_ID', '').strip()
 BOT_POLL_INTERVAL_SECONDS = int(os.environ.get('BOT_POLL_INTERVAL_SECONDS', '30') or 30)
 BOT_ANNOUNCE_READY = os.environ.get('BOT_ANNOUNCE_READY', 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
+BOT_SYNC_GUILD_COMMANDS = os.environ.get('BOT_SYNC_GUILD_COMMANDS', 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
 
 
 class WalterApiError(RuntimeError):
@@ -135,6 +136,10 @@ def _truncate_lines(lines: list[str], limit: int = 1900) -> str:
     return '\n'.join(output) or 'No data found.'
 
 
+def registered_command_names(tree: app_commands.CommandTree[Any]) -> list[str]:
+    return sorted(command.name for command in tree.get_commands())
+
+
 def format_standings(payload: dict[str, Any]) -> str:
     tournament = payload.get('tournament') or {}
     standings = payload.get('standings') or []
@@ -175,10 +180,12 @@ class WalterBot(discord.Client):
         self.api = WalterApiClient(BOT_API_BASE_URL, BOT_API_KEY)
         self._last_announced_round: int | None = None
         self._ready_announced = False
+        self._guild_commands_synced = False
 
     async def setup_hook(self):
         synced_commands = await self.tree.sync()
-        print(f'Synced {len(synced_commands)} Discord slash command(s).')
+        command_names = ', '.join(registered_command_names(self.tree))
+        print(f'Synced {len(synced_commands)} global Discord slash command(s): {command_names}')
         if BOT_CHANNEL_ID and BOT_POLL_TOURNAMENT_ID:
             self.loop.create_task(self._poll_pairings())
         elif BOT_CHANNEL_ID:
@@ -192,11 +199,25 @@ class WalterBot(discord.Client):
         print(f'Connected to {len(self.guilds)} Discord server(s).')
         print(f'Walter API: {BOT_API_BASE_URL}')
 
+        if BOT_SYNC_GUILD_COMMANDS and not self._guild_commands_synced:
+            await self._sync_guild_commands()
+
         if BOT_CHANNEL_ID and BOT_ANNOUNCE_READY and not self._ready_announced:
             channel = await self._get_messageable_channel(BOT_CHANNEL_ID)
             if channel is not None:
-                await channel.send('Walter bot is online. Use `/tournaments`, `/standings`, or `/pairings` to get tournament updates.')
+                await channel.send('Walter bot is online. Use `/tournaments`, `/standings`, `/pairings`, or `/connect` to get started.')
                 self._ready_announced = True
+
+    async def _sync_guild_commands(self):
+        command_names = ', '.join(registered_command_names(self.tree))
+        for guild in self.guilds:
+            try:
+                self.tree.copy_global_to(guild=guild)
+                synced_commands = await self.tree.sync(guild=guild)
+                print(f'Synced {len(synced_commands)} slash command(s) to guild {guild.id}: {command_names}')
+            except discord.DiscordException as exc:
+                print(f'Could not sync slash commands to guild {guild.id}: {exc}')
+        self._guild_commands_synced = True
 
     async def _get_messageable_channel(self, channel_id: str) -> discord.abc.Messageable | None:
         try:

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -83,6 +83,7 @@ $BotSecretKey = $cfg.bot_secret_key
 $BotPermissionsInt = $cfg.bot_permissions_int
 $BotChannelId = $cfg.bot_channel_id
 $BotAnnounceReady = $cfg.bot_announce_ready
+$BotSyncGuildCommands = $cfg.bot_sync_guild_commands
 $newadmin = New-Object System.Management.Automation.PSCredential($cfg.admin_email, (ConvertTo-SecureString $cfg.admin_pass -AsPlainText -Force))
 
 ######enable testing###########
@@ -109,6 +110,7 @@ if([string]::IsNullOrEmpty($BotRuntimeErrorLogFile)){ $BotRuntimeErrorLogFile = 
 if([string]::IsNullOrEmpty($BotApiBaseUrl)){ $BotApiBaseUrl = "http://127.0.0.1:$FlaskPort" }
 if([string]::IsNullOrEmpty($BotPollIntervalSeconds)){ $BotPollIntervalSeconds = 30 }
 if($null -eq $BotAnnounceReady){ $BotAnnounceReady = $true }
+if($null -eq $BotSyncGuildCommands){ $BotSyncGuildCommands = $true }
 
 #check if Flask/Waitress is already running and stop it if necessary
 $flaskpid = try{
@@ -155,6 +157,7 @@ $env:BOT_SECRET_KEY = $BotSecretKey
 $env:BOT_PERMISSIONS_INT = $BotPermissionsInt
 $env:BOT_CHANNEL_ID = $BotChannelId
 $env:BOT_ANNOUNCE_READY = $BotAnnounceReady
+$env:BOT_SYNC_GUILD_COMMANDS = $BotSyncGuildCommands
 
 $timestamp = Get-Date -Format "yyyyMMddHHmmss"
 

--- a/start-server.sh
+++ b/start-server.sh
@@ -479,6 +479,7 @@ keys = [
     'bot_permissions_int',
     'bot_channel_id',
     'bot_announce_ready',
+    'bot_sync_guild_commands',
 ]
 
 for key in keys:
@@ -537,6 +538,7 @@ BOT_SECRET_KEY="${BOT_SECRET_KEY:-}"
 BOT_PERMISSIONS_INT="${BOT_PERMISSIONS_INT:-}"
 BOT_CHANNEL_ID="${BOT_CHANNEL_ID:-}"
 BOT_ANNOUNCE_READY="${BOT_ANNOUNCE_READY:-true}"
+BOT_SYNC_GUILD_COMMANDS="${BOT_SYNC_GUILD_COMMANDS:-true}"
 
 cd "$SCRIPT_DIR"
 
@@ -565,6 +567,7 @@ export BOT_SECRET_KEY
 export BOT_PERMISSIONS_INT
 export BOT_CHANNEL_ID
 export BOT_ANNOUNCE_READY
+export BOT_SYNC_GUILD_COMMANDS
 
 ensure_letsencrypt_certificate
 

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -2,7 +2,19 @@ import discord_bot
 
 
 def test_discord_bot_registers_connect_command_instead_of_authorize():
-    command_names = {command.name for command in discord_bot.bot.tree.get_commands()}
+    command_names = set(discord_bot.registered_command_names(discord_bot.bot.tree))
 
     assert 'connect' in command_names
     assert 'authorize' not in command_names
+
+
+def test_discord_bot_registers_all_expected_slash_commands():
+    command_names = set(discord_bot.registered_command_names(discord_bot.bot.tree))
+
+    assert {
+        'connect',
+        'pairings',
+        'report_pairing',
+        'standings',
+        'tournaments',
+    }.issubset(command_names)


### PR DESCRIPTION
### Motivation
- Make the Discord `/connect` (and other slash) commands appear promptly in servers by syncing global commands into each connected guild at startup instead of waiting on Discord global propagation. 
- Provide an opt-out flag and surface the setting through startup scripts and docs so deployments can choose global-only behavior.

### Description
- Add `BOT_SYNC_GUILD_COMMANDS` environment/config option and expose it via `config.yaml`, `start-server.sh`, and `start-server.ps1`.
- Add `registered_command_names()` helper and log registered global command names during `setup_hook` for clearer startup output.
- On `on_ready` optionally copy global commands into each guild and `sync` them there (`_sync_guild_commands`), and update the ready announcement to mention `/connect`.
- Add/adjust tests in `tests/test_discord_bot.py` to assert the `connect` command is registered and the expected command set is present.

### Testing
- Ran `pytest tests/test_discord_bot.py` (2 tests) and they passed.
- Verified Python syntax with `python -m py_compile discord_bot.py` which succeeded.
- Verified shell startup plumbing with `bash -n start-server.sh` which reported no syntax errors.
- PowerShell script parsing could not be validated in this environment because `pwsh` is not available, so PS1 validation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34719e501883208836a9fa93295cb0)

## Summary by Sourcery

Sync Discord bot slash commands to connected guilds on startup and make this behavior configurable.

New Features:
- Add a BOT_SYNC_GUILD_COMMANDS configuration option, wired through environment variables, config.yaml, and startup scripts, to control whether slash commands are synced to each guild at startup.

Enhancements:
- Log the names of registered global slash commands during bot setup for clearer startup diagnostics.
- Sync global slash commands into each connected guild on first ready so commands like /connect become available immediately, and update the ready announcement message to mention /connect.

Documentation:
- Document the new bot_sync_guild_commands option and default behavior for guild command syncing in the README.

Tests:
- Extend Discord bot tests to assert that the connect command replaces authorize and that the full expected set of slash commands is registered.