### PR TITLE
Preserve POST for Discord bot /connect redirects

### DIFF
--- a/discord_bot.py
+++ b/discord_bot.py
@@ -14,7 +14,7 @@ import re
 import sys
 from pathlib import Path
 from typing import Any
-from urllib import error, request
+from urllib import error, parse, request
 
 
 def _bot_log(message: str) -> None:
@@ -63,6 +63,33 @@ def _format_http_error_detail(exc: error.HTTPError) -> str:
     return body or exc.reason or 'HTTP error'
 
 
+class _PreservePostRedirectHandler(request.HTTPRedirectHandler):
+    """Follow same-host redirects without converting JSON POSTs into GETs."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        if code not in {301, 302, 303, 307, 308}:
+            return None
+
+        old = parse.urlsplit(req.full_url)
+        new = parse.urlsplit(newurl)
+        if (old.hostname or '').lower() != (new.hostname or '').lower():
+            return None
+
+        old_port = old.port or (443 if old.scheme == 'https' else 80)
+        new_port = new.port or (443 if new.scheme == 'https' else 80)
+        if old_port != new_port and not (old.scheme == 'http' and old_port == 80 and new.scheme == 'https' and new_port == 443):
+            return None
+
+        return request.Request(
+            newurl,
+            data=req.data,
+            headers=dict(req.header_items()),
+            origin_req_host=req.origin_req_host,
+            unverifiable=True,
+            method=req.get_method(),
+        )
+
+
 class WalterApiClient:
     def __init__(self, base_url: str, api_key: str):
         self.base_url = base_url.rstrip('/')
@@ -106,7 +133,8 @@ class WalterApiClient:
         }
         api_request = request.Request(url, data=body, headers=headers, method='POST')
         try:
-            with request.urlopen(api_request, timeout=10) as response:
+            opener = request.build_opener(_PreservePostRedirectHandler)
+            with opener.open(api_request, timeout=10) as response:
                 return json.loads(response.read().decode('utf-8'))
         except error.HTTPError as exc:
             detail = _format_http_error_detail(exc)

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -84,3 +84,59 @@ def test_authorize_discord_user_falls_back_after_405(monkeypatch):
 
     assert asyncio.run(api.authorize_discord_user(123, 'walteruser', 'pass123')) == {'authorized': True}
     assert calls == ['/connect', '/api/v1/discord/authorize']
+
+
+def test_post_redirect_handler_preserves_connect_post_on_http_to_https_redirect():
+    import json
+    from urllib import request
+
+    body = json.dumps({'one_time_pass': 'pass123'}).encode('utf-8')
+    original = request.Request(
+        'http://walter-pair.us/connect',
+        data=body,
+        headers={
+            'Accept': 'application/json',
+            'Authorization': 'Bearer token',
+            'Content-Type': 'application/json',
+            'User-Agent': 'WalterDiscordBot/1.0',
+        },
+        method='POST',
+    )
+
+    redirected = discord_bot._PreservePostRedirectHandler().redirect_request(
+        original,
+        None,
+        301,
+        'Moved Permanently',
+        {},
+        'https://walter-pair.us/connect',
+    )
+
+    assert redirected is not None
+    assert redirected.full_url == 'https://walter-pair.us/connect'
+    assert redirected.get_method() == 'POST'
+    assert redirected.data == body
+    assert redirected.get_header('Content-type') == 'application/json'
+    assert redirected.get_header('Authorization') == 'Bearer token'
+
+
+def test_post_redirect_handler_rejects_cross_host_redirect():
+    from urllib import request
+
+    original = request.Request(
+        'http://walter-pair.us/connect',
+        data=b'{}',
+        headers={'Content-Type': 'application/json'},
+        method='POST',
+    )
+
+    redirected = discord_bot._PreservePostRedirectHandler().redirect_request(
+        original,
+        None,
+        302,
+        'Found',
+        {},
+        'https://example.com/connect',
+    )
+
+    assert redirected is None


### PR DESCRIPTION
### Motivation
- The bot's `POST` to `/connect` could be converted to a `GET` when an HTTP→HTTPS or other same-host redirect occurred, causing the `/connect` command to lose its JSON body and fail.
- Redirects that change host must still be rejected to avoid sending credentials to a different origin.

### Description
- Add a `_PreservePostRedirectHandler` class in `discord_bot.py` that implements `redirect_request` and preserves the HTTP method, body, and headers for same-host redirects with compatible ports.  
- Switch `WalterApiClient._post_json_sync` to use `request.build_opener(_PreservePostRedirectHandler)` so bot POSTs use the redirect-preserving opener.  
- Add two regression tests to `tests/test_discord_bot.py` that assert a same-host `http`→`https` redirect preserves the `POST` and that cross-host redirects are rejected.  
- Changes touch `discord_bot.py` and `tests/test_discord_bot.py`.

### Testing
- Ran `pytest tests/test_discord_bot.py` and the test suite passed with `9 passed, 1 warning`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34bd4acd048320b378f6bf30f71882)

## Summary by Sourcery

Preserve Discord bot /connect POST requests across safe same-host redirects while adding protections against cross-host redirects.

Bug Fixes:
- Ensure Discord bot JSON POSTs to /connect are not converted to GET requests when following same-host HTTP→HTTPS redirects.
- Reject cross-host redirects when handling Discord bot /connect requests to avoid leaking credentials.

Enhancements:
- Introduce a custom redirect handler that preserves method, body, and headers for safe same-host redirects and wire it into the synchronous JSON POST client.

Tests:
- Add regression tests verifying POST preservation on same-host HTTP→HTTPS redirects and rejection of cross-host redirects for the Discord bot client.