### PR TITLE
Add cube league play date listing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2307,6 +2307,33 @@ def create_app():
             'standings': league_standings_payload(league),
         })
 
+
+    def league_play_date_payload(play_date):
+        return {
+            'id': play_date.id,
+            'play_date': play_date.play_date.isoformat(),
+            'is_active': bool(play_date.is_active),
+            'available_cube_count': len(play_date.available_cubes),
+        }
+
+    @app.route('/api/v1/leagues/<int:league_id>/play-dates')
+    def api_league_play_dates(league_id):
+        require_api_permission('tournaments.manage')
+        league = db.session.get(League, league_id)
+        if not league or not league.is_cube_league:
+            return _json_error('cube league not found', 404)
+        play_dates = (
+            db.session.query(LeaguePlayDate)
+            .filter_by(league_id=league.id)
+            .order_by(LeaguePlayDate.play_date, LeaguePlayDate.id)
+            .all()
+        )
+        _api_log('leagues.play_dates', 'success', f'league_id={league.id}')
+        return jsonify({
+            'league': league_payload(league),
+            'play_dates': [league_play_date_payload(play_date) for play_date in play_dates],
+        })
+
     def cube_vote_poll_payload(league, play_date):
         available_links = sorted(play_date.available_cubes, key=lambda link: link.cube.title.lower())
         totals = {

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -152,6 +152,9 @@ class WalterApiClient:
     async def league_standings(self, league_id: int) -> dict[str, Any]:
         return await self.get_json(f'/api/v1/leagues/{league_id}/standings')
 
+    async def league_play_dates(self, league_id: int) -> dict[str, Any]:
+        return await self.get_json(f'/api/v1/leagues/{league_id}/play-dates')
+
     async def standings(self, tournament_id: int) -> dict[str, Any]:
         return await self.get_json(f'/api/v1/tournaments/{tournament_id}/standings')
 
@@ -277,6 +280,24 @@ def format_league_standings(payload: dict[str, Any]) -> str:
             f"{row['rank']}. {row['name']} — {row['league_points']} pts "
             f"({row['wins']}-{row['losses']}-{row['draws']}, {row['played']} events)"
         )
+    return _truncate_lines(lines)
+
+
+def format_league_play_dates(payload: dict[str, Any]) -> str:
+    league = payload.get('league') or {}
+    play_dates = payload.get('play_dates') or []
+    lines = [
+        f"**Play dates for {league.get('name', 'League')}**",
+        'Use the play date ID with `/cube_poll league_id:<league id> play_date_id:<play date id>`.',
+    ]
+    if not play_dates:
+        lines.append('No play dates are configured for this league.')
+        return '\n'.join(lines)
+
+    for play_date in play_dates:
+        status = 'active' if play_date.get('is_active') else 'inactive'
+        cube_count = play_date.get('available_cube_count', 0)
+        lines.append(f"{play_date['id']}: {play_date['play_date']} ({status}, {cube_count} cube(s))")
     return _truncate_lines(lines)
 
 
@@ -487,6 +508,19 @@ async def leagues(interaction: discord.Interaction):
             league_type = 'cube league' if league.get('is_cube_league') else 'league'
             lines.append(f"{league['id']}: {league['name']} ({league_type})")
         await interaction.followup.send(_truncate_lines(lines), ephemeral=True)
+    except WalterApiError as exc:
+        await interaction.followup.send(str(exc), ephemeral=True)
+
+
+@bot.tree.command(name='league_play_dates', description='List cube league play dates for /cube_poll.')
+@app_commands.describe(league_id='Walter cube league ID')
+async def league_play_dates(interaction: discord.Interaction, league_id: int):
+    await interaction.response.defer(thinking=True, ephemeral=True)
+    try:
+        await interaction.followup.send(
+            format_league_play_dates(await bot.api.league_play_dates(league_id)),
+            ephemeral=True,
+        )
     except WalterApiError as exc:
         await interaction.followup.send(str(exc), ephemeral=True)
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,22 @@
-from app.models import ApiKey, ApiLog, League, LeaguePlayer, LeagueResult, MatchResult, Role, Round, SiteLog, Tournament, TournamentPlayer, User
+from datetime import date
+
+from app.models import (
+    ApiKey,
+    ApiLog,
+    League,
+    LeagueCube,
+    LeaguePlayDate,
+    LeaguePlayDateCube,
+    LeaguePlayer,
+    LeagueResult,
+    MatchResult,
+    Role,
+    Round,
+    SiteLog,
+    Tournament,
+    TournamentPlayer,
+    User,
+)
 from app.pairing import pair_round
 
 
@@ -167,6 +185,33 @@ def _admin_api_token(session):
 
 
 
