### PR TITLE
Security: upgrade cryptography, prevent SSRF, use HMAC for tokens, sanitize redirects

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -21,6 +21,7 @@ from flask_login import (
     current_user,
 )
 from datetime import datetime, timedelta, timezone
+import ipaddress
 import math
 import os
 import random
@@ -37,6 +38,7 @@ import hashlib
 import time
 import urllib.parse
 import urllib.request
+import socket
 
 from collections import OrderedDict
 from urllib.parse import urlparse
@@ -139,13 +141,39 @@ def clean_cube_cobra_title(raw_title):
     return title or 'Cube Cobra Cube'
 
 
+def _host_resolves_publicly(host):
+    try:
+        addr_infos = socket.getaddrinfo(host, None)
+    except socket.gaierror:
+        return False
+    if not addr_infos:
+        return False
+    for addr_info in addr_infos:
+        address = addr_info[4][0]
+        try:
+            ip_address = ipaddress.ip_address(address)
+        except ValueError:
+            return False
+        if not ip_address.is_global:
+            return False
+    return True
+
+
 def is_allowed_cube_preview_image_url(image_url):
     parsed = urllib.parse.urlparse(image_url)
     host = (parsed.hostname or '').lower()
-    return parsed.scheme == 'https' and any(
-        host == allowed_host or host.endswith(f'.{allowed_host}')
-        for allowed_host in CUBE_PREVIEW_IMAGE_HOSTS
-    )
+    if parsed.scheme != 'https' or not host:
+        return False
+    if parsed.username or parsed.password or parsed.port not in (None, 443):
+        return False
+    if not any(host == allowed_host or host.endswith(f'.{allowed_host}') for allowed_host in CUBE_PREVIEW_IMAGE_HOSTS):
+        return False
+    return _host_resolves_publicly(host)
+
+
+class _NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
 
 
 def fetch_cube_cobra_metadata(raw_url):
@@ -157,7 +185,7 @@ def fetch_cube_cobra_metadata(raw_url):
             url,
             headers={'User-Agent': 'WaLTER cube preview bot/1.0'},
         )
-        with urllib.request.urlopen(req, timeout=8) as response:
+        with urllib.request.build_opener(_NoRedirectHandler).open(req, timeout=8) as response:
             content_type = response.headers.get('Content-Type', '')
             if 'text/html' in content_type or not content_type:
                 html = response.read(512000).decode('utf-8', errors='ignore')
@@ -1926,7 +1954,13 @@ def create_app():
         token = token or request.headers.get('X-API-Key', '').strip()
         if not token:
             return None, None
-        api_key = db.session.query(ApiKey).filter_by(key_hash=ApiKey.hash_token(token), revoked_at=None).first()
+        token_hash = ApiKey.hash_token(token)
+        api_key = db.session.query(ApiKey).filter_by(key_hash=token_hash, revoked_at=None).first()
+        if not api_key:
+            legacy_hash = ApiKey.legacy_hash_token(token)
+            api_key = db.session.query(ApiKey).filter_by(key_hash=legacy_hash, revoked_at=None).first()
+            if api_key:
+                api_key.key_hash = token_hash
         if not api_key or not api_key.user:
             return None, None
         api_key.last_used_at = utc_now()
@@ -2278,6 +2312,7 @@ def create_app():
         for candidate in db.session.query(User).filter(User.discord_authorization_token_hash.isnot(None)).all():
             if candidate.check_discord_authorization_token(one_time_pass):
                 user = candidate
+                candidate.discord_authorization_token_hash = candidate.hash_discord_authorization_token(one_time_pass)
                 break
         if not user:
             _api_log('discord.authorize', 'failure', _discord_authorize_log_details(error='invalid pass'))
@@ -2702,7 +2737,7 @@ def create_app():
                 image_url,
                 headers={'User-Agent': 'WaLTER cube preview bot/1.0'},
             )
