### PR TITLE
Fix /connect endpoint and add admin API logs

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -34,6 +34,7 @@ import glob
 import secrets
 import csv
 import hashlib
+import time
 import urllib.parse
 import urllib.request
 from collections import OrderedDict
@@ -404,6 +405,7 @@ def create_app():
             Vendor,
             ArtistProfile,
             ApiKey,
+            ApiLog,
             SiteLog,
             TournamentLog,
         )  # lazy import to avoid circular reference
@@ -474,6 +476,7 @@ def create_app():
         ApiKey.__table__.create(bind=db.engine, checkfirst=True)
 
         logs_engine = db.engines['logs']
+        ApiLog.__table__.create(bind=logs_engine, checkfirst=True)
         SiteLog.__table__.create(bind=logs_engine, checkfirst=True)
         logs_inspector = inspect(logs_engine)
         if 'site_log' in logs_inspector.get_table_names():
@@ -569,6 +572,7 @@ def create_app():
         DEFAULT_ROLE_PERMISSIONS,
         DEFAULT_ROLE_LEVELS,
         SiteLog,
+        ApiLog,
         TournamentLog,
         Message,
         Report,
@@ -1786,6 +1790,79 @@ def create_app():
     def _api_log(action, result, error=None):
         _safe_log_site(f'api.{action}', result, error)
 
+    def _is_api_logging_request():
+        return request.path.startswith('/api/') or request.path.rstrip('/') == '/connect'
+
+    def _redacted_api_headers():
+        headers = {}
+        sensitive = {'authorization', 'cookie', 'set-cookie', 'x-api-key'}
+        for key, value in request.headers.items():
+            headers[key] = '[redacted]' if key.lower() in sensitive else value
+        return headers
+
+    def _decode_body(data):
+        if not data:
+            return ''
+        text_value = data.decode('utf-8', errors='replace')
+        max_len = 20000
+        if len(text_value) > max_len:
+            return text_value[:max_len] + f'… [truncated {len(text_value) - max_len} chars]'
+        return text_value
+
+    def _safe_api_log_entry(response=None, error=None):
+        if not getattr(request, '_walter_api_log_enabled', False):
+            return
+        try:
+            response_body = ''
+            status_code = getattr(response, 'status_code', None)
+            if response is not None and not response.direct_passthrough:
+                response_body = _decode_body(response.get_data())
+            duration_ms = int((time.monotonic() - getattr(request, '_walter_api_started_at', time.monotonic())) * 1000)
+            user = None
+            api_key = None
+            try:
+                user, api_key = _api_current_user()
+            except Exception:
+                db.session.rollback()
+            entry = ApiLog(
+                method=request.method,
+                path=request.path,
+                query_string=request.query_string.decode('utf-8', errors='replace'),
+                status_code=status_code,
+                request_headers=json.dumps(_redacted_api_headers(), sort_keys=True),
+                request_body=_decode_body(getattr(request, '_walter_api_request_body', b'')),
+                response_body=response_body,
+                error=str(error) if error else None,
+                duration_ms=duration_ms,
+                api_key_id=api_key.id if api_key else None,
+                api_user_id=user.id if user else None,
+                ip_address=_client_ip(),
+                user_agent=request.headers.get('User-Agent', ''),
+            )
+            db.session.add(entry)
+            db.session.commit()
+        except Exception:
+            db.session.rollback()
+            app.logger.exception('Unable to write API log entry for %s %s', request.method, request.path)
+
+    @app.before_request
+    def capture_api_log_request():
+        if not _is_api_logging_request():
+            return
+        request._walter_api_log_enabled = True
+        request._walter_api_started_at = time.monotonic()
+        request._walter_api_request_body = request.get_data(cache=True)
+
+    @app.after_request
+    def capture_api_log_response(response):
+        _safe_api_log_entry(response=response)
+        return response
+
+    @app.teardown_request
+    def capture_api_log_exception(exc):
+        if exc is not None:
+            _safe_api_log_entry(error=exc)
+
     def _api_current_user():
         auth = request.headers.get('Authorization', '')
         token = ''
@@ -2082,11 +2159,11 @@ def create_app():
             'round': round_payload(round_obj),
         })
 
-    @app.route('/connect', methods=['POST'], strict_slashes=False)
+    @app.route('/connect', methods=['GET', 'POST'], strict_slashes=False)
     @app.route('/api/v1/discord/authorize', methods=['POST'], strict_slashes=False)
     def api_discord_authorize():
         require_api_permission('tournaments.manage')
-        data = request.get_json(silent=True) or {}
+        data = request.get_json(silent=True) or request.values.to_dict()
         discord_user_id = str(data.get('discord_user_id') or '').strip()
         discord_username = _normalize_discord_username(data.get('discord_username'))
         one_time_pass = str(data.get('one_time_pass') or '').strip()
@@ -5035,6 +5112,15 @@ def create_app():
             return redirect(url_for('permissions'))
         roles = db.session.query(Role).order_by(Role.level, Role.name).all()
         return render_template('admin/permissions.html', roles=roles, permission_groups=PERMISSION_GROUPS)
