### PR TITLE
Fix My Tournaments ordering for MySQL

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -4280,19 +4280,19 @@ def create_app():
         current_tournaments = (
             db.session.query(Tournament)
             .filter(Tournament.venue_id == venue.id)
-            .order_by(Tournament.start_time.desc().nullslast(), Tournament.created_at.desc())
+            .order_by(Tournament.start_time.is_(None), Tournament.start_time.desc(), Tournament.created_at.desc())
             .all()
         )
         available_tournaments = (
             db.session.query(Tournament)
             .filter(or_(Tournament.venue_id.is_(None), Tournament.venue_id != venue.id))
-            .order_by(Tournament.start_time.desc().nullslast(), Tournament.created_at.desc())
+            .order_by(Tournament.start_time.is_(None), Tournament.start_time.desc(), Tournament.created_at.desc())
             .all()
         )
         unassigned_tournaments = (
             db.session.query(Tournament)
             .filter(Tournament.venue_id.is_(None))
-            .order_by(Tournament.start_time.desc().nullslast(), Tournament.created_at.desc())
+            .order_by(Tournament.start_time.is_(None), Tournament.start_time.desc(), Tournament.created_at.desc())
             .all()
         )
         return render_template(
@@ -5629,7 +5629,7 @@ def create_app():
             db.session.query(TournamentPlayer)
             .join(Tournament)
             .filter(TournamentPlayer.user_id == current_user.id)
-            .order_by(Tournament.start_time.desc().nullslast(), Tournament.created_at.desc())
+            .order_by(Tournament.start_time.is_(None), Tournament.start_time.desc(), Tournament.created_at.desc())
             .all()
         )
         active_entries = [entry for entry in entries if not tournament_is_complete(entry.tournament)]

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -2,10 +2,27 @@ import json
 import random
 from itertools import product
 
+from sqlalchemy import select
+from sqlalchemy.dialects import mysql
+
 from app.app import db
 from app.models import Tournament, User, TournamentPlayer, Role, Round, Match, MatchResult, Venue, SiteLog, TournamentLog
 from app.pairing import pair_round, compute_standings, draft_seating_tables, seeded_cut_pairs
 from datetime import datetime
+
+
+def test_my_tournaments_query_uses_mysql_portable_null_ordering():
+    statement = (
+        select(TournamentPlayer)
+        .join(Tournament)
+        .filter(TournamentPlayer.user_id == 1)
+        .order_by(Tournament.start_time.is_(None), Tournament.start_time.desc(), Tournament.created_at.desc())
+    )
+
+    compiled = str(statement.compile(dialect=mysql.dialect()))
+
+    assert 'NULLS LAST' not in compiled
+    assert 'tournament.start_time IS NULL' in compiled
 
 
 def test_tournament_create_pairing_standings(session):


### PR DESCRIPTION
### Motivation
- After migrating to MySQL/MariaDB, queries that relied on SQLAlchemy's `NULLS LAST` ordering generated SQL unsupported by MySQL and broke pages such as `/my-tournaments` and venue tournament lists.
- The intent is to preserve the ordering semantics (scheduled tournaments first, newest first) while emitting SQL compatible with MySQL/MariaDB.

### Description
- Replace `order_by(Tournament.start_time.desc().nullslast(), Tournament.created_at.desc())` with a portable ordering using `order_by(Tournament.start_time.is_(None), Tournament.start_time.desc(), Tournament.created_at.desc())` in `app/app.py` for the venue lists and the `/my-tournaments` query.
- Update three occurrences: current venue tournaments, available/unassigned venue lists, and the `my_tournaments` entries query to use the new ordering.
- Add `tests/test_tournament.py::test_my_tournaments_query_uses_mysql_portable_null_ordering` which compiles the ordering for the MySQL dialect and asserts that the compiled SQL does not contain `NULLS LAST` and does contain `tournament.start_time IS NULL`.

### Testing
- Ran `pytest tests/test_tournament.py::test_my_tournaments_query_uses_mysql_portable_null_ordering`, and the test passed.
- The new test is self-contained and verifies the emitted SQL for the MySQL dialect does not use `NULLS LAST` and instead uses `IS NULL` ordering.
- Installing `pymysql` was performed as part of running the test to ensure the MySQL dialect is available and tests executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a580bcaeab0832088e73fb643bbcb62)

## Summary by Sourcery

Update tournament listing queries to use MySQL-compatible null ordering for start times while preserving existing sort semantics.

Bug Fixes:
- Fix venue tournament and My Tournaments pages breaking on MySQL/MariaDB due to unsupported NULLS LAST ordering.

Tests:
- Add a SQL compilation test to ensure the My Tournaments query uses portable null ordering compatible with the MySQL dialect.