### PR TITLE
Fix Discord bot /connect endpoint and startup defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,15 +87,16 @@ bot_client_id: ""
 bot_secret_key: ""
 bot_permissions_int: ""
 bot_channel_id: ""
-bot_announce_ready: true
-bot_sync_guild_commands: true
+bot_announce_ready: false
+bot_sync_guild_commands: false
+bot_clear_guild_commands: true
 ```
 
 For the included read-only Discord bot, create an administrator API key from
 Settings, set `bot_runtime_script: "discord_bot.py"`, set `bot_api_key` to that
 one-time key value, and set `bot_token` to the Discord bot token. The bot
 registers slash commands for listing tournaments, standings, latest-round
-pairings, connecting Walter accounts with `/connect`, and reporting pairing results. By default, the bot also syncs the same commands directly to every connected guild at startup so new commands such as `/connect` appear immediately instead of waiting for Discord global command propagation; set `bot_sync_guild_commands: false` to use global sync only. If `bot_channel_id` is set, it posts a startup message to that channel so you can verify the bot can write to the chat; set `bot_announce_ready: false` to suppress that message. If `bot_channel_id` and `bot_poll_tournament_id` are set, it also polls for newly paired rounds and posts pairings to that channel.
+pairings, connecting Walter accounts with `/connect`, and reporting pairing results. By default, the bot syncs global slash commands, clears stale guild-specific copies to avoid duplicate commands, and does not post a startup message. Set `bot_sync_guild_commands: true` only if you need immediate guild command updates, set `bot_clear_guild_commands: false` to leave existing guild-specific commands in place, and set `bot_announce_ready: true` to post a ready message when `bot_channel_id` is configured. If `bot_channel_id` and `bot_poll_tournament_id` are set, it also polls for newly paired rounds and posts pairings to that channel.
 
 ## Account verification and invites
 

--- a/app/app.py
+++ b/app/app.py
@@ -2082,6 +2082,7 @@ def create_app():
             'round': round_payload(round_obj),
         })
 
+    @app.route('/connect', methods=['POST'], strict_slashes=False)
     @app.route('/api/v1/discord/authorize', methods=['POST'], strict_slashes=False)
     def api_discord_authorize():
         require_api_permission('tournaments.manage')

--- a/config.yaml
+++ b/config.yaml
@@ -67,4 +67,6 @@ bot_client_id: ""
 bot_secret_key: ""
 bot_permissions_int: ""
 bot_channel_id: ""
-bot_sync_guild_commands: true
+bot_announce_ready: false
+bot_sync_guild_commands: false
+bot_clear_guild_commands: true

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -30,7 +30,7 @@ BOT_API_BASE_URL = os.environ.get('BOT_API_BASE_URL', 'http://127.0.0.1:5000').s
 BOT_API_KEY = os.environ.get('BOT_API_KEY', '').strip()
 BOT_POLL_TOURNAMENT_ID = os.environ.get('BOT_POLL_TOURNAMENT_ID', '').strip()
 BOT_POLL_INTERVAL_SECONDS = int(os.environ.get('BOT_POLL_INTERVAL_SECONDS', '30') or 30)
-BOT_ANNOUNCE_READY = os.environ.get('BOT_ANNOUNCE_READY', 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
+BOT_ANNOUNCE_READY = os.environ.get('BOT_ANNOUNCE_READY', 'false').strip().lower() not in {'0', 'false', 'no', 'off'}
 BOT_SYNC_GUILD_COMMANDS = os.environ.get('BOT_SYNC_GUILD_COMMANDS', 'false').strip().lower() not in {'0', 'false', 'no', 'off'}
 BOT_CLEAR_GUILD_COMMANDS = os.environ.get('BOT_CLEAR_GUILD_COMMANDS', 'true').strip().lower() not in {'0', 'false', 'no', 'off'}
 

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -84,6 +84,7 @@ $BotPermissionsInt = $cfg.bot_permissions_int
 $BotChannelId = $cfg.bot_channel_id
 $BotAnnounceReady = $cfg.bot_announce_ready
 $BotSyncGuildCommands = $cfg.bot_sync_guild_commands
+$BotClearGuildCommands = $cfg.bot_clear_guild_commands
 $newadmin = New-Object System.Management.Automation.PSCredential($cfg.admin_email, (ConvertTo-SecureString $cfg.admin_pass -AsPlainText -Force))
 
 ######enable testing###########
@@ -109,8 +110,9 @@ if([string]::IsNullOrEmpty($BotRuntimeLogFile)){ $BotRuntimeLogFile = "walter-bo
 if([string]::IsNullOrEmpty($BotRuntimeErrorLogFile)){ $BotRuntimeErrorLogFile = "walter-bot.err.log" }
 if([string]::IsNullOrEmpty($BotApiBaseUrl)){ $BotApiBaseUrl = "http://127.0.0.1:$FlaskPort" }
 if([string]::IsNullOrEmpty($BotPollIntervalSeconds)){ $BotPollIntervalSeconds = 30 }
-if($null -eq $BotAnnounceReady){ $BotAnnounceReady = $true }
-if($null -eq $BotSyncGuildCommands){ $BotSyncGuildCommands = $true }
+if($null -eq $BotAnnounceReady){ $BotAnnounceReady = $false }
+if($null -eq $BotSyncGuildCommands){ $BotSyncGuildCommands = $false }
+if($null -eq $BotClearGuildCommands){ $BotClearGuildCommands = $true }
 
 #check if Flask/Waitress is already running and stop it if necessary
 $flaskpid = try{
@@ -158,6 +160,7 @@ $env:BOT_PERMISSIONS_INT = $BotPermissionsInt
 $env:BOT_CHANNEL_ID = $BotChannelId
 $env:BOT_ANNOUNCE_READY = $BotAnnounceReady
 $env:BOT_SYNC_GUILD_COMMANDS = $BotSyncGuildCommands
+$env:BOT_CLEAR_GUILD_COMMANDS = $BotClearGuildCommands
 
 $timestamp = Get-Date -Format "yyyyMMddHHmmss"
 

--- a/start-server.sh
+++ b/start-server.sh
@@ -480,6 +480,7 @@ keys = [
     'bot_channel_id',
     'bot_announce_ready',
     'bot_sync_guild_commands',
+    'bot_clear_guild_commands',
 ]
 
 for key in keys:
@@ -537,8 +538,9 @@ BOT_CLIENT_ID="${BOT_CLIENT_ID:-}"
 BOT_SECRET_KEY="${BOT_SECRET_KEY:-}"
 BOT_PERMISSIONS_INT="${BOT_PERMISSIONS_INT:-}"
 BOT_CHANNEL_ID="${BOT_CHANNEL_ID:-}"
-BOT_ANNOUNCE_READY="${BOT_ANNOUNCE_READY:-true}"
-BOT_SYNC_GUILD_COMMANDS="${BOT_SYNC_GUILD_COMMANDS:-true}"
+BOT_ANNOUNCE_READY="${BOT_ANNOUNCE_READY:-false}"
+BOT_SYNC_GUILD_COMMANDS="${BOT_SYNC_GUILD_COMMANDS:-false}"
+BOT_CLEAR_GUILD_COMMANDS="${BOT_CLEAR_GUILD_COMMANDS:-true}"
 
 cd "$SCRIPT_DIR"
 
@@ -568,6 +570,7 @@ export BOT_PERMISSIONS_INT
 export BOT_CHANNEL_ID
 export BOT_ANNOUNCE_READY
 export BOT_SYNC_GUILD_COMMANDS
+export BOT_CLEAR_GUILD_COMMANDS
 
 ensure_letsencrypt_certificate
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -127,6 +127,33 @@ def _admin_api_token(session):
     return token
 
 
+
+
+def test_discord_authorization_accepts_legacy_connect_endpoint(client, session):
+    token = _admin_api_token(session)
+    user_role = session.query(Role).filter_by(name='user').one()
+    player = User(email='discord-connect@example.com', name='Discord Connect', role=user_role)
+    one_time_pass = 'connectpass123'
+    player.discord_username = 'walterconnect'
+    player.set_discord_authorization_token(one_time_pass)
+    session.add(player)
+    session.commit()
+
+    response = client.post(
+        '/connect',
+        json={
+            'discord_user_id': '2345678901',
+            'discord_username': 'walterconnect',
+            'one_time_pass': one_time_pass,
+        },
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert response.status_code == 200
+    session.refresh(player)
+    assert player.discord_user_id == '2345678901'
+    assert player.discord_authorization_token_hash is None
+
 def test_discord_authorization_requires_username_and_one_time_pass(client, session):
     token = _admin_api_token(session)
     user_role = session.query(Role).filter_by(name='user').one()

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -38,3 +38,7 @@ def test_http_error_detail_collapses_html_title():
 def test_guild_command_sync_is_disabled_by_default_to_avoid_duplicates():
     assert discord_bot.BOT_SYNC_GUILD_COMMANDS is False
     assert discord_bot.BOT_CLEAR_GUILD_COMMANDS is True
+
+
+def test_ready_announcement_is_disabled_by_default():
+    assert discord_bot.BOT_ANNOUNCE_READY is False


### PR DESCRIPTION
### Motivation
- Prevent legacy bot clients from receiving 405 Method Not Allowed when calling `/connect` by accepting the legacy path. 
- Avoid noisy startup behavior by not posting a ready announcement to a channel by default. 
- Reduce duplicate slash-command issues by disabling per-guild command sync by default and providing a way to clear stale guild-specific commands.

### Description
- Add a POST alias route for `/connect` that delegates to the existing `/api/v1/discord/authorize` handler in `app/app.py` so legacy requests succeed. 
- Change the default ready-announcement flag to disabled by default by setting `BOT_ANNOUNCE_READY` default to `false` in `discord_bot.py`, `config.yaml`, `start-server.sh`, and `start-server.ps1`. 
- Introduce `BOT_CLEAR_GUILD_COMMANDS` support, export the variable from startup scripts, and default `BOT_SYNC_GUILD_COMMANDS` to `false` while defaulting `BOT_CLEAR_GUILD_COMMANDS` to `true` to avoid duplicate commands. 
- Update `README.md` to document the new defaults and command-sync behavior. 
- Add regression tests: `test_discord_authorization_accepts_legacy_connect_endpoint` (accepts `/connect`) and `test_ready_announcement_is_disabled_by_default` (verifies default is disabled), and update `tests/test_discord_bot.py` expectations.

### Testing
- Ran `pytest tests/test_discord_bot.py tests/test_api.py -q` and all tests passed (`12 passed`, with warnings), so the new `/connect` alias and startup default behaviors are covered by automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34767c4b00832091ad664446cc04ef)

## Summary by Sourcery

Allow legacy Discord bot clients to authorize via the old /connect endpoint and adjust Discord bot startup behavior defaults to be less noisy and avoid duplicate guild commands.

New Features:
- Add a POST /connect alias that delegates to the existing Discord authorization endpoint so legacy clients can connect successfully.

Enhancements:
- Change Discord bot defaults so ready announcements are disabled and per-guild command sync is off by default while clearing stale guild commands by default to prevent duplicates.

Documentation:
- Update README to describe the new Discord bot defaults and guild command sync/clear behavior.

Tests:
- Add API and bot tests covering the legacy /connect endpoint, default-ready announcement behavior, and updated command sync defaults.

Chores:
- Propagate new Discord bot configuration keys and defaults through config.yaml and startup scripts for both shell and PowerShell environments.