### PR TITLE
Fix default Flask bind address display

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -4,7 +4,7 @@ admin_email: admin@example.com
 admin_pass: admin123
 flask_secret: dev-secret-change-me
 password_seed: dev-password-seed-change-me
-flask_ip: 192.168.1.7
+flask_ip: 0.0.0.0
 flask_port: 5000
 last_table_number: 200
 # Optional production HTTPS settings. When tls_domain is set, start-server.sh

--- a/scripts/install_nginx_config.sh
+++ b/scripts/install_nginx_config.sh
@@ -302,12 +302,17 @@ escape_sed_replacement() {
 }
 
 render_config() {
-  local escaped_domain escaped_server_names escaped_cert_dir escaped_acme_webroot escaped_flask_ip escaped_flask_port
+  local escaped_domain escaped_server_names escaped_cert_dir escaped_acme_webroot escaped_flask_ip escaped_flask_port upstream_flask_ip
+  upstream_flask_ip="$FLASK_IP"
+  if [[ "$upstream_flask_ip" == "0.0.0.0" || "$upstream_flask_ip" == "::" || "$upstream_flask_ip" == "[::]" ]]; then
+    upstream_flask_ip="127.0.0.1"
+  fi
+
   escaped_domain="$(escape_sed_replacement "$TLS_DOMAIN")"
   escaped_server_names="$(escape_sed_replacement "${SERVER_NAMES:-$TLS_DOMAIN}")"
   escaped_cert_dir="$(escape_sed_replacement "$CERT_DIR")"
   escaped_acme_webroot="$(escape_sed_replacement "$ACME_WEBROOT")"
-  escaped_flask_ip="$(escape_sed_replacement "$FLASK_IP")"
+  escaped_flask_ip="$(escape_sed_replacement "$upstream_flask_ip")"
   escaped_flask_port="$(escape_sed_replacement "$FLASK_PORT")"
 
   GENERATED_CONFIG="$(mktemp)"

--- a/start-server.ps1
+++ b/start-server.ps1
@@ -95,7 +95,7 @@ if([string]::IsNullOrEmpty($DatabasePath)){ $DatabasePath = $DefaultDb }
 if([string]::IsNullOrEmpty($LogDatabasePath)){ $LogDatabasePath = $DefaultLogDb }
 if([string]::IsNullOrEmpty($FlaskSecret)){ $FlaskSecret = "dev-secret-change-me" }
 if([string]::IsNullOrEmpty($PasswordSeed)){ $PasswordSeed = "dev-password-seed-change-me" }
-if([string]::IsNullOrEmpty($FlaskIP)){ $FlaskIP = "127.0.0.1" }
+if([string]::IsNullOrEmpty($FlaskIP)){ $FlaskIP = "0.0.0.0" }
 if([string]::IsNullOrEmpty($FlaskPort)){ $FlaskPort = 5000 }
 if([string]::IsNullOrEmpty($RegistrationPinTtlMinutes)){ $RegistrationPinTtlMinutes = 15 }
 if($null -eq $AccountCreationInviteOnly){ $AccountCreationInviteOnly = $false }
@@ -266,5 +266,24 @@ if(Test-BotRuntimeShouldStart){
 
 Start-Sleep -Seconds 3
 
+function Get-AppUrlHost {
+    param([string]$HostName)
+
+    # 0.0.0.0 and :: are bind addresses, not browsable destinations. When the
+    # app listens on every interface, show the primary IPv4 address instead.
+    if([string]::IsNullOrWhiteSpace($HostName) -or $HostName -eq "0.0.0.0" -or $HostName -eq "::" -or $HostName -eq "[::]"){
+        $ip = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
+            Where-Object { $_.IPAddress -notlike "169.254.*" -and $_.IPAddress -ne "127.0.0.1" } |
+            Sort-Object InterfaceMetric |
+            Select-Object -First 1 -ExpandProperty IPAddress
+        if([string]::IsNullOrWhiteSpace($ip)){ return "127.0.0.1" }
+        return $ip
+    }
+
+    return $HostName
+}
+
 #open the browser to the Flask app
-Start-Process "http://$($FlaskIP):$($FlaskPort)/"
+$AppUrlHost = Get-AppUrlHost $FlaskIP
+Start-Process "http://$($AppUrlHost):$($FlaskPort)/"
+Write-Host "Application URL: http://$($AppUrlHost):$($FlaskPort)/"

--- a/start-server.sh
+++ b/start-server.sh
@@ -510,7 +510,7 @@ ADMIN_EMAIL="${ADMIN_EMAIL:-admin@example.com}"
 ADMIN_PASS="${ADMIN_PASS:-admin123}"
 FLASK_SECRET="${FLASK_SECRET:-dev-secret-change-me}"
 PASSWORD_SEED="${PASSWORD_SEED:-dev-password-seed-change-me}"
-FLASK_IP="${FLASK_IP:-127.0.0.1}"
+FLASK_IP="${FLASK_IP:-0.0.0.0}"
 FLASK_PORT="${FLASK_PORT:-5000}"
 TLS_DOMAIN="${TLS_DOMAIN:-}"
 TLS_CERT_DIR="${TLS_CERT_DIR:-}"
@@ -811,7 +811,31 @@ fi
 
 sleep 3
 
-APP_URL="http://${FLASK_IP}:${FLASK_PORT}/"
+display_host_for_url() {
+  local host="$1"
+
+  # 0.0.0.0 and :: are bind addresses, not browsable destinations. When the
+  # app listens on every interface, show the primary address this machine uses
+  # for outbound LAN/Internet traffic instead.
+  if [[ "$host" == "0.0.0.0" || "$host" == "::" || "$host" == "[::]" || -z "$host" ]]; then
+    if command -v ip >/dev/null 2>&1; then
+      ip route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i <= NF; i++) if ($i == "src") {print $(i + 1); exit}}'
+      return
+    fi
+    if command -v hostname >/dev/null 2>&1; then
+      hostname -I 2>/dev/null | awk '{print $1}'
+      return
+    fi
+    printf '127.0.0.1\n'
+    return
+  fi
+
+  printf '%s\n' "$host"
+}
+
+APP_HOST="$(display_host_for_url "$FLASK_IP")"
+APP_HOST="${APP_HOST:-127.0.0.1}"
+APP_URL="http://${APP_HOST}:${FLASK_PORT}/"
 if command -v xdg-open >/dev/null 2>&1; then
   xdg-open "$APP_URL" >/dev/null 2>&1 || true
 elif command -v open >/dev/null 2>&1; then