+
+    @app.route('/admin/api-logs')
+    def admin_api_logs():
+        require_admin()
+        log_site('view_api_logs', 'success')
+        logs = db.session.query(ApiLog).order_by(ApiLog.timestamp.desc()).limit(500).all()
+        user_ids = {log.api_user_id for log in logs if log.api_user_id}
+        users = {u.id: u for u in db.session.query(User).filter(User.id.in_(user_ids)).all()} if user_ids else {}
+        return render_template('admin/api_logs.html', logs=logs, users=users)
 
     @app.route('/admin/logs')
     def site_logs():

--- a/app/models.py
+++ b/app/models.py
@@ -451,6 +451,25 @@ class ArtistProfile(db.Model):
 
     venue = db.relationship('Venue', backref=db.backref('artists', cascade='all, delete-orphan'))
 
+class ApiLog(db.Model):
+    __bind_key__ = 'logs'
+    id = db.Column(db.Integer, primary_key=True)
+    method = db.Column(db.String(12), nullable=False)
+    path = db.Column(db.Text, nullable=False)
+    query_string = db.Column(db.Text, nullable=True)
+    status_code = db.Column(db.Integer, nullable=True)
+    request_headers = db.Column(db.Text, nullable=True)
+    request_body = db.Column(db.Text, nullable=True)
+    response_body = db.Column(db.Text, nullable=True)
+    error = db.Column(db.Text, nullable=True)
+    timestamp = db.Column(db.DateTime, default=utc_now)
+    duration_ms = db.Column(db.Integer, nullable=True)
+    api_key_id = db.Column(db.Integer, nullable=True)
+    api_user_id = db.Column(db.Integer, nullable=True)
+    ip_address = db.Column(db.String(64), nullable=True)
+    user_agent = db.Column(db.Text, nullable=True)
+
+
 class SiteLog(db.Model):
     __bind_key__ = 'logs'
     id = db.Column(db.Integer, primary_key=True)

--- a/app/templates/admin/api_logs.html
+++ b/app/templates/admin/api_logs.html
@@ -1,0 +1,54 @@
+{% extends 'base.html' %}
+{% block content %}
+<div class="page-header">
+  <div>
+    <h2>API Logs</h2>
+    <p class="page-description">Verbose request and response logs for API endpoints, including the legacy <code>/connect</code> endpoint.</p>
+  </div>
+</div>
+{% if logs %}
+  <div class="table-responsive">
+    <table>
+      <thead>
+        <tr>
+          <th>Time</th>
+          <th>Request</th>
+          <th>Status</th>
+          <th>User</th>
+          <th>IP</th>
+          <th>Duration</th>
+          <th>Details</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for log in logs %}
+        <tr>
+          <td>{{ log.timestamp }}</td>
+          <td><code>{{ log.method }} {{ log.path }}{% if log.query_string %}?{{ log.query_string }}{% endif %}</code></td>
+          <td>{{ log.status_code or '-' }}</td>
+          <td>{% if log.api_user_id and users.get(log.api_user_id) %}{{ users.get(log.api_user_id).name }}{% elif log.api_user_id %}User #{{ log.api_user_id }}{% else %}-{% endif %}</td>
+          <td>{{ log.ip_address or '-' }}</td>
+          <td>{% if log.duration_ms is not none %}{{ log.duration_ms }} ms{% else %}-{% endif %}</td>
+          <td>
+            <details>
+              <summary>View</summary>
+              <p><strong>User agent:</strong> {{ log.user_agent or '-' }}</p>
+              <p><strong>API key ID:</strong> {{ log.api_key_id or '-' }}</p>
+              {% if log.error %}<p><strong>Error:</strong> {{ log.error }}</p>{% endif %}
+              <h4>Request headers</h4>
+              <pre>{{ log.request_headers or '' }}</pre>
+              <h4>Request body</h4>
+              <pre>{{ log.request_body or '' }}</pre>
+              <h4>Response body</h4>
+              <pre>{{ log.response_body or '' }}</pre>
+            </details>
+          </td>
+        </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+  </div>
+{% else %}
+  <p class="empty-state compact-empty">No API calls have been logged yet.</p>
+{% endif %}
+{% endblock %}

--- a/app/templates/admin/panel.html
+++ b/app/templates/admin/panel.html
@@ -24,6 +24,7 @@
   <div class="section-heading"><div><h3>Security Controls</h3><p>Audit bad logins and manage IP lockouts.</p></div></div>
   <div class="form-actions">
     <a class="btn" href="{{ url_for('admin_current_connections') }}">Current Connections</a>
+    <a class="btn" href="{{ url_for('admin_api_logs') }}">API Logs</a>
     <a class="btn" href="{{ url_for('admin_bad_logins') }}">Bad Login Audit</a>
     <a class="btn" href="{{ url_for('admin_ip_blacklist') }}">IP Blacklist</a>
   </div>

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,4 @@
-from app.models import ApiKey, League, MatchResult, Role, Round, SiteLog, Tournament, TournamentPlayer, User
+from app.models import ApiKey, ApiLog, League, MatchResult, Role, Round, SiteLog, Tournament, TournamentPlayer, User
 from app.pairing import pair_round
 
 
