### PR TITLE
Avoid duplicate Discord slash commands; collapse /connect HTML errors; accept trailing slashes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2082,7 +2082,7 @@ def create_app():
             'round': round_payload(round_obj),
         })
 
-    @app.route('/api/v1/discord/authorize', methods=['POST'])
+    @app.route('/api/v1/discord/authorize', methods=['POST'], strict_slashes=False)
     def api_discord_authorize():
         require_api_permission('tournaments.manage')
         data = request.get_json(silent=True) or {}
@@ -2112,7 +2112,7 @@ def create_app():
         _api_log('discord.authorize', 'success', f'user_id={user.id}')
         return jsonify({'authorized': True, 'user': user_payload(user)})
 
-    @app.route('/api/v1/discord/report-pairing', methods=['POST'])
+    @app.route('/api/v1/discord/report-pairing', methods=['POST'], strict_slashes=False)
     def api_discord_report_pairing():
         require_api_permission('tournaments.manage')
         data = request.get_json(silent=True) or {}

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import re
 import sys
 from pathlib import Path
 from typing import Any
@@ -30,11 +31,32 @@ BOT_API_KEY = os.environ.get('BOT_API_KEY', '').strip()
 BOT_POLL_TOURNAMENT_ID = os.environ.get('BOT_POLL_TOURNAMENT_ID', '').strip()
 BOT_POLL_INTERVAL_SECONDS = int(os.environ.get('BOT_POLL_INTERVAL_SECONDS', '30') or 30)
 BOT_ANNOUNCE_READY = os.environ.get('BOT_ANNOUNCE_READY', 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
-BOT_SYNC_GUILD_COMMANDS = os.environ.get('BOT_SYNC_GUILD_COMMANDS', 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
+BOT_SYNC_GUILD_COMMANDS = os.environ.get('BOT_SYNC_GUILD_COMMANDS', 'false').strip().lower() not in {'0', 'false', 'no', 'off'}
+BOT_CLEAR_GUILD_COMMANDS = os.environ.get('BOT_CLEAR_GUILD_COMMANDS', 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
 
 
 class WalterApiError(RuntimeError):
     """Raised when the Walter API cannot return a successful response."""
+
+
+def _format_http_error_detail(exc: error.HTTPError) -> str:
+    body = exc.read().decode('utf-8', errors='replace').strip()
+    content_type = exc.headers.get('Content-Type', '') if exc.headers else ''
+    if 'application/json' in content_type:
+        try:
+            import json
+
+            payload = json.loads(body)
+            if isinstance(payload, dict):
+                return str(payload.get('error') or payload.get('message') or payload)
+        except ValueError:
+            pass
+    if '<html' in body.lower():
+        title_match = re.search(r'<title>(.*?)</title>', body, re.IGNORECASE | re.DOTALL)
+        if title_match:
+            return re.sub(r'\s+', ' ', title_match.group(1)).strip()
+        return exc.reason or 'HTTP error'
+    return body or exc.reason or 'HTTP error'
 
 
 class WalterApiClient:
@@ -62,7 +84,7 @@ class WalterApiClient:
 
                 return json.loads(response.read().decode('utf-8'))
         except error.HTTPError as exc:
-            detail = exc.read().decode('utf-8', errors='replace')
+            detail = _format_http_error_detail(exc)
             raise WalterApiError(f'Walter API returned HTTP {exc.code}: {detail}') from exc
         except error.URLError as exc:
             raise WalterApiError(f'Could not reach Walter API: {exc.reason}') from exc
@@ -83,7 +105,7 @@ class WalterApiClient:
             with request.urlopen(api_request, timeout=10) as response:
                 return json.loads(response.read().decode('utf-8'))
         except error.HTTPError as exc:
-            detail = exc.read().decode('utf-8', errors='replace')
+            detail = _format_http_error_detail(exc)
             raise WalterApiError(f'Walter API returned HTTP {exc.code}: {detail}') from exc
         except error.URLError as exc:
             raise WalterApiError(f'Could not reach Walter API: {exc.reason}') from exc
@@ -199,8 +221,11 @@ class WalterBot(discord.Client):
         print(f'Connected to {len(self.guilds)} Discord server(s).')
         print(f'Walter API: {BOT_API_BASE_URL}')
 
-        if BOT_SYNC_GUILD_COMMANDS and not self._guild_commands_synced:
-            await self._sync_guild_commands()
+        if not self._guild_commands_synced:
+            if BOT_SYNC_GUILD_COMMANDS:
+                await self._sync_guild_commands()
+            elif BOT_CLEAR_GUILD_COMMANDS:
+                await self._clear_guild_commands()
 
         if BOT_CHANNEL_ID and BOT_ANNOUNCE_READY and not self._ready_announced:
             channel = await self._get_messageable_channel(BOT_CHANNEL_ID)
@@ -217,6 +242,16 @@ class WalterBot(discord.Client):
                 print(f'Synced {len(synced_commands)} slash command(s) to guild {guild.id}: {command_names}')
             except discord.DiscordException as exc:
                 print(f'Could not sync slash commands to guild {guild.id}: {exc}')
+        self._guild_commands_synced = True
+
+    async def _clear_guild_commands(self):
+        for guild in self.guilds:
+            try:
+                self.tree.clear_commands(guild=guild)
+                await self.tree.sync(guild=guild)
+                print(f'Cleared guild-specific slash commands for guild {guild.id}; using global commands only.')
+            except discord.DiscordException as exc:
+                print(f'Could not clear guild slash commands for guild {guild.id}: {exc}')
         self._guild_commands_synced = True
 
     async def _get_messageable_channel(self, channel_id: str) -> discord.abc.Messageable | None:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -138,7 +138,7 @@ def test_discord_authorization_requires_username_and_one_time_pass(client, sessi
     session.commit()
 
     response = client.post(
-        '/api/v1/discord/authorize',
+        '/api/v1/discord/authorize/',
         json={
             'discord_user_id': '1234567890',
             'discord_username': 'walterplayer',

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -18,3 +18,23 @@ def test_discord_bot_registers_all_expected_slash_commands():
         'standings',
         'tournaments',
     }.issubset(command_names)
+
+
+def test_http_error_detail_collapses_html_title():
+    from io import BytesIO
+    from urllib.error import HTTPError
+
+    exc = HTTPError(
+        'http://walter.test/api/v1/discord/authorize',
+        405,
+        'METHOD NOT ALLOWED',
+        {'Content-Type': 'text/html; charset=utf-8'},
+        BytesIO(b'<html><head><title>405 Method Not Allowed</title></head></html>'),
+    )
+
+    assert discord_bot._format_http_error_detail(exc) == '405 Method Not Allowed'
+
+
+def test_guild_command_sync_is_disabled_by_default_to_avoid_duplicates():
+    assert discord_bot.BOT_SYNC_GUILD_COMMANDS is False
+    assert discord_bot.BOT_CLEAR_GUILD_COMMANDS is True


### PR DESCRIPTION
### Motivation
- Prevent duplicate Walter slash commands appearing in Discord by avoiding automatic guild-specific command syncing and clearing stale guild commands by default. 
- Make `/connect` failures more user-friendly by collapsing noisy HTML error pages into concise messages. 
- Allow trailing slashes on the Discord-related API endpoints to avoid route mismatches from proxies or client URL variants.

### Description
- Change `BOT_SYNC_GUILD_COMMANDS` default to `false` and add `BOT_CLEAR_GUILD_COMMANDS` (default `true`) to prefer global commands and clear guild-specific registrations when appropriate. 
- Add `WalterBot._clear_guild_commands` and update `on_ready` to either sync guild commands (`_sync_guild_commands`) or clear them (`_clear_guild_commands`) depending on env flags. 
- Implement `_format_http_error_detail` to parse `HTTPError` bodies (JSON message, HTML `<title>`, or fallback) and use it when raising `WalterApiError` for HTTP errors. 
- Make the Flask endpoints `/api/v1/discord/authorize` and `/api/v1/discord/report-pairing` tolerant of trailing slashes by setting `strict_slashes=False`. 
- Add tests: HTML error-title collapsing, default command-sync flag behavior, and a trailing-slash authorization request adjustment in the API tests.

### Testing
- Ran `pytest tests/test_discord_bot.py tests/test_api.py -q` and all tests passed (`10 passed`).
- Verified syntax by running `python -m py_compile discord_bot.py app/app.py` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34735a649c83209dd0c9a0016ea5fa)

## Summary by Sourcery

Adjust Discord bot command management, improve Walter API HTTP error reporting, and relax Discord-related API routes to accept trailing slashes.

New Features:
- Introduce configurable clearing of guild-specific Discord slash commands in favor of global commands.

Bug Fixes:
- Prevent duplicate Discord slash commands by disabling guild command syncing by default and clearing existing guild-specific commands when configured.
- Collapse noisy HTML HTTP error pages into concise messages when surfacing Walter API failures.
- Allow trailing slashes on Discord authorization and pairing report API endpoints to avoid route mismatches.

Tests:
- Add tests for HTML HTTP error detail formatting, default guild command sync and clearing flags, and trailing-slash handling on the Discord authorization API.