### PR TITLE
Fix Discord connect flow and settings display

### DIFF
--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2442,3 +2442,15 @@ html[data-theme="dark"] .tournament-control-box .rounds-form {
     height: 120px;
   }
 }
+
+.one-time-discord-pass {
+  display: inline-block;
+  margin-top: 8px;
+  padding: 10px 14px;
+  border-radius: var(--radius-sm);
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--brand-text);
+  font-size: 1.35rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+}

--- a/app/templates/user_settings.html
+++ b/app/templates/user_settings.html
@@ -27,19 +27,20 @@
   <p class="muted">Add your Discord username, then generate a one-time pass and use it with <strong>/connect</strong> in Discord before reporting tournament pairings with the bot.</p>
   {% if new_discord_pass %}
     <div class="flash success">
-      Copy this one-time Discord pass now. It will not be shown again:<br>
-      <code>{{ new_discord_pass }}</code>
+      <strong>Copy this one-time Discord pass now. It will not be shown again:</strong><br>
+      <code class="one-time-discord-pass">{{ new_discord_pass }}</code>
     </div>
   {% endif %}
   <form method="post" class="stacked-form">
     <input type="hidden" name="action" value="discord_connection">
+    <p class="muted">Current Discord username: <strong>{{ current_user.discord_username or 'Not set' }}</strong></p>
     <label>Discord username
-      <input type="text" name="discord_username" maxlength="120" value="{{ current_user.discord_username or '' }}" placeholder="discord_username">
+      <input type="text" name="discord_username" maxlength="120" value="{{ current_user.discord_username or '' }}" placeholder="discord_username" autocomplete="off" autocapitalize="none" autocorrect="off" spellcheck="false" data-lpignore="true" data-1p-ignore="true" data-bwignore="true">
     </label>
     <p class="muted">
       Status:
       {% if current_user.discord_user_id %}
-        Connected to Discord user ID <code>{{ current_user.discord_user_id }}</code>.
+        Connected as <strong>{{ current_user.discord_username or 'unknown username' }}</strong> to Discord user ID <code>{{ current_user.discord_user_id }}</code>.
       {% else %}
         Not connected.
       {% endif %}

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -120,11 +120,17 @@ class WalterApiClient:
         return await self.get_json(f'/api/v1/tournaments/{tournament_id}/rounds/latest')
 
     async def authorize_discord_user(self, discord_user_id: int, discord_username: str, one_time_pass: str) -> dict[str, Any]:
-        return await self.post_json('/api/v1/discord/authorize', {
+        payload = {
             'discord_user_id': str(discord_user_id),
             'discord_username': discord_username,
             'one_time_pass': one_time_pass,
-        })
+        }
+        try:
+            return await self.post_json('/connect', payload)
+        except WalterApiError as exc:
+            if 'HTTP 405' not in str(exc):
+                raise
+            return await self.post_json('/api/v1/discord/authorize', payload)
 
     async def report_pairing(
         self,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -236,3 +236,29 @@ def test_discord_report_pairing_requires_authorized_participant(client, session)
         headers={'Authorization': f'Bearer {token}'},
     )
     assert blocked_response.status_code == 403
+
+
+def test_discord_settings_show_pass_prominently_and_disable_password_managers(client, session):
+    user_role = session.query(Role).filter_by(name='user').one()
+    user = User(email='discord-settings@example.com', name='Discord Settings', role=user_role)
+    user.set_password('secret')
+    session.add(user)
+    session.commit()
+
+    with client:
+        assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+        response = client.post(
+            '/settings',
+            data={
+                'action': 'discord_connection',
+                'discord_username': 'waltersettings',
+                'generate_discord_pass': '1',
+            },
+        )
+
+    html = response.get_data(as_text=True)
+    assert response.status_code == 200
+    assert 'Current Discord username: <strong>waltersettings</strong>' in html
+    assert 'class="one-time-discord-pass"' in html
+    assert 'autocomplete="off"' in html
+    assert 'data-lpignore="true"' in html

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -42,3 +42,43 @@ def test_guild_command_sync_is_disabled_by_default_to_avoid_duplicates():
 
 def test_ready_announcement_is_disabled_by_default():
     assert discord_bot.BOT_ANNOUNCE_READY is False
