### PR TITLE
Fix dashboard active tournament count

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -817,7 +817,8 @@ def create_app():
     @app.route('/home')
     @login_required
     def login_home():
-        active_count = db.session.query(Tournament).filter(Tournament.ended_at.is_(None)).count()
+        tournaments = db.session.query(Tournament).all()
+        active_count = sum(1 for tournament in tournaments if not tournament_is_complete(tournament))
         my_tournament_count = db.session.query(TournamentPlayer).filter_by(user_id=current_user.id).count()
         my_league_count = db.session.query(LeaguePlayer).filter_by(user_id=current_user.id).count()
         return render_template(

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -3,7 +3,7 @@ import random
 from itertools import product
 
 from app.app import db
-from app.models import Tournament, User, TournamentPlayer, Role, Round, MatchResult, Venue, SiteLog, TournamentLog
+from app.models import Tournament, User, TournamentPlayer, Role, Round, Match, MatchResult, Venue, SiteLog, TournamentLog
 from app.pairing import pair_round, compute_standings, draft_seating_tables, seeded_cut_pairs
 from datetime import datetime
 
@@ -816,3 +816,48 @@ def test_player_join_qr_only_visible_to_tournament_managers(client, session):
         assert response.status_code == 200
         html = response.get_data(as_text=True)
         assert 'Player Join QR' in html
+
+
+def test_home_active_count_matches_active_tournament_page_for_legacy_completed_tournaments(session, client):
+    role_admin = session.query(Role).filter_by(name='admin').first()
+    role_user = session.query(Role).filter_by(name='user').first()
+    admin = User(email='legacy-admin@example.com', name='Legacy Admin', role=role_admin, is_admin=True)
+    admin.set_password('secret')
+    tournament = Tournament(name='Legacy Completed Event', format='Constructed', rounds_override=1)
+    session.add_all([admin, tournament])
+    session.commit()
+
+    player_one = User(email='legacy-player-one@example.com', name='Legacy Player One', role=role_user)
+    player_two = User(email='legacy-player-two@example.com', name='Legacy Player Two', role=role_user)
+    session.add_all([player_one, player_two])
+    session.commit()
+
+    tournament_player_one = TournamentPlayer(tournament_id=tournament.id, user_id=player_one.id)
+    tournament_player_two = TournamentPlayer(tournament_id=tournament.id, user_id=player_two.id)
+    session.add_all([tournament_player_one, tournament_player_two])
+    session.commit()
+
+    result = MatchResult(player1_wins=2, player2_wins=0)
+    round_one = Round(tournament_id=tournament.id, number=1)
+    session.add_all([result, round_one])
+    session.commit()
+    session.add(Match(
+        round_id=round_one.id,
+        player1_id=tournament_player_one.id,
+        player2_id=tournament_player_two.id,
+        table_number=1,
+        completed=True,
+        result_id=result.id,
+    ))
+    session.commit()
+
+    assert tournament.ended_at is None
+    assert client.post('/login', data={'email': admin.email, 'password': 'secret'}).status_code == 302
+
+    home_response = client.get('/home')
+    active_response = client.get('/')
+
+    assert home_response.status_code == 200
+    assert active_response.status_code == 200
+    assert b'<span>Active tournaments</span><strong>0</strong>' in home_response.data
+    assert b'Legacy Completed Event' not in active_response.data


### PR DESCRIPTION
### Motivation
- The dashboard `/home` counted active tournaments using `ended_at is None`, which misreported legacy tournaments imported without `ended_at` as active. 
- The active tournaments landing page uses the `tournament_is_complete()` predicate, so the dashboard needs to use the same logic to stay consistent.

### Description
- Replace the dashboard active count query with an in-memory computation using `tournament_is_complete()`: `tournaments = db.session.query(Tournament).all()` and `active_count = sum(1 for tournament in tournaments if not tournament_is_complete(tournament))` in `app/app.py`.
- Add a regression test `test_home_active_count_matches_active_tournament_page_for_legacy_completed_tournaments` to `tests/test_tournament.py` that creates a legacy-completed tournament with no `ended_at` and asserts the dashboard shows `0` active tournaments and the tournament is absent from the active tournaments page.
- Add the `Match` import used by the new test in `tests/test_tournament.py`.

### Testing
- Ran `pytest tests/test_tournament.py::test_home_active_count_matches_active_tournament_page_for_legacy_completed_tournaments`, which passed.
- Ran the full `pytest tests/test_tournament.py`, and the suite passed (`28 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4afbeb864c832092568d0df2bbf769)

## Summary by Sourcery

Align dashboard active tournament count with the completion logic used by the active tournaments page to avoid misreporting legacy completed events as active.

Bug Fixes:
- Ensure legacy tournaments without an `ended_at` timestamp are not counted as active on the dashboard.
- Keep the dashboard active tournament count consistent with the active tournaments landing page by using the shared completion predicate.

Tests:
- Add a regression test that verifies legacy completed tournaments without `ended_at` appear as inactive on the dashboard and are absent from the active tournaments page.