-            with urllib.request.urlopen(req, timeout=8) as response:
+            with urllib.request.build_opener(_NoRedirectHandler).open(req, timeout=8) as response:
                 content_type = (
                     response.headers.get('Content-Type', 'application/octet-stream')
                     .split(';', 1)[0]
@@ -5595,7 +5630,7 @@ def create_app():
         flash('Tournament marked complete.', 'success')
         log_site('complete_tournament', 'success', f'tournament_id={tid}')
         log_tournament(tid, 'complete', 'success')
-        return redirect(request.referrer or url_for('index'))
+        return redirect(safe_redirect_target(request.referrer, 'index'))
 
     @app.route('/admin/tournaments/<int:tid>/reopen', methods=['POST'])
     def reopen_tournament(tid):
@@ -5609,7 +5644,7 @@ def create_app():
         flash('Tournament reopened.', 'success')
         log_site('reopen_tournament', 'success', f'tournament_id={tid}')
         log_tournament(tid, 'reopen', 'success')
-        return redirect(request.referrer or url_for('view_tournament', tid=tid))
+        return redirect(safe_redirect_target(request.referrer, 'view_tournament', tid=tid))
 
     @app.route('/admin/tournaments/<int:tid>/delete', methods=['POST'])
     def delete_tournament(tid):
@@ -5623,6 +5658,16 @@ def create_app():
         log_site('delete_tournament', 'success', t.name)
         log_tournament(tid, 'delete', 'success')
         return redirect(url_for('index'))
+
+
+    def safe_redirect_target(candidate, endpoint, **values):
+        fallback = url_for(endpoint, **values)
+        if not candidate:
+            return fallback
+        parsed = urlparse(candidate.strip())
+        if parsed.scheme or parsed.netloc or not parsed.path.startswith('/') or parsed.path.startswith('//'):
+            return fallback
+        return urllib.parse.urlunparse(('', '', parsed.path, '', parsed.query, ''))
 
     # ---------- Tournament ----------
 

--- a/app/models.py
+++ b/app/models.py
@@ -7,11 +7,33 @@ import os
 import json
 import secrets
 import hashlib
+import hmac
 from cryptography.hazmat.primitives.asymmetric import rsa, padding
 from cryptography.hazmat.primitives import serialization, hashes
 from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 from werkzeug.security import check_password_hash, generate_password_hash
+from flask import current_app
+
+
+def _token_hash_secret(purpose):
+    secret = None
+    try:
+        secret = current_app.config.get('SECRET_KEY')
+    except RuntimeError:
+        secret = None
+    secret = secret or os.environ.get('SECRET_KEY') or os.environ.get('PASSWORD_SEED')
+    if not secret:
+        secret = 'walter-development-token-hash-key'
+    return f'{purpose}:{secret}'.encode()
+
+
+def _hmac_token_digest(token, purpose):
+    return hmac.new(_token_hash_secret(purpose), token.encode(), hashlib.sha256).hexdigest()
+
+
+def _legacy_token_digest(token):
+    return hashlib.sha256(token.encode()).hexdigest()
 
 # Permission groups and default role permissions
 PERMISSION_GROUPS = {
@@ -134,7 +156,11 @@ class User(db.Model, UserMixin):
 
     @staticmethod
     def hash_discord_authorization_token(token):
-        return hashlib.sha256(token.encode()).hexdigest()
+        return _hmac_token_digest(token, 'discord-authorization')
+
+    @staticmethod
+    def legacy_discord_authorization_token_hash(token):
+        return _legacy_token_digest(token)
 
     def set_discord_authorization_token(self, token):
         self.discord_authorization_token_hash = self.hash_discord_authorization_token(token)
@@ -142,9 +168,10 @@ class User(db.Model, UserMixin):
     def check_discord_authorization_token(self, token):
         if not self.discord_authorization_token_hash:
             return False
-        return secrets.compare_digest(
-            self.discord_authorization_token_hash,
-            self.hash_discord_authorization_token(token),
+        token_hash = self.hash_discord_authorization_token(token)
+        legacy_hash = self.legacy_discord_authorization_token_hash(token)
+        return secrets.compare_digest(self.discord_authorization_token_hash, token_hash) or secrets.compare_digest(
+            self.discord_authorization_token_hash, legacy_hash
         )
 
     def set_password(self, pw, *, unlock=True):
@@ -230,7 +257,11 @@ class ApiKey(db.Model):
 
     @staticmethod
     def hash_token(token):
-        return hashlib.sha256(token.encode()).hexdigest()
+        return _hmac_token_digest(token, 'api-key')
+
+    @staticmethod
+    def legacy_hash_token(token):
+        return _legacy_token_digest(token)
 
     @classmethod
     def create_token(cls):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 Flask==3.1.3
 Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
-cryptography==48.0.0
+cryptography==49.0.0
 psutil==5.9.8
 PyYAML==6.0.1
 Pillow==12.2.0

--- a/walter-bot/discord/http.py
+++ b/walter-bot/discord/http.py
@@ -657,7 +657,7 @@ class HTTPClient:
 
                 try:
                     async with self.__session.request(method, url, **kwargs) as response:
-                        _log.debug('%s %s with %s has returned %s', method, url, kwargs.get('data'), response.status)
+                        _log.debug('%s %s has returned %s', method, url, response.status)
 
                         # even errors have text involved in them so this is safe to call
                         data = await json_or_text(response)


### PR DESCRIPTION
### Motivation
- Address security scanner findings by upgrading vulnerable dependencies and hardening code that fetches remote resources and handles secrets.  
- Prevent SSRF and related exposures when proxying external Cube Cobra images.  
- Avoid logging sensitive request payloads and improve token storage so leaked digests cannot be used without the site secret.  

### Description
- Bumped `cryptography` in `requirements.txt` from `48.0.0` to `49.0.0`.  
- Hardened Cube Cobra image handling in `app/app.py` by requiring `https`, disallowing userinfo/ports other than default, verifying DNS resolves to public IPs via `_host_resolves_publicly`, and disabling redirects with `_NoRedirectHandler`.  
- Replaced raw SHA-256 token digests with keyed HMAC digests in `app/models.py` and added legacy-digest verification plus on-success migration for `ApiKey` and Discord one-time-pass tokens.  
- Updated API key lookup in `app/app.py` to attempt legacy hash lookup and migrate to the new HMAC digest on success, and to migrate Discord token storage on successful verification.  
- Sanitized referrer-based redirects by introducing `safe_redirect_target` to ensure only local relative paths are followed.  
- Removed request payload from debug logging in `walter-bot/discord/http.py` to avoid logging sensitive data.  

### Testing
- Ran `python -m compileall app walter-bot/discord/http.py` which completed successfully.  
- Ran `python -m pytest -q`; non-async tests executed but the test run produced failures because async tests could not run due to missing async pytest support (error: "async def functions are not natively supported"); overall test summary from the run was `42 failed, 257 passed, 101 skipped`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a58100a00788320844f291785270397)

## Summary by Sourcery

Harden security around external image fetching, token hashing, and redirects while updating cryptography dependencies.

New Features:
- Introduce keyed HMAC-based hashing for API keys and Discord one-time authorization tokens with transparent migration from legacy digests.
- Add safe redirect handling that only permits local relative referrer URLs for tournament-related redirects.

Bug Fixes:
- Tighten Cube Cobra image proxying by enforcing HTTPS, restricting ports and credentials, validating public DNS resolution, and disabling HTTP redirects to mitigate SSRF risks.
- Prevent logging of potentially sensitive HTTP request payloads in the Discord bot HTTP client.

Enhancements:
- Add DNS-based public IP validation and a no-redirect HTTP handler to external Cube Cobra metadata and image fetches.
- Fallback to legacy token digests when authenticating API keys and Discord tokens and automatically migrate stored hashes on successful verification.

Build:
- Upgrade the cryptography dependency from 48.0.0 to 49.0.0.