### PR TITLE
Require Discord username on connect

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2167,24 +2167,25 @@ def create_app():
         discord_user_id = str(data.get('discord_user_id') or '').strip()
         discord_username = _normalize_discord_username(data.get('discord_username'))
         one_time_pass = str(data.get('one_time_pass') or '').strip()
+        discord_display_name = _normalize_discord_username(data.get('discord_display_name'))
+        discord_global_name = _normalize_discord_username(data.get('discord_global_name'))
 
         def _discord_authorize_log_details(**extra):
             details = {
                 'discord_user_id': discord_user_id,
                 'discord_username': discord_username,
+                'discord_display_name': discord_display_name,
+                'discord_global_name': discord_global_name,
                 **extra,
             }
             return '; '.join(f'{key}={value}' for key, value in details.items() if value not in (None, ''))
 
-        if not discord_user_id or not one_time_pass:
-            if request.method == 'GET' and not request.values:
-                _api_log('discord.authorize', 'success', 'connect endpoint status')
-                return jsonify({
-                    'ok': True,
-                    'endpoint': '/connect',
-                    'message': 'Use POST with discord_user_id and one_time_pass to connect a Discord account.',
-                })
-            return _json_error('discord_user_id and one_time_pass are required')
+        if request.method != 'POST':
+            _api_log('discord.authorize', 'failure', _discord_authorize_log_details(error='method not allowed'))
+            return _json_error('Use POST with discord_user_id, discord_username, and one_time_pass to connect a Discord account.', 405)
+        if not discord_user_id or not discord_username or not one_time_pass:
+            _api_log('discord.authorize', 'failure', _discord_authorize_log_details(error='missing required connection fields'))
+            return _json_error('discord_user_id, discord_username, and one_time_pass are required')
         user = None
         for candidate in db.session.query(User).filter(User.discord_authorization_token_hash.isnot(None)).all():
             if candidate.check_discord_authorization_token(one_time_pass):
@@ -2195,7 +2196,8 @@ def create_app():
             return _json_error('invalid or expired one-time pass', 403)
         if not user.discord_username:
             return _json_error('add your Discord username in Walter user settings before authorizing', 403)
-        if discord_username and user.discord_username.lower() != discord_username.lower():
+        if user.discord_username.lower() != discord_username.lower():
+            _api_log('discord.authorize', 'failure', _discord_authorize_log_details(user_id=user.id, error='username mismatch'))
             return _json_error('Discord username does not match Walter user settings', 403)
         existing = db.session.query(User).filter(User.discord_user_id == discord_user_id, User.id != user.id).first()
         if existing:

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -16,6 +16,10 @@ from pathlib import Path
 from typing import Any
 from urllib import error, request
 
+
+def _bot_log(message: str) -> None:
+    print(message, flush=True)
+
 VENDORED_DISCORD_PATH = Path(__file__).resolve().parent / 'walter-bot'
 if VENDORED_DISCORD_PATH.is_dir():
     sys.path.insert(0, str(VENDORED_DISCORD_PATH))
@@ -119,12 +123,28 @@ class WalterApiClient:
     async def latest_round(self, tournament_id: int) -> dict[str, Any]:
         return await self.get_json(f'/api/v1/tournaments/{tournament_id}/rounds/latest')
 
-    async def authorize_discord_user(self, discord_user_id: int, discord_username: str, one_time_pass: str) -> dict[str, Any]:
+    async def authorize_discord_user(
+        self,
+        discord_user_id: int,
+        discord_username: str,
+        one_time_pass: str,
+        discord_display_name: str = '',
+        discord_global_name: str = '',
+    ) -> dict[str, Any]:
         payload = {
             'discord_user_id': str(discord_user_id),
             'discord_username': discord_username,
+            'discord_display_name': discord_display_name,
+            'discord_global_name': discord_global_name,
             'one_time_pass': one_time_pass,
         }
+        _bot_log(
+            'Discord connect request: '
+            f'discord_user_id={discord_user_id}; '
+            f'discord_username={discord_username or "<missing>"}; '
+            f'discord_display_name={discord_display_name or "<missing>"}; '
+            f'discord_global_name={discord_global_name or "<missing>"}'
+        )
         try:
             return await self.post_json('/connect', payload)
         except WalterApiError as exc:
@@ -335,8 +355,16 @@ async def pairings(interaction: discord.Interaction, tournament_id: int):
 async def connect(interaction: discord.Interaction, one_time_pass: str):
     await interaction.response.defer(thinking=True, ephemeral=True)
     username = interaction.user.name
+    display_name = getattr(interaction.user, 'display_name', '') or ''
+    global_name = getattr(interaction.user, 'global_name', '') or ''
     try:
-        payload = await bot.api.authorize_discord_user(interaction.user.id, username, one_time_pass)
+        payload = await bot.api.authorize_discord_user(
+            interaction.user.id,
+            username,
+            one_time_pass,
+            discord_display_name=display_name,
+            discord_global_name=global_name,
+        )
         user = payload.get('user') or {}
         await interaction.followup.send(f"Connected Discord to Walter user **{user.get('name', 'Unknown')}**.", ephemeral=True)
     except WalterApiError as exc:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -136,7 +136,7 @@ def _admin_api_token(session):
 
 
 
