### PR TITLE
Generate tournament join QR codes locally

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -37,6 +37,9 @@ import hashlib
 import time
 import urllib.parse
 import urllib.request
+
+import qrcode
+
 from collections import OrderedDict
 from urllib.parse import urlparse
 from html.parser import HTMLParser
@@ -1391,7 +1394,7 @@ def create_app():
         if not t:
             abort(404)
         join_url = url_for('tournament_join_link', tid=tid, _external=True)
-        qr_url = f"https://api.qrserver.com/v1/create-qr-code/?size=320x320&data={join_url}"
+        qr_url = url_for('tournament_join_qr', tid=tid)
         is_player = False
         if current_user.is_authenticated:
             is_player = (
@@ -1401,6 +1404,27 @@ def create_app():
                 is not None
             )
         return render_template('tournament/join_link.html', t=t, join_url=join_url, qr_url=qr_url, is_player=is_player)
+
+    @app.route('/t/<int:tid>/join-qr.png')
+    def tournament_join_qr(tid):
+        from .models import Tournament
+        t = db.session.get(Tournament, tid)
+        if not t:
+            abort(404)
+        join_url = url_for('tournament_join_link', tid=tid, _external=True)
+        qr = qrcode.QRCode(
+            version=None,
+            error_correction=qrcode.constants.ERROR_CORRECT_M,
+            box_size=10,
+            border=4,
+        )
+        qr.add_data(join_url)
+        qr.make(fit=True)
+        img = qr.make_image(fill_color='black', back_color='white')
+        buf = io.BytesIO()
+        img.save(buf, format='PNG')
+        buf.seek(0)
+        return send_file(buf, mimetype='image/png', max_age=3600)
 
     @app.route('/logout')
     @login_required

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ cryptography==48.0.0
 psutil==5.9.8
 PyYAML==6.0.1
 Pillow==12.2.0
+qrcode==8.2
 waitress==3.0.2
 aiohttp>=3.7.4,<4
 audioop-lts; python_version>='3.13'

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -765,6 +765,32 @@ def test_duplicate_booth_numbers_are_blocked_across_artists_and_vendors(client, 
     assert session.query(ArtistProfile).filter_by(name='Duplicate Artist').first() is None
 
 
+def test_tournament_join_link_uses_local_qr_image(client, session):
+    tournament = Tournament(name='Local QR Event', format='Constructed')
+    session.add(tournament)
+    session.commit()
+
+    response = client.get(f'/t/{tournament.id}/join-link')
+
+    assert response.status_code == 200
+    html = response.get_data(as_text=True)
+    assert f'src="/t/{tournament.id}/join-qr.png"' in html
+    assert 'api.qrserver.com' not in html
+
+
+def test_tournament_join_qr_returns_png(client, session):
+    tournament = Tournament(name='PNG QR Event', format='Constructed')
+    session.add(tournament)
+    session.commit()
+
+    response = client.get(f'/t/{tournament.id}/join-qr.png')
+
+    assert response.status_code == 200
+    assert response.mimetype == 'image/png'
+    assert response.data.startswith(b'\x89PNG\r\n\x1a\n')
+    assert len(response.data) > 100
+
+
 def test_player_join_qr_only_visible_to_tournament_managers(client, session):
     manager_role = session.query(Role).filter_by(name='manager').one()
     user_role = session.query(Role).filter_by(name='user').one()


### PR DESCRIPTION
### Motivation
- QR images were being generated via an external API which caused broken/unstable QR display and an external dependency.

### Description
- Serve a local QR PNG at the new endpoint `GET /t/<int:tid>/join-qr.png` using the `qrcode` library and `send_file`.
- Update the join link page to reference the local QR URL (`qr_url = url_for('tournament_join_qr', tid=tid)`) instead of the external `api.qrserver.com` image API.
- Add `qrcode==8.2` to `requirements.txt` and import `qrcode` in the application.
- Add two regression tests: `test_tournament_join_link_uses_local_qr_image` and `test_tournament_join_qr_returns_png` in `tests/test_tournament.py`.

### Testing
- Ran `pytest tests/test_tournament.py -q` which completed successfully with all tests passing (`27 passed, 41 warnings`).
- The newly added tests asserting the local QR image URL and that the QR endpoint returns a valid PNG both passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b251086f08320ba9cd7a4a93b3b82)

## Summary by Sourcery

Serve tournament join QR codes from a new local endpoint and update the join link page to use it instead of an external QR service.

New Features:
- Add a /t/<tid>/join-qr.png endpoint that generates and serves a PNG QR code for the tournament join URL.

Enhancements:
- Switch tournament join link pages to reference a locally generated QR image rather than an external QR API.
- Add the qrcode dependency to support local QR code generation.

Tests:
- Add regression tests to verify the join link page uses the local QR image and that the QR endpoint returns a valid PNG.