### PR TITLE
Fix Discord cube poll vote syncing

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2372,6 +2372,25 @@ def create_app():
             return _json_error('cube vote not found', 404)
         return jsonify(cube_vote_poll_payload(league, play_date))
 
+    def discord_cube_poll_payload(poll):
+        return {
+            'poll': {
+                'league_id': poll.league_id,
+                'play_date_id': poll.play_date_id,
+                'channel_id': poll.channel_id,
+                'message_id': poll.message_id,
+            },
+            'cube_vote': cube_vote_poll_payload(poll.league, poll.play_date),
+        }
+
+    @app.route('/api/v1/discord/cube-polls/<message_id>')
+    def api_discord_cube_poll(message_id):
+        require_api_permission('tournaments.manage')
+        poll = db.session.query(LeagueCubeDiscordPoll).filter_by(message_id=str(message_id)).first()
+        if not poll:
+            return _json_error('Discord cube poll not found', 404)
+        return jsonify(discord_cube_poll_payload(poll))
+
     @app.route('/api/v1/discord/cube-polls', methods=['POST'], strict_slashes=False)
     def api_discord_cube_poll_register():
         require_api_permission('tournaments.manage')
@@ -2394,7 +2413,7 @@ def create_app():
         poll.play_date_id = play_date.id
         poll.channel_id = channel_id
         db.session.commit()
-        return jsonify({'registered': True, 'poll': {'message_id': poll.message_id}})
+        return jsonify({'registered': True, **discord_cube_poll_payload(poll)})
 
     @app.route('/api/v1/discord/cube-vote', methods=['POST'], strict_slashes=False)
     def api_discord_cube_vote():

--- a/discord_bot.py
+++ b/discord_bot.py
@@ -219,6 +219,9 @@ class WalterApiClient:
             'message_id': str(message_id),
         })
 