@@ -30,6 +30,12 @@ def test_admin_can_create_api_key_and_call_admin_api(client, session):
     assert create_response.get_json()['name'] == 'API League'
     assert session.query(League).filter_by(name='API League').one().is_cube_league
     assert session.query(SiteLog).filter_by(action='api.leagues.create', result='success').count() == 1
+    api_log = session.query(ApiLog).filter_by(path='/api/v1/leagues').one()
+    assert api_log.method == 'POST'
+    assert api_log.status_code == 201
+    assert 'API League' in api_log.request_body
+    assert 'API League' in api_log.response_body
+    assert '[redacted]' in api_log.request_headers
 
 
 def test_non_admin_cannot_create_api_key(client, session):
@@ -153,6 +159,36 @@ def test_discord_authorization_accepts_legacy_connect_endpoint(client, session):
     session.refresh(player)
     assert player.discord_user_id == '2345678901'
     assert player.discord_authorization_token_hash is None
+    api_log = session.query(ApiLog).filter_by(path='/connect').order_by(ApiLog.id.desc()).first()
+    assert api_log is not None
+    assert api_log.status_code == 200
+
+
+def test_discord_authorization_accepts_connect_query_parameters(client, session):
+    token = _admin_api_token(session)
+    user_role = session.query(Role).filter_by(name='user').one()
+    player = User(email='discord-connect-query@example.com', name='Discord Connect Query', role=user_role)
+    one_time_pass = 'connectquery123'
+    player.discord_username = 'walterquery'
+    player.set_discord_authorization_token(one_time_pass)
+    session.add(player)
+    session.commit()
+
+    response = client.get(
+        '/connect',
+        query_string={
+            'discord_user_id': '3456789012',
+            'discord_username': 'walterquery',
+            'one_time_pass': one_time_pass,
+        },
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert response.status_code == 200
+    session.refresh(player)
+    assert player.discord_user_id == '3456789012'
+    assert player.discord_authorization_token_hash is None
+
 
 def test_discord_authorization_requires_username_and_one_time_pass(client, session):
     token = _admin_api_token(session)


### PR DESCRIPTION
### Motivation
- Clients (including the Discord bot) were receiving 405s from the legacy `/connect` endpoint when they issued GET requests or used query parameters instead of JSON POST bodies.\
- There was no centralized verbose API audit trail accessible from the admin UI to diagnose API calls and authorization problems.\
- We need an admin-only place to view full request/response metadata (with sensitive headers redacted) to debug API failures.\

### Description
- Added a logs-bound `ApiLog` model to persist verbose API request/response metadata (method, path, query string, headers, request/response bodies, status, timing, API key/user IDs, IP, user-agent). (`app/models.py`)\
- Implemented request/response capture for API calls and the legacy `/connect` endpoint, including request-body capture, response capture, duration calculation, and redaction of sensitive headers like `Authorization` and `X-API-Key`. (`app/app.py`)\
- Made the legacy `/connect` endpoint accept `GET` and `POST` and read parameters from JSON body or query/form parameters to avoid 405 errors from clients that use query parameters. (`app/app.py`)\
- Added an admin-only UI page at `/admin/api-logs` and a template to list recent API logs with expandable request/response details, and linked it from the admin debug panel. (`app/templates/admin/api_logs.html`, `app/templates/admin/panel.html`)\
- Extended API tests to assert API log entries are created and redacted, and added a test that exercises `/connect` with query parameters. (`tests/test_api.py`)\

### Testing
- Ran `pytest tests/test_api.py -q` and the API-focused tests passed.\
- Ran `pytest tests -q` (tests directory) and the repository app tests covering the server/DB/API logic passed (reporting the test run that targets the application tests).\
- Ran the full `pytest -q` in this environment and observed unrelated failures in the bundled `walter-bot` async tests because the environment is missing an async pytest plugin (e.g. `pytest-asyncio`); the failures are external to the app changes and do not indicate regressions in the API logging or `/connect` fixes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34b57948608320b463345bfaf58753)

## Summary by Sourcery

Add centralized API request/response logging and improve legacy /connect endpoint compatibility.

New Features:
- Introduce an ApiLog model bound to the logs database to store detailed API request and response metadata.
- Add an admin-only API Logs page linked from the admin debug panel to inspect recent API activity with per-call details.

Bug Fixes:
- Update the legacy /connect endpoint to accept both GET and POST requests and support parameters from JSON bodies or query/form/query parameters to avoid 405 errors.

Enhancements:
- Capture and persist redacted request headers, bodies, responses, timing, and user/key context for API and /connect traffic via global request/response hooks.
- Extend API tests to verify API log creation, header redaction, and successful use of /connect with query parameters.