### PR TITLE
Use configured Flask IP in startup URL

### DIFF
--- a/start-server.ps1
+++ b/start-server.ps1
@@ -269,16 +269,10 @@ Start-Sleep -Seconds 3
 function Get-AppUrlHost {
     param([string]$HostName)
 
-    # 0.0.0.0 and :: are bind addresses, not browsable destinations. When the
-    # app listens on every interface, show the primary IPv4 address instead.
-    if([string]::IsNullOrWhiteSpace($HostName) -or $HostName -eq "0.0.0.0" -or $HostName -eq "::" -or $HostName -eq "[::]"){
-        $ip = Get-NetIPAddress -AddressFamily IPv4 -ErrorAction SilentlyContinue |
-            Where-Object { $_.IPAddress -notlike "169.254.*" -and $_.IPAddress -ne "127.0.0.1" } |
-            Sort-Object InterfaceMetric |
-            Select-Object -First 1 -ExpandProperty IPAddress
-        if([string]::IsNullOrWhiteSpace($ip)){ return "127.0.0.1" }
-        return $ip
-    }
+    # Use the configured Flask host exactly as provided in config.yaml so the
+    # startup output and browser launch match the configured bind address. Only
+    # fall back when the config value is empty.
+    if([string]::IsNullOrWhiteSpace($HostName)){ return "127.0.0.1" }
 
     return $HostName
 }

--- a/start-server.sh
+++ b/start-server.sh
@@ -814,18 +814,10 @@ sleep 3
 display_host_for_url() {
   local host="$1"
 
-  # 0.0.0.0 and :: are bind addresses, not browsable destinations. When the
-  # app listens on every interface, show the primary address this machine uses
-  # for outbound LAN/Internet traffic instead.
-  if [[ "$host" == "0.0.0.0" || "$host" == "::" || "$host" == "[::]" || -z "$host" ]]; then
-    if command -v ip >/dev/null 2>&1; then
-      ip route get 1.1.1.1 2>/dev/null | awk '{for (i = 1; i <= NF; i++) if ($i == "src") {print $(i + 1); exit}}'
-      return
-    fi
-    if command -v hostname >/dev/null 2>&1; then
-      hostname -I 2>/dev/null | awk '{print $1}'
-      return
-    fi
+  # Use the configured Flask host exactly as provided in config.yaml so the
+  # startup output and browser launch match the configured bind address. Only
+  # fall back when the config value is empty.
+  if [[ -z "$host" ]]; then
     printf '127.0.0.1\n'
     return
   fi


### PR DESCRIPTION
### Motivation
- The startup scripts were auto-detecting a LAN IP when `flask_ip` was set to bind-all addresses like `0.0.0.0`/`::`, causing the printed `Application URL` and browser launch to show an unexpected `192.*` address instead of the configured host. 
- The printed URL and browser open behavior should reflect the exact `flask_ip` value from `config.yaml` so startup output matches configuration.

### Description
- Change `display_host_for_url` in `start-server.sh` to return the configured host exactly when present and only fall back to `127.0.0.1` when the config value is empty. 
- Change `Get-AppUrlHost` in `start-server.ps1` to the same behavior so PowerShell startup output and `Start-Process` use the configured host. 
- Ensure `APP_HOST`/`APP_URL` use the returned host so the application URL printed and browser launch match the `flask_ip` from `config.yaml`.

### Testing
- Ran `bash -n start-server.sh` to verify shell syntax and it completed without errors. 
- Ran `git diff --check` to validate there are no whitespace or diff-check issues and it reported no problems. 
- Attempted to run the PowerShell parser check but `pwsh` was not available in the environment, so the scripted PowerShell parse step was skipped.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4af41484a88320a41a3a7dbcb41d82)

## Summary by Sourcery

Align startup application URL and browser launch with the configured Flask host from config.yaml.

Bug Fixes:
- Ensure shell and PowerShell startup scripts use the configured flask_ip value directly in APP_HOST/APP_URL instead of auto-detected LAN addresses when binding to all interfaces.
- Fallback to 127.0.0.1 only when no host is configured so printed URLs remain consistent with configuration.