### PR TITLE
Make user login sessions persistent (effectively unlimited)

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -68,6 +68,7 @@ CUBE_PREVIEW_IMAGE_HOSTS = {
     'cubecobra.com',
     'scryfall.io',
 }
+UNLIMITED_LOGIN_SESSION_DAYS = 36500
 
 MAJOR_60_CARD_FORMATS = [
     'Standard',
@@ -242,6 +243,8 @@ def create_app():
     app.config['ACCOUNT_LOCKOUT_ATTEMPTS'] = int(os.environ.get('ACCOUNT_LOCKOUT_ATTEMPTS', '3') or '3')
     app.config['IP_BLACKLIST_ATTEMPTS'] = int(os.environ.get('IP_BLACKLIST_ATTEMPTS', '10') or '10')
     app.config['PASSWORD_RESET_TTL_MINUTES'] = int(os.environ.get('PASSWORD_RESET_TTL_MINUTES', '60') or '60')
+    # Keep user login sessions effectively unlimited unless they explicitly log out.
+    app.config['PERMANENT_SESSION_LIFETIME'] = timedelta(days=UNLIMITED_LOGIN_SESSION_DAYS)
 
     last_table_env = os.environ.get('MTG_LAST_TABLE_NUMBER', '').strip()
     if last_table_env:
@@ -1323,7 +1326,8 @@ def create_app():
                 u.failed_login_count = 0
                 u.lock_reason = None
                 db.session.commit()
-                login_user(u)
+                session.permanent = True
+                login_user(u, remember=True, duration=timedelta(days=UNLIMITED_LOGIN_SESSION_DAYS))
                 try:
                     if not u.public_key or not u.private_key_encrypted:
                         u.generate_keys(password)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -1,4 +1,6 @@
 import json
+from email.utils import parsedate_to_datetime
+from datetime import datetime, timezone
 
 from sqlalchemy import text
 
@@ -210,6 +212,27 @@ def test_invite_only_registration_blocks_public_tournament_registration(client, 
     assert response.headers['Location'].endswith('/register')
     assert session.query(User).filter_by(email='invited@example.com').first() is None
 
+
+
+def test_successful_login_uses_effectively_unlimited_session_cookie(client, session):
+    user_role = session.query(Role).filter_by(name='user').one()
+    user = User(email='persistent@example.com', name='Persistent User', role=user_role)
+    user.set_password('secret')
+    session.add(user)
+    session.commit()
+
+    response = client.post('/login', data={'email': user.email, 'password': 'secret'})
+
+    assert response.status_code == 302
+    cookie_headers = response.headers.getlist('Set-Cookie')
+    assert any(header.startswith('remember_token=') for header in cookie_headers)
+    session_cookie = next(header for header in cookie_headers if header.startswith('session='))
+    remember_cookie = next(header for header in cookie_headers if header.startswith('remember_token='))
+    session_expiry = parsedate_to_datetime(session_cookie.split('Expires=', 1)[1].split(';', 1)[0])
+    remember_expiry = parsedate_to_datetime(remember_cookie.split('Expires=', 1)[1].split(';', 1)[0])
+    now = datetime.now(timezone.utc)
+    assert (session_expiry - now).days >= 36499
+    assert (remember_expiry - now).days >= 36499
 
 def test_account_locks_after_three_bad_passwords(client, session, app):
     app.config['ACCOUNT_LOCKOUT_ATTEMPTS'] = 3


### PR DESCRIPTION
### Motivation
- Users should remain logged in indefinitely unless they explicitly log out, avoiding unexpected session expirations.

### Description
- Introduced `UNLIMITED_LOGIN_SESSION_DAYS = 36500` and set `app.config['PERMANENT_SESSION_LIFETIME']` to `timedelta(days=UNLIMITED_LOGIN_SESSION_DAYS)` in `app/app.py` to provide an effectively unlimited permanent session lifetime.
- On successful authentication the code now sets `session.permanent = True` and calls `login_user(u, remember=True, duration=timedelta(days=UNLIMITED_LOGIN_SESSION_DAYS))` so both the session and the Flask-Login remember cookie are long-lived.
- Added a regression test `test_successful_login_uses_effectively_unlimited_session_cookie` in `tests/test_users.py` that checks the `session` and `remember_token` cookies have very long expiry dates.

### Testing
- Ran `python -m py_compile app/app.py tests/test_users.py` which succeeded.
- Ran `pytest tests/test_users.py::test_successful_login_uses_effectively_unlimited_session_cookie`, which was skipped in this environment because the MySQL test databases are unavailable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a580d9d7e888320a930897df88984ae)

## Summary by Sourcery

Make user login sessions effectively non-expiring by configuring a very long-lived permanent session and remember cookie on successful login.

New Features:
- Persist user login sessions for an effectively unlimited duration unless the user explicitly logs out.

Tests:
- Add a regression test verifying that both the session and remember_token cookies have very long expiry dates after successful login.