### PR DESCRIPTION
### Motivation
- The repo used a placeholder LAN IP in `config.yaml` which could confuse users and prevent the server from listening on all interfaces by default.
- When Waitress is bound to a bind-all address like `0.0.0.0`, the startup scripts printed or opened an unusable URL and the Nginx renderer could produce an upstream with `0.0.0.0`, which is not a valid upstream target.

### Description
- Changed the default `flask_ip` in `config.yaml` from `192.168.1.7` to `0.0.0.0` so the app binds to all interfaces by default.
- Updated `start-server.sh` to default `FLASK_IP` to `0.0.0.0` and added `display_host_for_url()` to resolve bind-all addresses to a usable local address for `APP_URL` before opening or printing it.
- Updated `start-server.ps1` to default `$FlaskIP` to `0.0.0.0` and added `Get-AppUrlHost` to resolve bind-all addresses to a primary IPv4 address for browser launch and display.
- Updated `scripts/install_nginx_config.sh` rendering to substitute `0.0.0.0`/`::` upstream addresses with `127.0.0.1` so generated Nginx upstreams are connectable when the app is bound to all interfaces.

### Testing
- Ran a shell syntax check with `bash -n start-server.sh scripts/install_nginx_config.sh`, which completed without errors.
- Executed `./scripts/install_nginx_config.sh --dry-run --no-reload` to validate rendering and install steps, which completed successfully in dry-run mode.
- Attempted a PowerShell parser check for `start-server.ps1` with `pwsh`, but `pwsh` was not available in the environment so that parser check was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4af079d674832089034e374bf10c22)

## Summary by Sourcery

Update default Flask bind address to 0.0.0.0 and adjust startup and Nginx configuration scripts so user-facing URLs and upstreams resolve to a valid local host when the server is bound to all interfaces.

Bug Fixes:
- Ensure startup scripts display and open a usable local URL when the Flask server binds to 0.0.0.0 or ::.
- Make generated Nginx upstream targets valid by substituting bind-all addresses with 127.0.0.1.

Enhancements:
- Default Flask bind address to 0.0.0.0 in config and startup scripts so the app listens on all interfaces by default.