-def test_connect_get_without_parameters_returns_status_for_bot_probe(client, session):
+def test_connect_get_without_parameters_rejects_anonymous_connection(client, session):
     token = _admin_api_token(session)
 
     response = client.get(
@@ -147,15 +147,13 @@ def test_connect_get_without_parameters_returns_status_for_bot_probe(client, ses
         },
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 405
     assert response.get_json() == {
-        'ok': True,
-        'endpoint': '/connect',
-        'message': 'Use POST with discord_user_id and one_time_pass to connect a Discord account.',
+        'error': 'Use POST with discord_user_id, discord_username, and one_time_pass to connect a Discord account.',
     }
     api_log = session.query(ApiLog).filter_by(path='/connect').order_by(ApiLog.id.desc()).first()
     assert api_log is not None
-    assert api_log.status_code == 200
+    assert api_log.status_code == 405
 
 
 def test_discord_authorization_accepts_legacy_connect_endpoint(client, session):
@@ -215,7 +213,7 @@ def test_discord_authorization_logs_bot_username_for_invalid_pass(client, sessio
     assert 'discord_username=wrongpassuser' in site_log.error
 
 
-def test_discord_authorization_accepts_connect_query_parameters(client, session):
+def test_discord_authorization_rejects_connect_query_parameters(client, session):
     token = _admin_api_token(session)
     user_role = session.query(Role).filter_by(name='user').one()
     player = User(email='discord-connect-query@example.com', name='Discord Connect Query', role=user_role)
@@ -235,11 +233,36 @@ def test_discord_authorization_accepts_connect_query_parameters(client, session)
         headers={'Authorization': f'Bearer {token}'},
     )
 
-    assert response.status_code == 200
+    assert response.status_code == 405
     session.refresh(player)
-    assert player.discord_user_id == '3456789012'
-    assert player.discord_authorization_token_hash is None
+    assert player.discord_user_id is None
+    assert player.discord_authorization_token_hash is not None
 
+
+
+def test_discord_authorization_rejects_missing_discord_username(client, session):
+    token = _admin_api_token(session)
+    user_role = session.query(Role).filter_by(name='user').one()
+    player = User(email='discord-missing-name@example.com', name='Discord Missing Name', role=user_role)
+    one_time_pass = 'missingname123'
+    player.discord_username = 'waltermissing'
+    player.set_discord_authorization_token(one_time_pass)
+    session.add(player)
+    session.commit()
+
+    response = client.post(
+        '/connect',
+        json={
+            'discord_user_id': '5678901234',
+            'one_time_pass': one_time_pass,
+        },
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json() == {'error': 'discord_user_id, discord_username, and one_time_pass are required'}
+    session.refresh(player)
+    assert player.discord_user_id is None
 
 def test_discord_authorization_requires_username_and_one_time_pass(client, session):
     token = _admin_api_token(session)

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -62,6 +62,8 @@ def test_authorize_discord_user_uses_connect_endpoint_first(monkeypatch):
     assert calls == [('/connect', {
         'discord_user_id': '123',
         'discord_username': 'walteruser',
+        'discord_display_name': '',
+        'discord_global_name': '',
         'one_time_pass': 'pass123',
     })]
 


### PR DESCRIPTION
### Motivation

- Prevent anonymous or query-string `/connect` probes from succeeding by requiring an authenticated POST with a Discord username and one-time pass. 
- Ensure the bot forwards more of the Discord identity (username, display name, global name) so the server can validate and log who initiated the connection. 
- Improve auditability by recording Discord identity fields in the API authorization logs so mismatches and failures can be traced. 

### Description

- Require `POST` and require `discord_user_id`, `discord_username`, and `one_time_pass` in the `/connect` handler in `app/app.py`, returning `405` for non-POST and `400` for missing fields. 
- Add `discord_display_name` and `discord_global_name` extraction and include these fields in `_discord_authorize_log_details` and site logs for `api.discord.authorize`. 
- Tighten username validation to always compare the normalized Walter `discord_username` against the provided `discord_username` and log mismatches. 
- Update `discord_bot.py` to pass `discord_display_name` and `discord_global_name` from `interaction.user`, add a `_bot_log` helper that prints flushed output (captured by `walter-bot.log`), and include the extra identity fields in the `/connect` payload. 
- Update tests to reflect the new behavior and payload fields in `tests/test_api.py` and `tests/test_discord_bot.py`, and add a test for missing `discord_username` in the connect payload. 

### Testing

- Ran the updated unit tests with `pytest -q tests/test_discord_bot.py tests/test_api.py` and all tests passed (`19 passed`).
- The updated tests exercise GET/POST `/connect` behaviors, username mismatch logging, and the bot-side `authorize_discord_user` payload changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34bb6a0b308320890d8f060db61d32)

## Summary by Sourcery

Require authenticated POST-based Discord connect requests with full username details and improve logging of Discord identity during authorization.

Bug Fixes:
- Reject anonymous or query-string-based /connect attempts with proper 405 responses and without binding Discord IDs.
- Validate that discord_username is provided and matches the stored Walter username before completing Discord authorization, logging mismatches for auditing.

Enhancements:
- Include Discord display and global names in authorization payloads and API logs to improve traceability of who initiated connections.
- Add bot-side logging of Discord connect requests and extend the Discord bot connect command to send additional identity fields.

Tests:
- Update API and bot tests for the stricter /connect behavior and new identity fields, and add coverage for missing discord_username in the connect payload.