### PR TITLE
Fix startup when QR dependency is missing and ensure venv Python compatibility

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -38,8 +38,6 @@ import time
 import urllib.parse
 import urllib.request
 
-import qrcode
-
 from collections import OrderedDict
 from urllib.parse import urlparse
 from html.parser import HTMLParser
@@ -1407,6 +1405,8 @@ def create_app():
 
     @app.route('/t/<int:tid>/join-qr.png')
     def tournament_join_qr(tid):
+        import qrcode
+
         from .models import Tournament
         t = db.session.get(Tournament, tid)
         if not t:

--- a/start-server.sh
+++ b/start-server.sh
@@ -361,10 +361,20 @@ install_python_package_support() {
   fi
 }
 
+venv_python_supported() {
+  [[ -x "$VENV_DIR/bin/python" ]] || return 1
+  "$VENV_DIR/bin/python" -c 'import sys; raise SystemExit(0 if (3, 10) <= sys.version_info[:2] <= (3, 12) else 1)' >/dev/null 2>&1
+}
+
 ensure_venv() {
   if [[ -x "$VENV_DIR/bin/python" ]]; then
-    PYTHON_BIN="$VENV_DIR/bin/python"
-    return 0
+    if venv_python_supported; then
+      PYTHON_BIN="$VENV_DIR/bin/python"
+      return 0
+    fi
+
+    echo "Existing virtual environment uses an unsupported Python version; recreating it with $PYTHON_BIN." >&2
+    rm -rf "$VENV_DIR"
   fi
 
   if ! "$PYTHON_BIN" -m venv "$VENV_DIR"; then


### PR DESCRIPTION
### Motivation
- Prevent Flask CLI commands and app import from failing when the optional `qrcode` package is not installed in the active environment. 
- Avoid using an existing virtualenv that was created with an unsupported Python version, which can bypass the script's supported Python selection and cause runtime issues.

### Description
- Removed the module-level `qrcode` import and instead import `qrcode` inside the tournament QR route so the dependency is only required when the route is used (`app/app.py`).
- Added a `venv_python_supported` check and updated `ensure_venv()` to recreate the `.venv` if it exists but uses an unsupported Python version, with an explanatory message before removing the venv (`start-server.sh`).
- The changes scope the QR dependency to runtime use and ensure the startup script enforces the script's supported Python range before installing requirements.

### Testing
- Ran `python -m py_compile app/app.py` which succeeded.
- Validated shell script syntax with `bash -n start-server.sh` and verified `import app.app` via `timeout 10s python -c 'import app.app; print("app import ok")'`, both succeeded.
- Confirmed Flask CLI commands are available with `timeout 10s python -m flask --app app.app --help | sed -n '/Commands:/,$p'`, which listed commands successfully.
- Ran `pytest -q tests/test_db_upgrade.py tests/test_api.py` and all tests passed (`22 passed`, with warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b30c0c748832096ecf51da6d53471)

## Summary by Sourcery

Ensure application startup and routing behave correctly when optional QR dependencies are absent and when an existing virtual environment uses an unsupported Python version.

Bug Fixes:
- Delay importing the optional qrcode dependency until the tournament QR route is invoked so the app can start without qrcode installed.
- Avoid reusing an existing virtual environment created with an unsupported Python version by detecting it and recreating the venv.

Enhancements:
- Add a Python version compatibility check for the virtual environment to enforce the supported Python range before use.