### PR TITLE
Add Discord bot league commands and API league standings endpoint

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1918,6 +1918,39 @@ def create_app():
             })
         return rows
 
+    def league_standings_payload(league):
+        league_players = db.session.query(LeaguePlayer).filter_by(league_id=league.id).all()
+        results = db.session.query(LeagueResult).filter_by(league_id=league.id).all()
+        results_by_player = {}
+        for result in results:
+            results_by_player.setdefault(result.user_id, []).append(result)
+
+        rows = []
+        for league_player in league_players:
+            player_results = sorted(
+                results_by_player.get(league_player.user_id, []),
+                key=lambda result: (result.points or 0, result.wins or 0, -(result.losses or 0)),
+                reverse=True,
+            )
+            played = len(player_results)
+            counted_count = math.ceil(played * 0.75) if played else 0
+            counted = player_results[:counted_count]
+            rows.append({
+                'user_id': league_player.user_id,
+                'name': league_player.user.name if league_player.user else 'Unknown',
+                'played': played,
+                'counted_count': counted_count,
+                'league_points': sum(result.points or 0 for result in counted),
+                'raw_points': sum(result.points or 0 for result in player_results),
+                'wins': sum(result.wins or 0 for result in counted),
+                'draws': sum(result.draws or 0 for result in counted),
+                'losses': sum(result.losses or 0 for result in counted),
+            })
+        rows.sort(key=lambda row: (-row['league_points'], -row['wins'], row['losses'], row['name'].lower()))
+        for index, row in enumerate(rows, start=1):
+            row['rank'] = index
+        return rows
+
     def match_payload(match):
         players = []
         for player in (match.player1, match.player2, match.player3, match.player4):
@@ -2258,6 +2291,18 @@ def create_app():
         log_tournament(tournament.id, 'discord_report', 'success', f'user_id={user.id}; match_id={match.id}')
         _api_log('discord.report_pairing', 'success', f'tournament_id={tournament.id}; match_id={match.id}; user_id={user.id}')
         return jsonify({'reported': True, 'match': match_payload(match), 'round': round_payload(round_obj)})
+
+    @app.route('/api/v1/leagues/<int:league_id>/standings')
+    def api_league_standings(league_id):
+        require_api_permission('tournaments.manage')
+        league = db.session.get(League, league_id)
+        if not league:
+            return _json_error('not found', 404)
+        _api_log('leagues.standings', 'success', f'league_id={league.id}')
+        return jsonify({
+            'league': league_payload(league),
+            'standings': league_standings_payload(league),
+        })
 
     @app.route('/api/v1/leagues/<int:league_id>', methods=['GET', 'PATCH', 'DELETE'])
     def api_league_detail(league_id):

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -145,6 +145,12 @@ class WalterApiClient:
     async def tournaments(self) -> dict[str, Any]:
         return await self.get_json('/api/v1/tournaments')
 
+    async def leagues(self) -> dict[str, Any]:
+        return await self.get_json('/api/v1/leagues')
+
+    async def league_standings(self, league_id: int) -> dict[str, Any]:
+        return await self.get_json(f'/api/v1/leagues/{league_id}/standings')
+
     async def standings(self, tournament_id: int) -> dict[str, Any]:
         return await self.get_json(f'/api/v1/tournaments/{tournament_id}/standings')
 
@@ -230,6 +236,22 @@ def format_standings(payload: dict[str, Any]) -> str:
     return _truncate_lines(lines)
 
 
+def format_league_standings(payload: dict[str, Any]) -> str:
+    league = payload.get('league') or {}
+    standings = payload.get('standings') or []
+    lines = [f"**League standings: {league.get('name', 'League')}**"]
+    if not standings:
+        lines.append('No league standings are available yet.')
+        return '\n'.join(lines)
+
+    for row in standings:
+        lines.append(
+            f"{row['rank']}. {row['name']} — {row['league_points']} pts "
+            f"({row['wins']}-{row['losses']}-{row['draws']}, {row['played']} events)"
+        )
+    return _truncate_lines(lines)
+
+
 def format_pairings(payload: dict[str, Any]) -> str:
     tournament = payload.get('tournament') or {}
     round_payload = payload.get('round') or {}
@@ -284,7 +306,7 @@ class WalterBot(discord.Client):
         if BOT_CHANNEL_ID and BOT_ANNOUNCE_READY and not self._ready_announced:
             channel = await self._get_messageable_channel(BOT_CHANNEL_ID)
             if channel is not None:
-                await channel.send('Walter bot is online. Use `/tournaments`, `/standings`, `/pairings`, or `/connect` to get started.')
+                await channel.send('Walter bot is online. Use `/tournaments`, `/leagues`, `/standings`, `/league_standings`, `/pairings`, or `/connect` to get started.')
                 self._ready_announced = True
 
     async def _sync_guild_commands(self):
@@ -354,6 +376,31 @@ async def tournaments(interaction: discord.Interaction):
         for tournament in tournaments_payload[:25]:
             lines.append(f"{tournament['id']}: {tournament['name']} ({tournament['format']})")
         await interaction.followup.send(_truncate_lines(lines), ephemeral=True)
