### PR TITLE
Add /connect GET status for bot probes and enrich Discord authorize logs

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2167,7 +2167,23 @@ def create_app():
         discord_user_id = str(data.get('discord_user_id') or '').strip()
         discord_username = _normalize_discord_username(data.get('discord_username'))
         one_time_pass = str(data.get('one_time_pass') or '').strip()
+
+        def _discord_authorize_log_details(**extra):
+            details = {
+                'discord_user_id': discord_user_id,
+                'discord_username': discord_username,
+                **extra,
+            }
+            return '; '.join(f'{key}={value}' for key, value in details.items() if value not in (None, ''))
+
         if not discord_user_id or not one_time_pass:
+            if request.method == 'GET' and not request.values:
+                _api_log('discord.authorize', 'success', 'connect endpoint status')
+                return jsonify({
+                    'ok': True,
+                    'endpoint': '/connect',
+                    'message': 'Use POST with discord_user_id and one_time_pass to connect a Discord account.',
+                })
             return _json_error('discord_user_id and one_time_pass are required')
         user = None
         for candidate in db.session.query(User).filter(User.discord_authorization_token_hash.isnot(None)).all():
@@ -2175,7 +2191,7 @@ def create_app():
                 user = candidate
                 break
         if not user:
-            _api_log('discord.authorize', 'failure', 'invalid pass')
+            _api_log('discord.authorize', 'failure', _discord_authorize_log_details(error='invalid pass'))
             return _json_error('invalid or expired one-time pass', 403)
         if not user.discord_username:
             return _json_error('add your Discord username in Walter user settings before authorizing', 403)
@@ -2187,7 +2203,7 @@ def create_app():
         user.discord_user_id = discord_user_id
         user.discord_authorization_token_hash = None
         db.session.commit()
-        _api_log('discord.authorize', 'success', f'user_id={user.id}')
+        _api_log('discord.authorize', 'success', _discord_authorize_log_details(user_id=user.id))
         return jsonify({'authorized': True, 'user': user_payload(user)})
 
     @app.route('/api/v1/discord/report-pairing', methods=['POST'], strict_slashes=False)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -135,6 +135,29 @@ def _admin_api_token(session):
 
 
 
+
+def test_connect_get_without_parameters_returns_status_for_bot_probe(client, session):
+    token = _admin_api_token(session)
+
+    response = client.get(
+        '/connect',
+        headers={
+            'Authorization': f'Bearer {token}',
+            'User-Agent': 'WalterDiscordBot/1.0',
+        },
+    )
+
+    assert response.status_code == 200
+    assert response.get_json() == {
+        'ok': True,
+        'endpoint': '/connect',
+        'message': 'Use POST with discord_user_id and one_time_pass to connect a Discord account.',
+    }
+    api_log = session.query(ApiLog).filter_by(path='/connect').order_by(ApiLog.id.desc()).first()
+    assert api_log is not None
+    assert api_log.status_code == 200
+
+
 def test_discord_authorization_accepts_legacy_connect_endpoint(client, session):
     token = _admin_api_token(session)
     user_role = session.query(Role).filter_by(name='user').one()
@@ -162,6 +185,34 @@ def test_discord_authorization_accepts_legacy_connect_endpoint(client, session):
     api_log = session.query(ApiLog).filter_by(path='/connect').order_by(ApiLog.id.desc()).first()
     assert api_log is not None
     assert api_log.status_code == 200
+    site_log = session.query(SiteLog).filter_by(action='api.discord.authorize').order_by(SiteLog.id.desc()).first()
+    assert site_log is not None
+    assert site_log.result == 'success'
+    assert f'user_id={player.id}' in site_log.error
+    assert 'discord_user_id=2345678901' in site_log.error
+    assert 'discord_username=walterconnect' in site_log.error
+
+
+def test_discord_authorization_logs_bot_username_for_invalid_pass(client, session):
+    token = _admin_api_token(session)
+
+    response = client.post(
+        '/connect',
+        json={
+            'discord_user_id': '4567890123',
+            'discord_username': 'wrongpassuser',
+            'one_time_pass': 'not-the-pass',
+        },
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert response.status_code == 403
+    site_log = session.query(SiteLog).filter_by(action='api.discord.authorize').order_by(SiteLog.id.desc()).first()
+    assert site_log is not None
+    assert site_log.result == 'failure'
+    assert 'error=invalid pass' in site_log.error
+    assert 'discord_user_id=4567890123' in site_log.error
+    assert 'discord_username=wrongpassuser' in site_log.error
 
 
 def test_discord_authorization_accepts_connect_query_parameters(client, session):


### PR DESCRIPTION
### Motivation

- Provide a safe status response for bot probes hitting the legacy `/connect` endpoint via GET and avoid treating empty GETs as errors. 
- Improve logging for Discord authorization flows to include the bot-supplied `discord_user_id` and `discord_username` and preserve existing `user_id` context for better auditability.

### Description

- Added a helper `_discord_authorize_log_details` to format log details with `discord_user_id`, `discord_username`, and extra fields. 
- Return a JSON status from `GET /connect` when the request has no query/body parameters and log a successful probe instead of returning an error. 
- Updated success and failure logging in the Discord authorize flow to include the composed details string rather than plain messages. 
- Extended tests in `tests/test_api.py` to cover the GET probe behavior and to assert that site logs contain the combined log fields on both success and failure.

### Testing

- Added and ran `tests/test_api.py::test_connect_get_without_parameters_returns_status_for_bot_probe` which asserts a `200` probe response and an `ApiLog` entry, and the test passed. 
- Ran `tests/test_api.py::test_discord_authorization_accepts_legacy_connect_endpoint` which now also asserts `SiteLog` contains `user_id`, `discord_user_id`, and `discord_username`, and the test passed. 
- Ran `tests/test_api.py::test_discord_authorization_logs_bot_username_for_invalid_pass` which validates failure logging includes `error`, `discord_user_id`, and `discord_username`, and the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34b868735c8320a555831efe1fbd02)

## Summary by Sourcery

Handle bot status probes on the legacy /connect endpoint and enrich Discord authorization logging.

New Features:
- Return a JSON status response for GET /connect requests without parameters to support bot health probes.

Enhancements:
- Include discord_user_id and discord_username, along with optional user_id and error fields, in Discord authorization success and failure logs for better traceability.

Tests:
- Add and extend API and logging tests to cover GET /connect probe behavior and detailed Discord authorization logging for both success and failure flows.