+    async def cube_poll_by_message(self, message_id: int) -> dict[str, Any]:
+        return await self.get_json(f'/api/v1/discord/cube-polls/{message_id}')
+
     async def submit_cube_vote(
         self,
         discord_user_id: int,
@@ -432,8 +435,33 @@ class WalterBot(discord.Client):
                 print(f'Pairing poll failed: {exc}')
             await asyncio.sleep(max(BOT_POLL_INTERVAL_SECONDS, 10))
 
-    async def _refresh_cube_poll_message(self, message_id: int):
+    def _cache_cube_poll_metadata(self, poll_payload: dict[str, Any], message: Any | None = None) -> dict[str, Any]:
+        poll = poll_payload.get('poll') or {}
+        cube_vote = poll_payload.get('cube_vote') or {}
+        cubes = (cube_vote.get('cubes') or [])[:len(CUBE_POLL_EMOJIS)]
+        metadata = {
+            'league_id': poll['league_id'],
+            'play_date_id': poll['play_date_id'],
+            'channel_id': int(poll['channel_id']),
+            'cube_ids': [cube['id'] for cube in cubes],
+        }
+        if message is not None:
+            metadata['message'] = message
+        self._cube_polls[int(poll['message_id'])] = metadata
+        return metadata
+
+    async def _metadata_for_cube_poll_message(self, message_id: int) -> dict[str, Any] | None:
         metadata = self._cube_polls.get(message_id)
+        if metadata:
+            return metadata
+        try:
+            return self._cache_cube_poll_metadata(await self.api.cube_poll_by_message(message_id))
+        except WalterApiError as exc:
+            print(f'Could not load Discord cube poll metadata for message {message_id}: {exc}')
+            return None
+
+    async def _refresh_cube_poll_message(self, message_id: int):
+        metadata = await self._metadata_for_cube_poll_message(message_id)
         if not metadata:
             return
         try:
@@ -463,7 +491,7 @@ class WalterBot(discord.Client):
     async def _handle_cube_vote_reaction(self, payload: discord.RawReactionActionEvent, selected: bool):
         if payload.user_id == (self.user.id if self.user else None):
             return
-        metadata = self._cube_polls.get(payload.message_id)
+        metadata = await self._metadata_for_cube_poll_message(payload.message_id)
         if not metadata:
             return
         emoji = str(payload.emoji)
@@ -634,14 +662,9 @@ async def cube_poll(interaction: discord.Interaction, league_id: int, play_date_
             await interaction.followup.send(f'Posted the poll, but could not pin it: {exc}', ephemeral=True)
         else:
             await interaction.followup.send('Posted and pinned the cube vote poll.', ephemeral=True)
-        bot._cube_polls[message.id] = {
-            'league_id': league_id,
-            'play_date_id': play_date_id,
-            'channel_id': message.channel.id,
-            'message': message,
-            'cube_ids': [cube['id'] for cube in cubes],
-        }
-        await bot.api.register_cube_poll(league_id, play_date_id, message.channel.id, message.id)
+        poll_payload = await bot.api.register_cube_poll(league_id, play_date_id, message.channel.id, message.id)
+        poll_payload['cube_vote'] = payload
+        bot._cache_cube_poll_metadata(poll_payload, message)
         bot.loop.create_task(bot._poll_cube_vote_updates(message.id))
     except WalterApiError as exc:
         await interaction.followup.send(str(exc), ephemeral=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -213,6 +213,54 @@ def test_api_key_can_list_cube_league_play_dates_for_discord_poll(client, sessio
         {'id': second.id, 'play_date': '2026-07-08', 'is_active': False, 'available_cube_count': 0},
     ]
 
+def test_api_key_can_fetch_registered_discord_cube_poll(client, session):
+    token = _admin_api_token(session)
+    league = League(name='API Cube Poll Lookup', is_cube_league=True)
+    cube = LeagueCube(
+        league=league,
+        cube_cobra_url='https://cubecobra.com/cube/overview/lookup',
+        title='Lookup Cube',
+    )
+    play_date = LeaguePlayDate(league=league, play_date=date(2026, 7, 1), is_active=True)
+    session.add_all([league, cube, play_date])
+    session.flush()
+    session.add(LeaguePlayDateCube(play_date_id=play_date.id, cube_id=cube.id))
+    session.commit()
+
+    register_response = client.post(
+        '/api/v1/discord/cube-polls',
+        json={
+            'league_id': league.id,
+            'play_date_id': play_date.id,
+            'channel_id': '12345',
+            'message_id': '67890',
+        },
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert register_response.status_code == 200
+    registered_payload = register_response.get_json()
+    assert registered_payload['registered'] is True
+    assert registered_payload['poll'] == {
+        'league_id': league.id,
+        'play_date_id': play_date.id,
+        'channel_id': '12345',
+        'message_id': '67890',
+    }
+    assert registered_payload['cube_vote']['cubes'][0]['id'] == cube.id
+
+    lookup_response = client.get(
+        '/api/v1/discord/cube-polls/67890',
+        headers={'Authorization': f'Bearer {token}'},
+    )
+
+    assert lookup_response.status_code == 200
+    lookup_payload = lookup_response.get_json()
+    assert lookup_payload['poll'] == registered_payload['poll']
+    assert lookup_payload['cube_vote']['league']['name'] == 'API Cube Poll Lookup'
+    assert lookup_payload['cube_vote']['cubes'][0]['title'] == 'Lookup Cube'
+
+
 def test_connect_get_without_parameters_rejects_anonymous_connection(client, session):
     token = _admin_api_token(session)
 

--- a/tests/test_discord_bot.py
+++ b/tests/test_discord_bot.py
@@ -198,3 +198,16 @@ def test_format_league_play_dates_shows_ids_for_cube_poll():
     assert '/cube_poll league_id:<league id> play_date_id:<play date id>' in formatted
     assert '42: 2026-07-01 (active, 3 cube(s))' in formatted
     assert '43: 2026-07-08 (inactive, 1 cube(s))' in formatted
+
+
+def test_cache_cube_poll_metadata_uses_registered_poll_payload():
+    payload = {
+        'poll': {'league_id': 7, 'play_date_id': 42, 'channel_id': '12345', 'message_id': '67890'},
+        'cube_vote': {'cubes': [{'id': 111}, {'id': 222}]},
+    }
+    client = discord_bot.WalterBot()
+
+    metadata = client._cache_cube_poll_metadata(payload)
+
+    assert metadata == {'league_id': 7, 'play_date_id': 42, 'channel_id': 12345, 'cube_ids': [111, 222]}
+    assert client._cube_polls[67890] == metadata


### PR DESCRIPTION
### Motivation
- Ensure Discord reactions continue to mirror cube-vote state on the site when the bot has restarted or the in-memory poll cache is missing by providing a way to recover poll metadata by Discord message ID.
- Avoid missed vote syncs caused by cache misses and make poll registration responses useful for bootstrapping bot state.

### Description
- Add `discord_cube_poll_payload` helper and a new API endpoint `GET /api/v1/discord/cube-polls/<message_id>` that returns registered poll metadata plus the current cube-vote payload. (`app/app.py`)
- Update `POST /api/v1/discord/cube-polls` to return the same full metadata payload on registration instead of only the message id. (`app/app.py`)
- Add `cube_poll_by_message` to `WalterApiClient` and implement `WalterBot._cache_cube_poll_metadata` and `_metadata_for_cube_poll_message` to hydrate and cache poll metadata from the API. (`discord_bot.py`)
- Change `_refresh_cube_poll_message`, the reaction handlers, and the `/cube_poll` command to use the new metadata hydration path so reactions trigger `submit_cube_vote` even when the bot has no cached poll data. (`discord_bot.py`)
- Add regression tests for the API lookup and metadata caching (`tests/test_api.py`, `tests/test_discord_bot.py`).

### Testing
- Ran `pytest tests/test_discord_bot.py tests/test_api.py -q` and the test suite passed (all tests succeeded).
- Added `test_api_key_can_fetch_registered_discord_cube_poll` to verify the lookup endpoint payload and `test_cache_cube_poll_metadata_uses_registered_poll_payload` to validate bot caching behavior; both are covered by the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b1c1cbf0483209c94f831f5a84a43)

## Summary by Sourcery

Expose Discord cube poll metadata via API and update the Discord bot to hydrate and cache poll state from the backend for robust vote syncing.

New Features:
- Add an authenticated API endpoint to fetch registered Discord cube poll metadata and associated cube-vote payload by message ID.
- Return full poll and cube-vote metadata from the Discord cube poll registration API instead of only the message ID.

Enhancements:
- Teach the Discord bot to cache cube poll metadata from API responses and to lazily hydrate missing poll state when handling reactions or refreshing poll messages.

Tests:
- Add API and bot unit tests covering Discord cube poll lookup, registration payload contents, and cache population behavior.