### PR TITLE
Restrict regular user admin access and clean up tournament players UI

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4466,6 +4466,7 @@ def create_app():
     @app.route('/admin/venues/vendors', methods=['GET', 'POST'])
     @login_required
     def vendor_management():
+        require_permission('venues.manage')
         venue_query = db.session.query(Venue).order_by(Venue.name)
         if not current_user.has_permission('venues.manage'):
             visible_ids = venue_ids_for_user(current_user)
@@ -4528,6 +4529,7 @@ def create_app():
     @app.route('/admin/venues/artists', methods=['GET', 'POST'])
     @login_required
     def artist_management():
+        require_permission('venues.manage')
         venue_query = db.session.query(Venue).order_by(Venue.name)
         if not current_user.has_permission('venues.manage'):
             visible_ids = venue_ids_for_user(current_user)

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2454,3 +2454,49 @@ html[data-theme="dark"] .tournament-control-box .rounds-form {
   font-weight: 800;
   letter-spacing: 0.08em;
 }
+
+.players-roster-grid {
+  display:grid;
+  grid-template-columns:repeat(auto-fit, minmax(240px, 1fr));
+  gap:16px;
+}
+.player-roster-card {
+  display:flex;
+  flex-direction:column;
+  gap:12px;
+  padding:16px;
+  border:1px solid rgba(148, 163, 184, 0.28);
+  border-radius:var(--radius-md);
+  background:var(--brand-surface);
+  box-shadow:var(--shadow-soft);
+}
+.player-roster-card__header {
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:12px;
+}
+.player-roster-card__header h4 { margin:0; }
+.player-roster-card__deck,
+.player-replace-form {
+  display:flex;
+  flex-wrap:wrap;
+  gap:8px;
+  align-items:center;
+}
+.player-roster-card .deck-status {
+  display:inline-flex;
+  border-radius:999px;
+  padding:4px 10px;
+  font-size:0.82rem;
+  font-weight:700;
+  background:rgba(245, 158, 11, 0.14);
+  color:#92400e;
+}
+.player-roster-card .deck-status-submitted {
+  background:rgba(34, 197, 94, 0.16);
+  color:var(--dark-green);
+}
+.deck-submitted-at { color:var(--muted-text); font-size:0.9rem; }
+.player-replace-details summary { cursor:pointer; font-weight:700; }
+.player-replace-details select { min-width:180px; }

--- a/app/templates/admin/venue_detail.html
+++ b/app/templates/admin/venue_detail.html
@@ -2,15 +2,17 @@
 {% block content %}
 <section class="page-header">
   <div class="page-header__title">
-    <span class="eyebrow">Venue Management</span>
+    <span class="eyebrow">Venue</span>
     <h2>{{ venue.name }}</h2>
-    <p class="page-description">Manage this venue's tournaments, artists, and vendors from one place.</p>
+    <p class="page-description">View this venue's tournaments, artists, vendors, and available services.</p>
   </div>
   <div class="page-header__actions">
     <a class="btn secondary" href="{{ url_for('venue_management') }}">All Venues</a>
+    {% if current_user.has_permission('venues.manage') %}
     <a class="btn secondary" href="{{ url_for('vendor_management') }}">Vendors</a>
     <a class="btn secondary" href="{{ url_for('artist_management') }}">Artists</a>
     <a class="btn secondary" href="{{ url_for('lost_and_found', venue_id=venue.id) }}">Lost &amp; Found</a>
+    {% endif %}
   </div>
 </section>
 
@@ -87,13 +89,13 @@
     <div>
       <h4>Artists</h4>
       {% if venue.artists %}
