### PR TITLE
Ensure MySQL driver is installed at startup

### DIFF
--- a/start-server.sh
+++ b/start-server.sh
@@ -601,12 +601,13 @@ printf 'Installing dependencies...\n'
 # requirements.txt or a previous dependency install was interrupted.
 if ! "$PYTHON_BIN" - <<'PY' >/dev/null 2>&1
 import aiohttp  # noqa: F401
+import pymysql  # noqa: F401
 import qrcode  # noqa: F401
 from PIL import Image  # noqa: F401
 PY
 then
   printf 'Installing missing runtime dependencies...\n'
-  "$PYTHON_BIN" -m pip install 'aiohttp>=3.7.4,<4' 'qrcode[pil]==8.2' >/dev/null
+  "$PYTHON_BIN" -m pip install 'aiohttp>=3.7.4,<4' 'PyMySQL==1.1.2' 'qrcode[pil]==8.2' >/dev/null
 fi
 
 if is_truthy "$BOT_INSTALL_ENABLED"; then


### PR DESCRIPTION
### Motivation
- After migrating the database to MySQL, the application can raise `ModuleNotFoundError: No module named 'pymysql'` during Flask import when the driver is missing, so the startup script should detect and install it before initializing the app.

### Description
- Update `start-server.sh` to include `import pymysql` in the runtime import check and add `'PyMySQL==1.1.2'` to the fallback `pip` install command so the MySQL driver is installed when missing.

### Testing
- Ran `bash -n start-server.sh` (syntax check) which succeeded. 
- Ran `python -m pytest tests/test_card_db.py` which completed with `1 passed, 1 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a580abdf0448320be5c7dee82a08000)

## Summary by Sourcery

Ensure the startup script installs all required runtime dependencies before initializing the application.

Bug Fixes:
- Detect and install the PyMySQL driver at startup to prevent ModuleNotFoundError when using MySQL.

Enhancements:
- Extend the runtime dependency check to include PyMySQL alongside existing Python packages.