+
+
+def test_authorize_discord_user_uses_connect_endpoint_first(monkeypatch):
+    import asyncio
+
+    calls = []
+
+    def fake_post(path, payload):
+        calls.append((path, payload))
+        return {'authorized': True}
+
+    api = discord_bot.WalterApiClient('http://walter.test', 'token')
+    monkeypatch.setattr(api, '_post_json_sync', fake_post)
+
+    result = asyncio.run(api.authorize_discord_user(123, 'walteruser', 'pass123'))
+
+    assert result == {'authorized': True}
+    assert calls == [('/connect', {
+        'discord_user_id': '123',
+        'discord_username': 'walteruser',
+        'one_time_pass': 'pass123',
+    })]
+
+
+def test_authorize_discord_user_falls_back_after_405(monkeypatch):
+    import asyncio
+
+    calls = []
+
+    def fake_post(path, payload):
+        calls.append(path)
+        if path == '/connect':
+            raise discord_bot.WalterApiError('Walter API returned HTTP 405: Method Not Allowed')
+        return {'authorized': True}
+
+    api = discord_bot.WalterApiClient('http://walter.test', 'token')
+    monkeypatch.setattr(api, '_post_json_sync', fake_post)
+
+    assert asyncio.run(api.authorize_discord_user(123, 'walteruser', 'pass123')) == {'authorized': True}
+    assert calls == ['/connect', '/api/v1/discord/authorize']


### PR DESCRIPTION
### Motivation
- Some deployments still return HTTP 405 for the old `/connect` endpoint so the bot should try the legacy endpoint first and fall back when necessary.
- The generated one-time Discord pass must be more prominent so users reliably copy it before it disappears.
- Password managers were auto-filling the Discord username field, which can cause incorrect authorizations and must be discouraged.
- Showing the current Discord username on the settings page improves clarity when diagnosing connect issues.

### Description
- Change `WalterApiClient.authorize_discord_user` to attempt `POST /connect` first and fall back to `POST /api/v1/discord/authorize` if a `WalterApiError` indicates HTTP 405. (`discord_bot.py`)
- Update `app/templates/user_settings.html` to display the current Discord username, render the one-time pass with a `one-time-discord-pass` class, update the connected status text, and add `autocomplete="off"` plus common password-manager ignore attributes to the username input. (`app/templates/user_settings.html`)
- Add CSS rules for `.one-time-discord-pass` to make the pass larger and more visible. (`app/static/style.css`)
- Add tests that cover the `/connect`-first behavior and 405 fallback, and a test asserting the settings page shows the pass prominently and disables autofill. (`tests/test_discord_bot.py`, `tests/test_api.py`)

### Testing
- Ran the updated bot and API unit tests with `pytest tests/test_discord_bot.py` and the new `tests/test_api.py` checks, and they passed.
- Ran `pytest tests -q` and a final `pytest -q` full-suite run locally; the final run completed successfully with `106 passed` (warnings only).
- Note: some environments may run the vendored `walter-bot/tests` async suite which requires an async pytest plugin such as `pytest-asyncio`, and those tests can fail if the plugin is missing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3478e7af74832089cf923049ec4672)

## Summary by Sourcery

Update the Discord connect flow to prefer the legacy /connect endpoint with fallback and improve the Discord connection UX in user settings.

New Features:
- Display the current Discord username and clearer connection status text on the user settings page.
- Highlight the one-time Discord pass with dedicated styling to make it more prominent.

Bug Fixes:
- Ensure Discord authorization attempts the legacy /connect endpoint first and falls back to the newer API when /connect returns HTTP 405.
- Discourage password managers from auto-filling the Discord username field on the settings page.

Enhancements:
- Add styling for the one-time Discord pass block to improve visibility and readability.

Tests:
- Add tests verifying the /connect-first Discord authorization behavior and HTTP 405 fallback.
- Add an integration test asserting the settings page shows the Discord pass prominently and disables password managers on the username input.