-      <table class="table compact-table"><tbody>{% for artist in venue.artists %}<tr><td><a href="{{ url_for('artist_management') }}#artist-{{ artist.id }}">{{ artist.name }}</a></td><td>{{ artist.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
+      <table class="table compact-table"><thead><tr><th>Name</th><th>Booth</th><th>Services</th></tr></thead><tbody>{% for artist in venue.artists %}<tr><td>{{ artist.name }}</td><td>{{ artist.booth_number or '-' }}</td><td>{{ artist.services_provided or '-' }}</td></tr>{% endfor %}</tbody></table>
       {% else %}<p class="empty-state compact-empty">No artists.</p>{% endif %}
     </div>
     <div>
       <h4>Vendors</h4>
       {% if venue.vendors %}
-      <table class="table compact-table"><tbody>{% for vendor in venue.vendors %}<tr><td><a href="{{ url_for('vendor_management') }}#vendor-{{ vendor.id }}">{{ vendor.name }}</a></td><td>{{ vendor.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
+      <table class="table compact-table"><thead><tr><th>Name</th><th>Booth</th><th>Services</th></tr></thead><tbody>{% for vendor in venue.vendors %}<tr><td>{{ vendor.name }}</td><td>{{ vendor.booth_number or '-' }}</td><td>{{ vendor.services_provided or '-' }}</td></tr>{% endfor %}</tbody></table>
       {% else %}<p class="empty-state compact-empty">No vendors.</p>{% endif %}
     </div>
   </div>

--- a/app/templates/admin/venues.html
+++ b/app/templates/admin/venues.html
@@ -2,14 +2,16 @@
 {% block content %}
 <section class="page-header">
   <div class="page-header__title">
-    <span class="eyebrow">Admin</span>
-    <h2>Venue Management</h2>
-    <p class="page-description">Create venues, open each venue workspace, and manage venue assets.</p>
+    <span class="eyebrow">{% if can_manage_venues %}Admin{% else %}Venue{% endif %}</span>
+    <h2>{% if can_manage_venues %}Venue Management{% else %}Venues{% endif %}</h2>
+    <p class="page-description">{% if can_manage_venues %}Create venues, open each venue workspace, and manage venue assets.{% else %}View venue details and the services available at each venue.{% endif %}</p>
   </div>
+  {% if can_manage_venues %}
   <div class="page-header__actions">
     <a class="btn secondary" href="{{ url_for('vendor_management') }}">Vendor Management</a>
     <a class="btn secondary" href="{{ url_for('artist_management') }}">Artist Profiles</a>
   </div>
+  {% endif %}
 </section>
 {% if can_manage_venues %}
 <section class="panel-card">
@@ -52,19 +54,19 @@
             <div>
               <h4>Artists</h4>
               {% if venue.artists %}
-              <table class="table compact-table"><tbody>{% for artist in venue.artists %}<tr><td><a href="{{ url_for('artist_management') }}#artist-{{ artist.id }}">{{ artist.name }}</a></td><td>{{ artist.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
+              <table class="table compact-table"><tbody>{% for artist in venue.artists %}<tr><td>{{ artist.name }}</td><td>{{ artist.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
               {% else %}<p class="empty-state compact-empty">No artists.</p>{% endif %}
             </div>
             <div>
               <h4>Vendors</h4>
               {% if venue.vendors %}
-              <table class="table compact-table"><tbody>{% for vendor in venue.vendors %}<tr><td><a href="{{ url_for('vendor_management') }}#vendor-{{ vendor.id }}">{{ vendor.name }}</a></td><td>{{ vendor.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
+              <table class="table compact-table"><tbody>{% for vendor in venue.vendors %}<tr><td>{{ vendor.name }}</td><td>{{ vendor.booth_number or '-' }}</td></tr>{% endfor %}</tbody></table>
               {% else %}<p class="empty-state compact-empty">No vendors.</p>{% endif %}
             </div>
             <div>
               <h4>Tournaments</h4>
               {% if venue.tournaments %}
-              <table class="table compact-table"><tbody>{% for tournament in venue.tournaments %}<tr><td><a href="{{ url_for('view_tournament', tid=tournament.id) }}">{{ tournament.name }}</a></td><td>{{ tournament.start_time or '-' }}</td></tr>{% endfor %}</tbody></table><div class="form-actions"><a class="btn secondary" href="{{ url_for('venue_detail', venue_id=venue.id) }}">Manage tournament list</a> <a class="btn secondary" href="{{ url_for('lost_and_found', venue_id=venue.id) }}">Lost &amp; Found</a></div>
+              <table class="table compact-table"><tbody>{% for tournament in venue.tournaments %}<tr><td><a href="{{ url_for('view_tournament', tid=tournament.id) }}">{{ tournament.name }}</a></td><td>{{ tournament.start_time or '-' }}</td></tr>{% endfor %}</tbody></table>{% if can_manage_venues %}<div class="form-actions"><a class="btn secondary" href="{{ url_for('venue_detail', venue_id=venue.id) }}">Manage tournament list</a> <a class="btn secondary" href="{{ url_for('lost_and_found', venue_id=venue.id) }}">Lost &amp; Found</a></div>{% endif %}
               {% else %}<p class="empty-state compact-empty">No tournaments.</p>{% endif %}
             </div>
           </div>

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -48,7 +48,7 @@
           <li class="nav-item has-dropdown">
             <button class="nav-link" type="button" data-dropdown-toggle aria-expanded="false">Admin</button>
             <div class="dropdown-menu" role="menu">
-              {% if current_user.has_permission('venues.manage') or current_user.is_authenticated %}
+              {% if current_user.has_permission('venues.manage') %}
               <a class="dropdown-item" href="{{ url_for('venue_management') }}">Venues</a>
               {% endif %}
               {% if current_user.has_permission('users.manage') %}

--- a/app/templates/tournament/view.html
+++ b/app/templates/tournament/view.html
@@ -557,55 +557,44 @@ Sideboard
 
 <section class="panel-card">
 <div class="section-heading"><div><h3>Players ({{ players|length }})</h3><p>Registered player roster and deck submission status.</p></div></div>
-<table class="players-table">
-  <thead>
-    <tr>
-      <th>Player</th>
-      {% if can_view_player_decks %}
-      <th>Deck</th>
-      {% endif %}
-      {% if current_user.has_permission('tournaments.manage') %}<th>Admin</th>{% endif %}
-    </tr>
-  </thead>
-  <tbody>
+<div class="players-roster-grid">
   {% for p in players %}
-    <tr>
-      <td>{{ p.user.name }}</td>
+  {% set deck = p.deck %}
+  <article class="player-roster-card">
+    <div class="player-roster-card__header">
+      <h4>{{ p.user.name }}</h4>
       {% if can_view_player_decks %}
-      {% set deck = p.deck %}
-      <td class="player-deck-cell">
-        {% if deck %}
-        <div class="player-deck-actions">
-          <a class="btn" href="{{ url_for('view_player_deck', tid=t.id, player_id=p.id) }}">View Deck</a>
-          <span class="deck-counts">Main {{ deck.total_mainboard() }} · Side {{ deck.total_sideboard() }}</span>
-          <span class="deck-status {% if deck.is_submitted %}deck-status-submitted{% else %}deck-status-draft{% endif %}">
-            {% if deck.is_submitted %}
-              Submitted{% if deck.submitted_at %} {{ deck.submitted_at }}{% endif %}
-            {% else %}
-              Not submitted
-            {% endif %}
-          </span>
-        </div>
-        {% else %}
-        <span class="deck-status deck-status-draft">No deck submitted</span>
-        {% endif %}
-      </td>
+      <span class="deck-status {% if deck and deck.is_submitted %}deck-status-submitted{% else %}deck-status-draft{% endif %}">
+        {% if deck and deck.is_submitted %}Deck submitted{% elif deck %}Deck not submitted{% else %}No deck submitted{% endif %}
+      </span>
       {% endif %}
-      {% if current_user.has_permission('tournaments.manage') %}
-      <td>
-        <form method="post" action="{{ url_for('replace_tournament_player', tid=t.id, player_id=p.id) }}" class="inline-form">
-          <select name="replacement_user_id" required>
-            <option value="">Replace with...</option>
-            {% for user in available_users %}<option value="{{ user.id }}">{{ user.name }}{% if user.email %} — {{ user.email }}{% endif %}</option>{% endfor %}
-          </select>
-          <button class="btn ghost" type="submit">Replace</button>
-        </form>
-      </td>
+    </div>
+    {% if can_view_player_decks %}
+    <div class="player-roster-card__deck">
+      {% if deck %}
+      <span class="deck-counts">Main {{ deck.total_mainboard() }} · Side {{ deck.total_sideboard() }}</span>
+      {% if deck.submitted_at and deck.is_submitted %}<span class="deck-submitted-at">Submitted {{ deck.submitted_at }}</span>{% endif %}
+      <a class="btn secondary" href="{{ url_for('view_player_deck', tid=t.id, player_id=p.id) }}">View Deck</a>
+      {% else %}
+      <span class="empty-state compact-empty">Awaiting deck list.</span>
       {% endif %}
-    </tr>
+    </div>
+    {% endif %}
+    {% if current_user.has_permission('tournaments.manage') %}
+    <details class="player-replace-details">
+      <summary>Replace player</summary>
+      <form method="post" action="{{ url_for('replace_tournament_player', tid=t.id, player_id=p.id) }}" class="inline-form player-replace-form">
+        <select name="replacement_user_id" required>
+          <option value="">Choose replacement...</option>
+          {% for user in available_users %}<option value="{{ user.id }}">{{ user.name }}{% if user.email %} — {{ user.email }}{% endif %}</option>{% endfor %}
+        </select>
+        <button class="btn ghost" type="submit">Replace</button>
+      </form>
+    </details>
+    {% endif %}
+  </article>
   {% endfor %}
-  </tbody>
-</table>
+</div>
 </section>
 
 {% endblock %}

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -554,3 +554,43 @@ def test_invalid_site_theme_falls_back_to_light(client, session):
     assert response.status_code == 200
     assert b'data-theme="light"' in response.data
     assert session.get(SiteSetting, 'site_theme').value == 'light'
+
+def test_regular_user_cannot_access_admin_management_surfaces(client, session):
+    from app.models import Role, User, Venue, Vendor, ArtistProfile, Tournament, TournamentPlayer
+
+    user_role = session.query(Role).filter_by(name='user').one()
+    user = User(email='regular-venue@example.com', name='Regular Venue User', role=user_role)
+    user.set_password('secret')
+    venue = Venue(name='Public Venue', notes='Open play area')
+    vendor = Vendor(name='Sleeve Seller', venue=venue, services_provided='Sleeves and deck boxes')
+    artist = ArtistProfile(name='Token Artist', venue=venue, services_provided='Token sketches')
+    tournament = Tournament(name='Venue Event', format='Constructed', venue=venue)
+    session.add_all([user, venue, vendor, artist, tournament])
+    session.flush()
+    session.add(TournamentPlayer(tournament_id=tournament.id, user_id=user.id))
+    session.commit()
+
+    assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+
+    home = client.get('/').get_data(as_text=True)
+    assert 'data-dropdown-toggle aria-expanded="false">Admin</button>' not in home
+    assert 'Registration Invites' not in home
+    assert 'Site Settings' not in home
+
+    assert client.get('/admin/site-settings').status_code == 403
+    assert client.get('/admin/registration-invites').status_code == 403
+    assert client.post('/admin/registration-invites', data={'email': 'invitee@example.com'}).status_code == 403
+    assert client.get('/admin/venues/vendors').status_code == 403
+    assert client.get('/admin/venues/artists').status_code == 403
+
+    venue_page = client.get(f'/admin/venues/{venue.id}')
+    assert venue_page.status_code == 200
+    html = venue_page.get_data(as_text=True)
+    assert 'Sleeve Seller' in html
+    assert 'Sleeves and deck boxes' in html
+    assert 'Token Artist' in html
+    assert 'Token sketches' in html
+    assert 'Vendor Management' not in html
+    assert 'Artist Profiles' not in html
+    assert 'Lost &amp; Found' not in html
+    assert 'Bulk Add Tournaments' not in html


### PR DESCRIPTION
### Motivation
- Prevent regular users from accessing admin management surfaces (registration invites, site settings, vendor/artist management) while still allowing them to view venue service information. 
- Make vendor/artist management routes enforce `venues.manage` so only authorized users can edit venue assets. 
- Improve the admin view of tournament player listings to present a clearer roster card UI and a compact replace-player control for managers.

### Description
- Hide the Venues admin link for non-venue-managers and keep Site Settings / Registration Invites gated by their existing permissions by updating the main nav template (`app/templates/base.html`).
- Require `venues.manage` for vendor and artist management endpoints by adding `require_permission('venues.manage')` to `vendor_management` and `artist_management` handlers (`app/app.py`).
- Render venue pages as read-only for regular users and include services/notes fields in vendor/artist tables so non-managers can view what services are available (`app/templates/admin/venues.html`, `app/templates/admin/venue_detail.html`).
- Replace the players table on the tournament admin view with responsive player roster cards that show deck status, counts, a `View Deck` action and a collapsed replacement form for managers, and add associated styles in `app/static/style.css` (`app/templates/tournament/view.html`).
- Add a regression test `test_regular_user_cannot_access_admin_management_surfaces` to verify that regular users cannot see or access admin surfaces while still seeing venue service details (`tests/test_users.py`).

### Testing
- Ran `pytest tests/test_users.py tests/test_tournament.py -q` and all tests passed (54 passed, 113 warnings). 
- The added regression test `test_regular_user_cannot_access_admin_management_surfaces` was executed and passed. 
- Ran `git diff --check` with no whitespace or diff errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4afeced0dc832086bdc97ee5c8bbf1)

## Summary by Sourcery

Restrict access to venue and tournament admin surfaces for regular users while improving venue service visibility and refreshing the tournament players roster UI.

New Features:
- Introduce a card-based players roster layout on the tournament admin view with deck status, counts, and a compact player replacement control.
- Expose vendor and artist service details on venue pages so regular users can see available services at each venue.

Bug Fixes:
- Ensure regular users cannot access admin management pages such as site settings, registration invites, and vendor/artist management routes while still viewing venue details.

Enhancements:
- Gate venue vendor and artist management endpoints and navigation links behind the venues.manage permission to limit editing to authorized users.
- Update venue management and detail pages to present read-only views and hide management actions when the user lacks venues.manage.

Tests:
- Add a regression test confirming that regular users cannot see or reach admin management surfaces but can view venue service information.