+    except WalterApiError as exc:
+        await interaction.followup.send(str(exc), ephemeral=True)
+
+
+@bot.tree.command(name='leagues', description='List Walter leagues.')
+async def leagues(interaction: discord.Interaction):
+    await interaction.response.defer(thinking=True)
+    try:
+        payload = await bot.api.leagues()
+        leagues_payload = payload.get('leagues') or []
+        lines = ['**Walter leagues**']
+        for league in leagues_payload[:25]:
+            league_type = 'cube league' if league.get('is_cube_league') else 'league'
+            lines.append(f"{league['id']}: {league['name']} ({league_type})")
+        await interaction.followup.send(_truncate_lines(lines), ephemeral=True)
+    except WalterApiError as exc:
+        await interaction.followup.send(str(exc), ephemeral=True)
+
+
+@bot.tree.command(name='league_standings', description='Print league standings.')
+@app_commands.describe(league_id='Walter league ID')
+async def league_standings(interaction: discord.Interaction, league_id: int):
+    await interaction.response.defer(thinking=True)
+    try:
+        await interaction.followup.send(format_league_standings(await bot.api.league_standings(league_id)))
     except WalterApiError as exc:
         await interaction.followup.send(str(exc), ephemeral=True)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,4 @@
-from app.models import ApiKey, ApiLog, League, MatchResult, Role, Round, SiteLog, Tournament, TournamentPlayer, User
+from app.models import ApiKey, ApiLog, League, LeaguePlayer, LeagueResult, MatchResult, Role, Round, SiteLog, Tournament, TournamentPlayer, User
 from app.pairing import pair_round
 
 
@@ -121,6 +121,38 @@ def test_api_key_can_read_tournament_standings_and_latest_round(client, session)
     assert len(latest_round['matches']) == 2
     assert latest_round['matches'][0]['table_number'] == 1
     assert len(latest_round['matches'][0]['players']) == 2
+
+
+def test_api_key_can_read_league_standings(client, session):
+    token = _admin_api_token(session)
+    user_role = session.query(Role).filter_by(name='user').one()
+    league = League(name='API Standings League')
+    player_one = User(email='league-one@example.com', name='League One', role=user_role)
+    player_two = User(email='league-two@example.com', name='League Two', role=user_role)
+    tournament = Tournament(name='League Event', format='Draft', league=league)
+    session.add_all([league, player_one, player_two, tournament])
+    session.flush()
+    session.add_all([
+        LeaguePlayer(league_id=league.id, user_id=player_one.id),
+        LeaguePlayer(league_id=league.id, user_id=player_two.id),
+        LeagueResult(league_id=league.id, tournament_id=tournament.id, user_id=player_one.id, points=9, wins=3, draws=0, losses=0),
+        LeagueResult(league_id=league.id, tournament_id=tournament.id, user_id=player_two.id, points=3, wins=1, draws=0, losses=2),
+    ])
+    session.commit()
+
+    response = client.get(
+        f'/api/v1/leagues/{league.id}/standings',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['league']['name'] == 'API Standings League'
+    assert payload['standings'][0]['rank'] == 1
+    assert payload['standings'][0]['name'] == 'League One'
+    assert payload['standings'][0]['league_points'] == 9
+    assert payload['standings'][0]['wins'] == 3
+    assert payload['standings'][0]['played'] == 1
 
 
 def _admin_api_token(session):

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -15,6 +15,8 @@ def test_discord_bot_registers_all_expected_slash_commands():
         'connect',
         'pairings',
         'report_pairing',
+        'league_standings',
+        'leagues',
         'standings',
         'tournaments',
     }.issubset(command_names)
@@ -140,3 +142,23 @@ def test_post_redirect_handler_rejects_cross_host_redirect():
     )
 
     assert redirected is None
+
+
+def test_format_league_standings_includes_record_and_events():
+    payload = {
+        'league': {'name': 'Friday League'},
+        'standings': [{
+            'rank': 1,
+            'name': 'Player One',
+            'league_points': 9,
+            'wins': 3,
+            'losses': 1,
+            'draws': 0,
+            'played': 2,
+        }],
+    }
+
+    assert discord_bot.format_league_standings(payload) == (
+        '**League standings: Friday League**\n'
+        '1. Player One — 9 pts (3-1-0, 2 events)'
+    )


### PR DESCRIPTION
### Motivation
- Provide Discord users with the ability to list leagues and view league standings from the Walter site via the bot.
- Expose an API endpoint to return league standings payloads so the bot can retrieve ranked league data programmatically.

### Description
- Added `league_standings_payload` and an API route `GET /api/v1/leagues/<league_id>/standings` that returns `{'league': ..., 'standings': [...]}` using the same counted-results scoring logic (`app/app.py`).
- Extended the Discord API client `WalterApiClient` with `leagues()` and `league_standings(league_id)` to call the new endpoints (`discord_bot.py`).
- Implemented `format_league_standings(payload)` to render league standings for Discord and added slash commands `leagues` and `league_standings` to the bot, and updated the ready announcement to mention the new commands (`discord_bot.py`).
- Added/updated tests to cover the new API endpoint and bot formatting/command registration in `tests/test_api.py` and `tests/test_discord_bot.py`.

### Testing
- Ran `pytest tests/test_discord_bot.py tests/test_api.py` which completed successfully with `23 passed` (warnings only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34c06413bc83209c881c6a6b2b5a22)

## Summary by Sourcery

Add API support and Discord bot commands for viewing Walter league listings and standings.

New Features:
- Expose a league standings API endpoint returning league metadata and computed standings for a given league.
- Add Discord bot commands to list leagues and display league standings using the new API payloads.

Enhancements:
- Extend the Discord API client and formatting helpers to handle league listings and league standings output.
- Update the bot ready announcement to advertise the new league-related commands.

Tests:
- Add API tests covering league standings retrieval and ranking fields.
- Extend Discord bot tests to validate registration of new commands and league standings formatting.