+def test_api_key_can_list_cube_league_play_dates_for_discord_poll(client, session):
+    token = _admin_api_token(session)
+    league = League(name='API Cube Dates', is_cube_league=True)
+    cube = LeagueCube(
+        league=league,
+        cube_cobra_url='https://cubecobra.com/cube/overview/alpha',
+        title='Alpha Cube',
+    )
+    first = LeaguePlayDate(league=league, play_date=date(2026, 7, 1), is_active=True)
+    second = LeaguePlayDate(league=league, play_date=date(2026, 7, 8), is_active=False)
+    session.add_all([league, cube, first, second])
+    session.flush()
+    session.add(LeaguePlayDateCube(play_date_id=first.id, cube_id=cube.id))
+    session.commit()
+
+    response = client.get(
+        f'/api/v1/leagues/{league.id}/play-dates',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert response.status_code == 200
+    payload = response.get_json()
+    assert payload['league']['name'] == 'API Cube Dates'
+    assert payload['play_dates'] == [
+        {'id': first.id, 'play_date': '2026-07-01', 'is_active': True, 'available_cube_count': 1},
+        {'id': second.id, 'play_date': '2026-07-08', 'is_active': False, 'available_cube_count': 0},
+    ]
 
 def test_connect_get_without_parameters_rejects_anonymous_connection(client, session):
     token = _admin_api_token(session)

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -16,6 +16,7 @@ def test_discord_bot_registers_all_expected_slash_commands():
         'cube_poll',
         'pairings',
         'report_pairing',
+        'league_play_dates',
         'league_standings',
         'leagues',
         'standings',
@@ -180,3 +181,20 @@ def test_format_cube_poll_includes_options_and_vote_totals():
     assert '**Cube vote: Cube League — 2026-07-01**' in formatted
     assert '1️⃣ **Alpha Cube** — 2 vote(s)' in formatted
     assert '2️⃣ **Beta Cube** — 1 vote(s)' in formatted
+
+
+def test_format_league_play_dates_shows_ids_for_cube_poll():
+    payload = {
+        'league': {'id': 7, 'name': 'Cube League'},
+        'play_dates': [
+            {'id': 42, 'play_date': '2026-07-01', 'is_active': True, 'available_cube_count': 3},
+            {'id': 43, 'play_date': '2026-07-08', 'is_active': False, 'available_cube_count': 1},
+        ],
+    }
+
+    formatted = discord_bot.format_league_play_dates(payload)
+
+    assert '**Play dates for Cube League**' in formatted
+    assert '/cube_poll league_id:<league id> play_date_id:<play date id>' in formatted
+    assert '42: 2026-07-01 (active, 3 cube(s))' in formatted
+    assert '43: 2026-07-08 (inactive, 1 cube(s))' in formatted


### PR DESCRIPTION
### Motivation

- Provide a way to list cube-league play dates (with IDs and available cube counts) so Discord users can find the `play_date_id` required by `/cube_poll`.
- Expose the play-date information via an authenticated API so bots and external tools can query play dates for a cube league.

### Description

- Add a new API route `GET /api/v1/leagues/<league_id>/play-dates` in `app/app.py` that returns the league and a list of play dates including `id`, `play_date`, `is_active`, and `available_cube_count`, with permission checks and logging.
- Add `league_play_dates` to the Discord API client in `discord_bot.py` to call the new endpoint.
- Implement `format_league_play_dates(payload)` in `discord_bot.py` to format the response for Discord and add a `/league_play_dates` slash command that posts the formatted, ephemeral listing and instructs users to use the `play_date_id` with `/cube_poll`.
- Add tests: `test_api.py` includes `test_api_key_can_list_cube_league_play_dates_for_discord_poll`, and `tests/test_discord_bot.py` adds command-registration expectations and `test_format_league_play_dates_shows_ids_for_cube_poll` for the formatter output.

### Testing

- Ran `python -m pytest tests/test_discord_bot.py tests/test_api.py -q` and all tests passed (`26 passed`) with warnings only, indicating the new API, formatter, and command behave as expected.
- The formatter and command registration tests in `tests/test_discord_bot.py` and the API test in `tests/test_api.py` passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b19a844408320abf35ef04cd7d7a0)

## Summary by Sourcery

Add API and Discord support for listing cube league play dates, including IDs and available cube counts, for use with cube poll commands.

New Features:
- Expose a league play dates listing via GET /api/v1/leagues/<league_id>/play-dates, returning league metadata and play date details for cube leagues.
- Add a Discord slash command /league_play_dates that fetches and displays league play dates for use with /cube_poll.

Tests:
- Add API test covering cube league play dates listing, including cube counts and active status ordering.
- Extend Discord bot tests to cover registration of the new /league_play_dates command and the league play dates formatter output.