### PR TITLE
Restrict site admin surfaces

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -2827,6 +2827,11 @@ def create_app():
     def require_admin():
         require_permission('admin.panel')
 
+    def require_site_admin():
+        if not current_user.is_authenticated or not current_user.is_admin:
+            log_site('unauthorized_access', 'failure', 'site_admin')
+            abort(403)
+
     def venue_ids_for_user(user):
         if not user or not getattr(user, 'is_authenticated', False):
             return set()
@@ -5182,7 +5187,7 @@ def create_app():
     @app.route('/admin/site-settings', methods=['GET', 'POST'])
     @login_required
     def site_settings():
-        require_permission('admin.site_settings')
+        require_site_admin()
         if request.method == 'POST':
             action = request.form.get('action')
             if action == 'settings':
@@ -5209,7 +5214,7 @@ def create_app():
     @app.route('/admin/registration-invites', methods=['GET', 'POST'])
     @login_required
     def admin_registration_invites():
-        require_permission('admin.site_settings')
+        require_site_admin()
         if request.method == 'POST':
             email = request.form.get('email', '').strip().lower()
             if not email:
@@ -5242,7 +5247,7 @@ def create_app():
     @app.route('/admin/registration-invites/<int:invite_id>/revoke', methods=['POST'])
     @login_required
     def revoke_registration_invite(invite_id):
-        require_permission('admin.site_settings')
+        require_site_admin()
         invite = db.session.get(RegistrationInvite, invite_id)
         if not invite:
             abort(404)

--- a/app/templates/base.html
+++ b/app/templates/base.html
@@ -44,7 +44,7 @@
             </div>
           </li>
           {% endif %}
-          {% if current_user.has_permission('users.manage') or current_user.has_permission('admin.panel') or current_user.has_permission('admin.permissions') or current_user.has_permission('admin.login_audit') or current_user.has_permission('admin.ip_blacklist') or current_user.has_permission('admin.site_settings') or current_user.has_permission('venues.manage') %}
+          {% if current_user.is_admin %}
           <li class="nav-item has-dropdown">
             <button class="nav-link" type="button" data-dropdown-toggle aria-expanded="false">Admin</button>
             <div class="dropdown-menu" role="menu">

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -555,6 +555,37 @@ def test_invalid_site_theme_falls_back_to_light(client, session):
     assert b'data-theme="light"' in response.data
     assert session.get(SiteSetting, 'site_theme').value == 'light'
 
+
+def test_non_admin_with_admin_permissions_cannot_access_site_admin_surfaces(client, session):
+    from app.models import RegistrationInvite, SiteSetting
+
+    manager_role = session.query(Role).filter_by(name='manager').one()
+    manager_perms = manager_role.permissions_dict()
+    manager_perms['admin.site_settings'] = True
+    manager_role.permissions = json.dumps(manager_perms)
+    manager = User(email='manager-site-admin@example.com', name='Manager Site Admin', role=manager_role)
+    manager.set_password('secret')
+    session.add(manager)
+    session.commit()
+
+    assert client.post('/login', data={'email': manager.email, 'password': 'secret'}).status_code == 302
+
+    home = client.get('/').get_data(as_text=True)
+    assert 'data-dropdown-toggle aria-expanded="false">Admin</button>' not in home
+    assert 'Site Settings' not in home
+    assert 'Registration Invites' not in home
+
+    assert client.get('/admin/site-settings').status_code == 403
+    assert client.post(
+        '/admin/site-settings',
+        data={'action': 'settings', 'registration_mode': 'closed', 'site_theme': 'dark'},
+    ).status_code == 403
+    assert session.get(SiteSetting, 'registration_mode') is None
+    assert client.get('/admin/registration-invites').status_code == 403
+    assert client.post('/admin/registration-invites', data={'email': 'invitee@example.com'}).status_code == 403
+    assert session.query(RegistrationInvite).count() == 0
+
+
 def test_regular_user_cannot_access_admin_management_surfaces(client, session):
     from app.models import Role, User, Venue, Vendor, ArtistProfile, Tournament, TournamentPlayer
 


### PR DESCRIPTION
### Motivation

- Prevent non-admin users from managing site-wide settings or sending registration invites and from seeing the Admin nav even if they hold some management permissions.

### Description

- Add `require_site_admin()` which requires `current_user.is_admin` and aborts with 403 when not satisfied, logging the attempt.
- Require `require_site_admin()` on the `/admin/site-settings`, `/admin/registration-invites`, and invite revoke routes instead of using `require_permission('admin.site_settings')`.
- Hide the Admin dropdown in `app/templates/base.html` by checking `current_user.is_admin` rather than a collection of permission checks so only real admins see the Admin tab.
- Add a regression test `test_non_admin_with_admin_permissions_cannot_access_site_admin_surfaces` in `tests/test_users.py` to assert that a non-admin user with `admin.site_settings` granted cannot view or invoke site admin surfaces.

### Testing

- Ran `pytest tests/test_users.py -q`, and the test suite passed successfully (`27 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4b01399178832092cd5a3a86d40a61)

## Summary by Sourcery

Restrict site administration surfaces so that only true site admins can access site-wide settings and registration invite management and see the Admin navigation.

Bug Fixes:
- Prevent non-admin users with admin-related permissions from accessing site settings and registration invite management endpoints or seeing the Admin navigation dropdown.

Enhancements:
- Introduce a site admin guard that enforces `current_user.is_admin` and logs unauthorized access attempts before returning 403.
- Simplify the Admin navigation visibility logic to rely solely on the user being a site admin.

Tests:
- Add a regression test ensuring a non-admin user granted `admin.site_settings` cannot view or invoke site administration pages or actions.