### PR TITLE
Ensure QR generation dependencies include image support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ cryptography==48.0.0
 psutil==5.9.8
 PyYAML==6.0.1
 Pillow==12.2.0
-qrcode==8.2
+qrcode[pil]==8.2
 waitress==3.0.2
 aiohttp>=3.7.4,<4
 audioop-lts; python_version>='3.13'


### PR DESCRIPTION
### Motivation
- Fix QR generation failures where the local `/t/<tid>/join-qr.png` endpoint could not render PNG images because the `qrcode` package was installed without its image (Pillow) extras.

### Description
- Update `requirements.txt` to replace `qrcode==8.2` with `qrcode[pil]==8.2` so the package installs its Pillow/image extra and can produce PNG QR images.

### Testing
- Installed with `python -m pip install 'qrcode[pil]==8.2'` and ran `pytest -q tests/test_tournament.py::test_tournament_join_qr_returns_png tests/test_tournament.py::test_tournament_join_link_uses_local_qr_image`, and both tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b321ba91483208dffa84844c9862c)