### PR TITLE
Introduce granular permissions and enforce them across routes

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -1175,7 +1175,8 @@ def create_app():
         invite_token = request.values.get('invite', '').strip()
         invite = _valid_registration_invite(invite_token)
         mode = registration_mode()
-        if request.method == 'GET' and mode == 'closed':
+        can_register_account = current_user.is_authenticated and current_user.has_permission('accounts.register')
+        if request.method == 'GET' and mode == 'closed' and not can_register_account:
             flash('Registration is currently closed. Contact an administrator for access.', 'error')
         if request.method == 'POST':
             email = request.form['email'].strip().lower()
@@ -1197,7 +1198,7 @@ def create_app():
                 log_site('register', 'failure', 'email exists')
                 return redirect(url_for('register', invite=invite_token) if invite_token else url_for('register'))
             mode = registration_mode()
-            if mode == 'closed':
+            if mode == 'closed' and not can_register_account:
                 flash('Registration is currently closed.', 'error')
                 log_site('register', 'failure', 'registration closed')
                 return redirect(url_for('register'))
@@ -1211,7 +1212,7 @@ def create_app():
                     flash("Selected tournament was not found", "error")
                     log_site('register', 'failure', 'invalid tournament selection')
                     return redirect(url_for('register', invite=invite_token) if invite_token else url_for('register'))
-            if mode == 'invite_only' and not invite:
+            if mode == 'invite_only' and not invite and not can_register_account:
                 flash('Account creation is invite only. Use the invite link sent by an administrator.', 'error')
                 log_site('register', 'failure', 'invite required')
                 return redirect(url_for('register'))
@@ -1361,6 +1362,9 @@ def create_app():
                 _safe_log_site('login', 'failure', 'account locked')
                 return render_template('login.html')
             if u and u.check_password(password):
+                if not u.has_permission('accounts.authenticate'):
+                    _safe_log_site('login', 'failure', 'missing accounts.authenticate')
+                    abort(403)
                 u.failed_login_count = 0
                 u.lock_reason = None
                 db.session.commit()
@@ -1428,6 +1432,8 @@ def create_app():
             log_site('password_reset', 'failure', f'invalid or expired token; ip={_client_ip()}')
             flash('Password reset link is invalid or expired.', 'error')
             return redirect(url_for('password_reset_request'))
+        if reset.user.locked_at or not reset.user.has_permission('accounts.authenticate'):
+            abort(403)
         if request.method == 'POST':
             password = request.form.get('password', '')
             password_confirm = request.form.get('password_confirm', '')
@@ -1444,6 +1450,7 @@ def create_app():
         return render_template('password_reset_form.html', token=token)
 
     @app.route('/t/<int:tid>/join-link')
+    @login_required
     def tournament_join_link(tid):
         from .models import Tournament, TournamentPlayer
         t = db.session.get(Tournament, tid)
@@ -1462,6 +1469,7 @@ def create_app():
         return render_template('tournament/join_link.html', t=t, join_url=join_url, qr_url=qr_url, is_player=is_player, registration_mode=registration_mode())
 
     @app.route('/t/<int:tid>/join-qr.png')
+    @login_required
     def tournament_join_qr(tid):
         import qrcode
 
@@ -1590,6 +1598,7 @@ def create_app():
     @app.route('/messages')
     @login_required
     def messages_home():
+        require_permission('messages.use')
         judge_access = current_user.has_permission('tournaments.manage')
         admin_access = current_user.has_permission('admin.panel')
         return render_template('messages/index.html', judge_access=judge_access, admin_access=admin_access)
@@ -1598,6 +1607,7 @@ def create_app():
     @app.route('/messages/inbox')
     @login_required
     def messages_inbox():
+        require_permission('messages.use')
         from .models import Message
         private_key = load_private_key_from_session()
         msgs = []
@@ -1629,6 +1639,7 @@ def create_app():
     @app.route('/messages/sent')
     @login_required
     def messages_sent():
+        require_permission('messages.use')
         from .models import Message
 
         private_key = load_private_key_from_session()
@@ -1665,6 +1676,7 @@ def create_app():
     @app.route('/messages/send', methods=['GET', 'POST'])
     @login_required
     def send_message():
+        require_permission('messages.use')
         from .models import User
         if request.method == 'POST':
             recipient_id_raw = request.form.get('recipient_id', '').strip()
@@ -1695,6 +1707,7 @@ def create_app():
     @app.route('/messages/view/<int:mid>')
     @login_required
     def view_message(mid):
+        require_permission('messages.use')
         from .models import Message
 
         msg = db.session.get(Message, mid)
@@ -1732,6 +1745,7 @@ def create_app():
     @app.route('/messages/<int:mid>/reply', methods=['POST'])
     @login_required
     def reply_message(mid):
+        require_permission('messages.use')
         from .models import Message
 
         msg = db.session.get(Message, mid)
@@ -1846,6 +1860,7 @@ def create_app():
     @app.route('/api/users/search')
     @login_required
     def api_user_search():
+        require_permission('users.search')
         term = (request.args.get('q') or '').strip()
         results = []
         if term:
@@ -1868,6 +1883,7 @@ def create_app():
     @app.route('/api/messages/unread')
     @login_required
     def api_unread_messages():
+        require_permission('messages.use')
         count = (
             db.session.query(Message)
             .filter_by(recipient_id=current_user.id, is_read=False)
@@ -2134,6 +2150,7 @@ def create_app():
     @app.route('/settings', methods=['GET', 'POST'])
     @login_required
     def user_settings():
+        require_permission('accounts.manage_self')
         new_api_key = None
         new_discord_pass = None
         if request.method == 'POST':
@@ -2182,6 +2199,7 @@ def create_app():
     @app.route('/settings/api-keys/<int:key_id>/revoke', methods=['POST'])
     @login_required
     def revoke_api_key(key_id):
+        require_permission('accounts.api_keys.revoke_self')
         key = db.session.get(ApiKey, key_id)
         if not key or key.user_id != current_user.id:
             abort(404)
@@ -2665,6 +2683,7 @@ def create_app():
     @app.route('/reports', methods=['GET', 'POST'])
     @login_required
     def submit_report():
+        require_permission('reports.submit')
         if request.method == 'POST':
             report_type = request.form.get('report_type')
             description = (request.form.get('description') or '').strip()
@@ -2797,6 +2816,7 @@ def create_app():
     @app.route('/cube-cobra-image')
     @login_required
     def cube_cobra_image():
+        require_permission('media.view')
         image_url = request.args.get('url', '').strip()
         if not is_allowed_cube_preview_image_url(image_url):
             abort(404)
@@ -2829,6 +2849,7 @@ def create_app():
     @app.route('/media/<path:filename>')
     @login_required
     def media_file(filename):
+        require_permission('media.view')
         media_dir = app.config.get('MEDIA_STORAGE_DIR')
         if not media_dir:
             abort(404)
@@ -3269,15 +3290,9 @@ def create_app():
         """Return True if ``user`` may view decks for ``tournament``."""
         if not user or not getattr(user, 'is_authenticated', False):
             return False
-        if hasattr(user, 'has_permission') and user.has_permission('tournaments.manage'):
+        if hasattr(user, 'has_permission') and user.has_permission('decks.view'):
             return True
-        if assigned_judge_ids is None:
-            assigned = set(tournament.floor_judge_ids() or [])
-            if tournament.head_judge_id:
-                assigned.add(tournament.head_judge_id)
-        else:
-            assigned = set(assigned_judge_ids)
-        return user.id in assigned
+        return False
 
     def deck_modifications_locked(tournament):
         from .models import Round  # lazy import
@@ -5062,6 +5077,7 @@ def create_app():
     @app.route('/my-leagues')
     @login_required
     def my_leagues():
+        require_permission('leagues.view')
         memberships = (
             db.session.query(LeaguePlayer)
             .join(League)
@@ -5074,6 +5090,7 @@ def create_app():
     @app.route('/leagues/<int:league_id>')
     @login_required
     def view_league(league_id):
+        require_permission('leagues.view')
         league = db.session.get(League, league_id)
         if not league:
             abort(404)
@@ -5128,6 +5145,7 @@ def create_app():
     @app.route('/leagues/<int:league_id>/cubes', methods=['GET', 'POST'])
     @login_required
     def league_cube_voting(league_id):
+        require_permission('leagues.cube_vote')
         league = db.session.get(League, league_id)
         if not league or not league.is_cube_league:
             abort(404)
@@ -5749,6 +5767,7 @@ def create_app():
     @app.route('/my-tournaments')
     @login_required
     def my_tournaments():
+        require_permission('tournaments.view_self')
         entries = (
             db.session.query(TournamentPlayer)
             .join(Tournament)
@@ -5766,6 +5785,7 @@ def create_app():
         )
 
     @app.route('/t/<int:tid>')
+    @login_required
     def view_tournament(tid):
         t = db.session.get(Tournament, tid)
         if not t: abort(404)
@@ -5868,6 +5888,7 @@ def create_app():
     @app.route('/t/<int:tid>/decklists')
     @login_required
     def tournament_decklists(tid):
+        require_permission('decks.view')
         t = db.session.get(Tournament, tid)
         if not t:
             abort(404)
@@ -5952,7 +5973,7 @@ def create_app():
         if not t:
             abort(404)
         tp = get_player_entry(tid, current_user.id)
-        if not tp and not current_user.has_permission('tournaments.manage'):
+        if not tp or not current_user.has_permission('decks.manage_self'):
             abort(403)
         query = (request.args.get('q') or '').strip()
         if len(query) < 2:
@@ -5973,6 +5994,7 @@ def create_app():
         t = db.session.get(Tournament, tid)
         if not t:
             abort(404)
+        require_permission('decks.manage_self')
         tp = get_player_entry(tid, current_user.id)
         if not tp:
             abort(403)
@@ -6056,6 +6078,7 @@ def create_app():
         t = db.session.get(Tournament, tid)
         if not t:
             abort(404)
+        require_permission('decks.manage_self')
         tp = get_player_entry(tid, current_user.id)
         if not tp:
             abort(403)
@@ -6109,6 +6132,7 @@ def create_app():
     def upload_deck_image(tid):
         from .models import Tournament
 
+        require_permission('decks.manage_self')
         t = db.session.get(Tournament, tid)
         if not t:
             abort(404)
@@ -6136,6 +6160,7 @@ def create_app():
     def delete_deck_image(tid):
         from .models import Tournament
 
+        require_permission('decks.manage_self')
         t = db.session.get(Tournament, tid)
         if not t:
             abort(404)
@@ -6495,6 +6520,7 @@ def create_app():
         return redirect(url_for('view_tournament', tid=tid))
 
     @app.route('/t/<int:tid>/draft-seating')
+    @login_required
     def draft_seating(tid):
         t = db.session.get(Tournament, tid)
         if not t or t.format != 'Draft':
@@ -6785,6 +6811,7 @@ def create_app():
         return redirect(url_for('view_tournament', tid=tid))
 
     @app.route('/t/<int:tid>/round/<int:rid>')
+    @login_required
     def view_round(tid, rid):
         r = db.session.get(Round, rid)
         if not r or r.tournament_id != tid:
@@ -6826,12 +6853,15 @@ def create_app():
         from .models import TournamentPlayer, MatchResult
         # Only participants or tournament managers can report
         t = m.round.tournament
-        if not current_user.has_permission('tournaments.manage') and current_user.id not in (
+        is_participant = current_user.id in (
             m.player1.user_id,
             m.player2.user_id if m.player2_id else None,
             m.player3.user_id if m.player3_id else None,
             m.player4.user_id if m.player4_id else None,
-        ):
+        )
+        if is_participant:
+            require_permission('matches.report_self')
+        elif not current_user.has_permission('tournaments.manage'):
             abort(403)
         next_round = db.session.query(Round).filter(Round.tournament_id==t.id, Round.number>m.round.number).first()
         if next_round:
@@ -6916,6 +6946,7 @@ def create_app():
         return render_template('match/report.html', m=m, t=t)
 
     @app.route('/t/<int:tid>/standings')
+    @login_required
     def standings(tid):
         t = db.session.get(Tournament, tid)
         if not t: abort(404)
@@ -6946,6 +6977,7 @@ def create_app():
                                timer_remaining=timer_remaining, server_now=datetime.utcnow())
 
     @app.route('/t/<int:tid>/bracket')
+    @login_required
     def bracket(tid):
         t = db.session.get(Tournament, tid)
         if not t: abort(404)

--- a/app/models.py
+++ b/app/models.py
@@ -37,12 +37,22 @@ def _legacy_token_digest(token):
 
 # Permission groups and default role permissions
 PERMISSION_GROUPS = {
+    'accounts': {
+        'register': 'Register accounts when public registration is unavailable',
+        'authenticate': 'Authenticate and reset a password',
+        'manage_self': 'Manage personal settings and Discord link',
+        'api_keys.revoke_self': 'Revoke a personally owned API key',
+    },
+    'messages': {
+        'use': 'Read, send, and reply to personal messages',
+    },
     'tournaments': {
         'manage': 'Create and manage tournaments',
         'join': 'Join tournaments',
         'approve_join': 'Approve tournament join requests',
         'bulk_manage': 'Bulk edit tournaments',
         'delete_leagues': 'Delete leagues',
+        'view_self': 'View tournaments you have joined',
     },
     'venues': {
         'manage': 'Create and manage venues, vendors, and artists',
@@ -50,6 +60,24 @@ PERMISSION_GROUPS = {
     'users': {
         'manage': 'Manage users',
         'manage_admins': 'Manage admin level users',
+        'search': 'Search the user directory',
+    },
+    'reports': {
+        'submit': 'Submit bug and player reports',
+    },
+    'leagues': {
+        'view': 'View available leagues',
+        'cube_vote': 'View and submit league cube votes',
+    },
+    'decks': {
+        'manage_self': 'Create and update your own deck',
+        'view': 'View other players’ tournament decks',
+    },
+    'matches': {
+        'report_self': 'Report your own match and drop yourself',
+    },
+    'media': {
+        'view': 'View uploaded media and permitted cube images',
     },
     'admin': {
         'panel': 'Access admin panel',
@@ -73,6 +101,7 @@ def all_permission_keys():
 DEFAULT_ROLE_PERMISSIONS = {
     'admin': {key: True for key in all_permission_keys()},
     'manager': {
+        'accounts.register': True,
         'tournaments.manage': True,
         'users.manage': True,
         'tournaments.approve_join': True,
@@ -98,6 +127,26 @@ DEFAULT_ROLE_PERMISSIONS = {
         'tournaments.join': True,
     },
 }
+
+_ALL_ROLE_PERMISSION_KEYS = {
+    'accounts.authenticate',
+    'accounts.manage_self',
+    'accounts.api_keys.revoke_self',
+    'messages.use',
+    'reports.submit',
+    'leagues.view',
+    'leagues.cube_vote',
+    'tournaments.view_self',
+    'decks.manage_self',
+    'matches.report_self',
+    'media.view',
+}
+
+for role_permissions in DEFAULT_ROLE_PERMISSIONS.values():
+    role_permissions.update({key: True for key in _ALL_ROLE_PERMISSION_KEYS})
+for role_name in ('admin', 'manager', 'venue judge', 'event head judge'):
+    DEFAULT_ROLE_PERMISSIONS[role_name]['users.search'] = True
+    DEFAULT_ROLE_PERMISSIONS[role_name]['decks.view'] = True
 
 
 

--- a/documentation/permissions.schema.json
+++ b/documentation/permissions.schema.json
@@ -1,0 +1,710 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://walter.local/schemas/permissions.schema.json",
+  "title": "WaLTER permissions",
+  "type": "object",
+  "properties": {
+    "permissions": {
+      "type": "object",
+      "properties": {
+        "tournaments.manage": {
+          "type": "boolean",
+          "default": false,
+          "description": "Create and manage tournaments",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge"
+          ],
+          "x-current-actions": [
+            "Create, edit, complete, reopen, and delete tournaments",
+            "Manage players, rounds, timers, judges, leagues, and schedules"
+          ]
+        },
+        "tournaments.join": {
+          "type": "boolean",
+          "default": false,
+          "description": "Join tournaments",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "user"
+          ],
+          "x-current-actions": [
+            "Join a tournament or request approval"
+          ]
+        },
+        "tournaments.approve_join": {
+          "type": "boolean",
+          "default": false,
+          "description": "Approve tournament join requests",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge"
+          ],
+          "x-current-actions": [
+            "View, approve, and reject tournament join requests"
+          ]
+        },
+        "tournaments.bulk_manage": {
+          "type": "boolean",
+          "default": false,
+          "description": "Bulk edit tournaments",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "Bulk update or delete tournaments"
+          ]
+        },
+        "tournaments.delete_leagues": {
+          "type": "boolean",
+          "default": false,
+          "description": "Delete leagues",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "Delete a league"
+          ]
+        },
+        "venues.manage": {
+          "type": "boolean",
+          "default": false,
+          "description": "Create and manage venues, vendors, and artists",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge"
+          ],
+          "x-current-actions": [
+            "Create and update venues, vendors, and artists"
+          ]
+        },
+        "users.manage": {
+          "type": "boolean",
+          "default": false,
+          "description": "Manage users",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge"
+          ],
+          "x-current-actions": [
+            "List, view, create, update, and delete users"
+          ]
+        },
+        "users.manage_admins": {
+          "type": "boolean",
+          "default": false,
+          "description": "Manage admin-level users",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "View and modify admin accounts"
+          ]
+        },
+        "admin.panel": {
+          "type": "boolean",
+          "default": false,
+          "description": "Access the admin panel",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "View administrative dashboards, logs, reports, connections, and backups"
+          ]
+        },
+        "admin.permissions": {
+          "type": "boolean",
+          "default": false,
+          "description": "Manage roles and permissions",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "Create roles and grant role or user permissions"
+          ]
+        },
+        "admin.login_audit": {
+          "type": "boolean",
+          "default": false,
+          "description": "Audit failed login attempts",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "View failed-login audit records"
+          ]
+        },
+        "admin.ip_blacklist": {
+          "type": "boolean",
+          "default": false,
+          "description": "Manage blacklisted IP addresses",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "View, change, and export the IP blacklist"
+          ]
+        },
+        "admin.site_settings": {
+          "type": "boolean",
+          "default": false,
+          "description": "Manage site settings and registration invites",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "Change site settings and manage registration invites"
+          ]
+        },
+        "admin.api_keys": {
+          "type": "boolean",
+          "default": false,
+          "description": "Create API keys",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin"
+          ],
+          "x-current-actions": [
+            "Create an API key"
+          ]
+        },
+        "accounts.register": {
+          "type": "boolean",
+          "default": false,
+          "description": "Register account",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager"
+          ],
+          "x-current-actions": [
+            "Register account"
+          ],
+          "x-routes": [
+            "/register",
+            "/register/verify",
+            "/register/verify/<token>"
+          ],
+          "x-methods": [
+            "GET",
+            "POST"
+          ],
+          "request": "An admin or manager can register a new user. A person without an account can register only when registration is open or with a valid invite token."
+        },
+        "accounts.authenticate": {
+          "type": "boolean",
+          "default": false,
+          "description": "Authenticate and reset password",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "Authenticate and reset password"
+          ],
+          "x-routes": [
+            "/login",
+            "/logout",
+            "/password-reset",
+            "/password-reset/<token>"
+          ],
+          "x-methods": [
+            "GET",
+            "POST"
+          ],
+          "request": "A user can log in or out. Password reset requires a valid token. Authentication and password reset are unavailable to blocked or locked users."
+        },
+        "accounts.manage_self": {
+          "type": "boolean",
+          "default": false,
+          "description": "Manage own settings and Discord link",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "Manage own settings and Discord link"
+          ],
+          "x-routes": [
+            "/settings"
+          ],
+          "x-methods": [
+            "GET",
+            "POST"
+          ],
+          "request": "A logged-in user can manage their own settings and Discord link."
+        },
+        "accounts.api_keys.revoke_self": {
+          "type": "boolean",
+          "default": false,
+          "description": "Revoke own API key",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "Revoke own API key"
+          ],
+          "x-routes": [
+            "/settings/api-keys/<key_id>/revoke"
+          ],
+          "x-methods": [
+            "POST"
+          ],
+          "request": "A logged-in user can revoke an API key they own."
+        },
+        "messages.use": {
+          "type": "boolean",
+          "default": false,
+          "description": "Read, send, and reply to personal messages",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "View inbox and sent messages",
+            "Send, view, and reply to an owned message",
+            "Read unread-message count"
+          ],
+          "x-routes": [
+            "/messages",
+            "/messages/player",
+            "/messages/inbox",
+            "/messages/sent",
+            "/messages/player/send",
+            "/messages/send",
+            "/messages/view/<mid>",
+            "/messages/<mid>/reply",
+            "/api/messages/unread"
+          ],
+          "x-methods": [
+            "GET",
+            "POST"
+          ],
+          "request": "A logged-in user can read, send, and reply to personal messages. A message is visible only to its sender or recipient."
+        },
+        "users.search": {
+          "type": "boolean",
+          "default": false,
+          "description": "Search the user directory",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge"
+          ],
+          "x-current-actions": [
+            "Search users by name or email"
+          ],
+          "x-routes": [
+            "/api/users/search"
+          ],
+          "x-methods": [
+            "GET"
+          ],
+          "request": "A logged-in user can search the user directory only when their role grants this permission."
+        },
+        "reports.submit": {
+          "type": "boolean",
+          "default": false,
+          "description": "Submit bug and player reports",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "Submit a bug report",
+            "Submit a player report"
+          ],
+          "x-routes": [
+            "/reports"
+          ],
+          "x-methods": [
+            "GET",
+            "POST"
+          ],
+          "request": "A logged-in user can submit bug and player reports."
+        },
+        "leagues.view": {
+          "type": "boolean",
+          "default": false,
+          "description": "View available leagues",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "View own league memberships",
+            "View a league"
+          ],
+          "x-routes": [
+            "/my-leagues",
+            "/leagues/<league_id>"
+          ],
+          "x-methods": [
+            "GET"
+          ],
+          "request": "A logged-in user can view available leagues. A league is visible only to its members or users with tournaments.manage."
+        },
+        "leagues.cube_vote": {
+          "type": "boolean",
+          "default": false,
+          "description": "View and submit league cube votes",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "View cube ballots",
+            "Submit or update own cube votes"
+          ],
+          "x-routes": [
+            "/leagues/<league_id>/cubes"
+          ],
+          "x-methods": [
+            "GET",
+            "POST"
+          ],
+          "request": "A logged-in user can vote only in a league they belong to or when they have tournaments.manage."
+        },
+        "tournaments.view_self": {
+          "type": "boolean",
+          "default": false,
+          "description": "View tournaments joined by the current user",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "View own active tournament registrations"
+          ],
+          "x-routes": [
+            "/my-tournaments"
+          ],
+          "x-methods": [
+            "GET"
+          ],
+          "request": "A logged-in user can view tournaments in which they participate."
+        },
+        "decks.manage_self": {
+          "type": "boolean",
+          "default": false,
+          "description": "Create and update own deck",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "Search cards",
+            "Save, import, or submit own deck",
+            "Upload or delete own deck image"
+          ],
+          "x-routes": [
+            "/t/<tid>/deck/search",
+            "/t/<tid>/deck/manual",
+            "/t/<tid>/deck/mtgo",
+            "/t/<tid>/deck/image",
+            "/t/<tid>/deck/image/delete"
+          ],
+          "x-methods": [
+            "GET",
+            "POST"
+          ],
+          "request": "A logged-in tournament participant can create and update their own deck."
+        },
+        "decks.view": {
+          "type": "boolean",
+          "default": false,
+          "description": "View tournament decklists and player decks",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge"
+          ],
+          "x-current-actions": [
+            "View tournament decklists",
+            "View another player’s deck"
+          ],
+          "x-routes": [
+            "/t/<tid>/decklists",
+            "/t/<tid>/players/<player_id>/deck"
+          ],
+          "x-methods": [
+            "GET"
+          ],
+          "request": "A user can always view their own deck. Viewing another player’s deck requires this permission."
+        },
+        "matches.report_self": {
+          "type": "boolean",
+          "default": false,
+          "description": "Report own match and drop self",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "View and submit own match result",
+            "Drop self while reporting"
+          ],
+          "x-routes": [
+            "/match/<mid>"
+          ],
+          "x-methods": [
+            "GET",
+            "POST"
+          ],
+          "request": "A logged-in match participant can report their own match and drop themselves. Reporting for others requires tournaments.manage."
+        },
+        "media.view": {
+          "type": "boolean",
+          "default": false,
+          "description": "View uploaded media and proxied cube images",
+          "x-assignment-status": "assigned",
+          "x-current-roles": [
+            "admin",
+            "manager",
+            "venue judge",
+            "event head judge",
+            "floor judge",
+            "user"
+          ],
+          "x-current-actions": [
+            "View uploaded media",
+            "Request a permitted Cube Cobra image"
+          ],
+          "x-routes": [
+            "/media/<filename>",
+            "/cube-cobra-image"
+          ],
+          "x-methods": [
+            "GET"
+          ],
+          "request": "A logged-in user with this permission can view uploaded media. Proxied cube images must also use a safe, permitted URL."
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "required": [
+    "permissions"
+  ],
+  "additionalProperties": false,
+  "x-default-role-permissions": {
+    "admin": [
+      "accounts.api_keys.revoke_self",
+      "accounts.authenticate",
+      "accounts.manage_self",
+      "accounts.register",
+      "admin.api_keys",
+      "admin.ip_blacklist",
+      "admin.login_audit",
+      "admin.panel",
+      "admin.permissions",
+      "admin.site_settings",
+      "decks.manage_self",
+      "decks.view",
+      "leagues.cube_vote",
+      "leagues.view",
+      "matches.report_self",
+      "media.view",
+      "messages.use",
+      "reports.submit",
+      "tournaments.approve_join",
+      "tournaments.bulk_manage",
+      "tournaments.delete_leagues",
+      "tournaments.join",
+      "tournaments.manage",
+      "tournaments.view_self",
+      "users.manage",
+      "users.manage_admins",
+      "users.search",
+      "venues.manage"
+    ],
+    "manager": [
+      "accounts.api_keys.revoke_self",
+      "accounts.authenticate",
+      "accounts.manage_self",
+      "accounts.register",
+      "decks.manage_self",
+      "decks.view",
+      "leagues.cube_vote",
+      "leagues.view",
+      "matches.report_self",
+      "media.view",
+      "messages.use",
+      "reports.submit",
+      "tournaments.approve_join",
+      "tournaments.manage",
+      "tournaments.view_self",
+      "users.manage",
+      "users.search",
+      "venues.manage"
+    ],
+    "venue judge": [
+      "accounts.api_keys.revoke_self",
+      "accounts.authenticate",
+      "accounts.manage_self",
+      "decks.manage_self",
+      "decks.view",
+      "leagues.cube_vote",
+      "leagues.view",
+      "matches.report_self",
+      "media.view",
+      "messages.use",
+      "reports.submit",
+      "tournaments.approve_join",
+      "tournaments.manage",
+      "tournaments.view_self",
+      "users.manage",
+      "users.search",
+      "venues.manage"
+    ],
+    "event head judge": [
+      "accounts.api_keys.revoke_self",
+      "accounts.authenticate",
+      "accounts.manage_self",
+      "decks.manage_self",
+      "decks.view",
+      "leagues.cube_vote",
+      "leagues.view",
+      "matches.report_self",
+      "media.view",
+      "messages.use",
+      "reports.submit",
+      "tournaments.approve_join",
+      "tournaments.manage",
+      "tournaments.view_self",
+      "users.manage",
+      "users.search",
+      "venues.manage"
+    ],
+    "floor judge": [
+      "accounts.api_keys.revoke_self",
+      "accounts.authenticate",
+      "accounts.manage_self",
+      "decks.manage_self",
+      "leagues.cube_vote",
+      "leagues.view",
+      "matches.report_self",
+      "media.view",
+      "messages.use",
+      "reports.submit",
+      "tournaments.approve_join",
+      "tournaments.view_self",
+      "users.manage"
+    ],
+    "user": [
+      "accounts.api_keys.revoke_self",
+      "accounts.authenticate",
+      "accounts.manage_self",
+      "decks.manage_self",
+      "leagues.cube_vote",
+      "leagues.view",
+      "matches.report_self",
+      "media.view",
+      "messages.use",
+      "reports.submit",
+      "tournaments.join",
+      "tournaments.view_self"
+    ]
+  },
+  "x-unpermissioned-actions": [
+    {
+      "id": "tournaments.public_read",
+      "permission": null,
+      "x-current-roles": [],
+      "x-current-actions": [
+        "View tournament overview, rounds, standings, bracket, draft seating, join link, and join QR code"
+      ],
+      "x-routes": [
+        "/t/<tid>",
+        "/t/<tid>/round/<rid>",
+        "/t/<tid>/standings",
+        "/t/<tid>/bracket",
+        "/t/<tid>/draft-seating",
+        "/t/<tid>/join-link",
+        "/t/<tid>/join-qr.png"
+      ],
+      "x-methods": [
+        "GET"
+      ],
+      "request": "Do not display tournament information publicly."
+    }
+  ]
+}

--- a/tests/test_decklists.py
+++ b/tests/test_decklists.py
@@ -375,7 +375,7 @@ def test_deck_changes_locked_prevents_updates(client, session, user):
     assert tp.deck is None
 
 
-def test_floor_judge_can_view_player_deck(client, session, user):
+def test_event_head_judge_can_view_player_deck(client, session, user):
     tournament = create_tournament(session)
     tp = register_player(session, tournament, user)
     deck = TournamentPlayerDeck(
@@ -388,8 +388,8 @@ def test_floor_judge_can_view_player_deck(client, session, user):
     session.add(deck)
     session.commit()
 
-    judge_role = session.query(Role).filter_by(name='floor judge').first()
-    judge = User(email='judge@example.com', name='Floor Judge', role=judge_role)
+    judge_role = session.query(Role).filter_by(name='event head judge').first()
+    judge = User(email='judge@example.com', name='Event Head Judge', role=judge_role)
     judge.set_password('secret')
     session.add(judge)
     session.commit()

--- a/tests/test_tournament.py
+++ b/tests/test_tournament.py
@@ -471,7 +471,7 @@ def test_bulk_register_adds_existing_users(client, session):
 def test_bulk_edit_tournament_controls_stay_bound_to_bulk_form(client, session):
     bulk_role = Role(
         name='bulk form manager',
-        permissions=json.dumps({'tournaments.bulk_manage': True, 'tournaments.manage': True}),
+        permissions=json.dumps({'accounts.authenticate': True, 'tournaments.bulk_manage': True, 'tournaments.manage': True}),
         level=100,
     )
     user = User(email='bulk-form-manager@example.com', name='Bulk Form Manager', role=bulk_role)
@@ -528,7 +528,7 @@ def test_tournament_manager_can_bulk_add_tournament_to_venue(client, session):
 def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session):
     bulk_role = Role(
         name='bulk venue manager',
-        permissions=json.dumps({'tournaments.bulk_manage': True, 'venues.manage': True}),
+        permissions=json.dumps({'accounts.authenticate': True, 'tournaments.bulk_manage': True, 'venues.manage': True}),
         level=100,
     )
     user = User(email='bulk-venue-manager@example.com', name='Bulk Venue Manager', role=bulk_role)
@@ -556,7 +556,7 @@ def test_bulk_edit_tournaments_adds_selected_tournament_to_venue(client, session
 def test_bulk_edit_tournaments_adds_multiple_unique_tournaments_to_venue(client, session):
     bulk_role = Role(
         name='bulk multi venue manager',
-        permissions=json.dumps({'tournaments.bulk_manage': True, 'venues.manage': True}),
+        permissions=json.dumps({'accounts.authenticate': True, 'tournaments.bulk_manage': True, 'venues.manage': True}),
         level=100,
     )
     user = User(email='bulk-multi-venue-manager@example.com', name='Bulk Multi Venue Manager', role=bulk_role)
@@ -586,7 +586,7 @@ def test_bulk_edit_tournaments_adds_multiple_unique_tournaments_to_venue(client,
 def test_bulk_edit_tournaments_ignores_duplicate_tournament_ids(client, session):
     bulk_role = Role(
         name='bulk duplicate venue manager',
-        permissions=json.dumps({'tournaments.bulk_manage': True, 'venues.manage': True}),
+        permissions=json.dumps({'accounts.authenticate': True, 'tournaments.bulk_manage': True, 'venues.manage': True}),
         level=100,
     )
     user = User(email='bulk-duplicate-venue-manager@example.com', name='Bulk Duplicate Venue Manager', role=bulk_role)

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -75,6 +75,50 @@ def test_roles_can_approve_join(session):
         assert perms.get('tournaments.approve_join')
 
 
+def test_new_permission_role_grants(session):
+    roles = {role.name: role.permissions_dict() for role in session.query(Role).all()}
+    all_role_permissions = {
+        'accounts.authenticate', 'accounts.manage_self', 'accounts.api_keys.revoke_self',
+        'messages.use', 'reports.submit', 'leagues.view', 'leagues.cube_vote',
+        'tournaments.view_self', 'decks.manage_self', 'matches.report_self', 'media.view',
+    }
+    for permissions in roles.values():
+        assert all(permissions.get(key) for key in all_role_permissions)
+    for role_name in ('admin', 'manager'):
+        assert roles[role_name].get('accounts.register')
+    for role_name in ('admin', 'manager', 'venue judge', 'event head judge'):
+        assert roles[role_name].get('users.search')
+        assert roles[role_name].get('decks.view')
+    assert 'tournaments.view_public' not in roles['admin']
+
+
+def test_tournament_information_is_not_public(client, session):
+    from app.models import Tournament
+
+    tournament = Tournament(name='Private listing', format='Commander')
+    session.add(tournament)
+    session.commit()
+
+    paths = (
+        f'/t/{tournament.id}', f'/t/{tournament.id}/standings',
+        f'/t/{tournament.id}/bracket', f'/t/{tournament.id}/draft-seating',
+        f'/t/{tournament.id}/join-link', f'/t/{tournament.id}/join-qr.png',
+    )
+    for path in paths:
+        assert client.get(path).status_code == 302
+
+
+def test_user_search_requires_permission(client, session):
+    role = Role(name='no-search', permissions=json.dumps({'accounts.authenticate': True}))
+    user = User(email='no-search@example.com', name='No Search', role=role)
+    user.set_password('secret')
+    session.add_all([role, user])
+    session.commit()
+
+    assert client.post('/login', data={'email': user.email, 'password': 'secret'}).status_code == 302
+    assert client.get('/api/users/search?q=test').status_code == 403
+
+
 def test_admin_bulk_delete_users(client, session):
     admin_role = session.query(Role).filter_by(name='admin').one()
     user_role = session.query(Role).filter_by(name='user').one()


### PR DESCRIPTION
### Motivation

- Centralize and document application permissions to control who can perform actions like account registration, messaging, deck management, and league interactions.
- Prevent unauthorized access to sensitive flows (login/password reset, media proxy, message inbox, deck operations, user search) by enforcing explicit permissions on routes.

### Description

- Added new permission groups and keys in `app/models.py` and expanded default role permissions to include `accounts`, `messages`, `decks`, `leagues`, `reports`, `matches`, `media`, and new keys such as `accounts.authenticate`, `messages.use`, `decks.manage_self`, and `decks.view`.
- Updated role defaults so all roles receive a baseline set of new permission keys and granted `users.search`/`decks.view` to higher-level roles, and applied changes to `DEFAULT_ROLE_PERMISSIONS` initialization.
- Enforced permission checks throughout `app/app.py` by requiring appropriate permissions on endpoints (examples: registration when closed, `accounts.authenticate` on login/reset flows, `messages.use` on message endpoints, `users.search` on `/api/users/search`, `decks.*` permissions on deck routes, `media.view` on media and cube preview endpoints, plus several `@login_required` additions and adjusted logic for viewing decks).
- Added `documentation/permissions.schema.json` to describe the permission model, list routes and methods for permissions, and include default role assignments.
- Updated tests to reflect the new permission model and behaviour in `tests/test_users.py`, `tests/test_decklists.py`, and `tests/test_tournament.py`.

### Testing

- Ran the modified unit tests in `tests/test_users.py`, `tests/test_decklists.py`, and `tests/test_tournament.py` using `pytest`, and the updated tests passed.
- Verified permission-protected endpoints return expected HTTP statuses for users with and without the required permissions via the updated tests, which succeeded.
- No automated test failures were observed in the exercised test cases.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8236acf04c8320ac82e09fdd148def)

## Summary by Sourcery

Introduce granular, role-based permissions and enforce them across key user, messaging, deck, league, media, and tournament routes.

New Features:
- Define new permission groups and keys for accounts, messages, reports, leagues, decks, matches, media, tournaments, and users in the central permission model.
- Grant baseline permissions (authenticate, self-management, messaging, leagues, decks, matches, media, etc.) to all roles and additional search and deck viewing permissions to elevated roles.
- Add a permissions schema documentation file describing available permissions, route mappings, and default role assignments.

Enhancements:
- Tighten access control on registration, login, password reset, user settings, API key revocation, messaging, user search, reports, media access, leagues, tournaments, deck management, and match reporting via explicit permission checks and login requirements.
- Simplify tournament deck visibility logic so it depends solely on a dedicated deck viewing permission instead of judge assignment heuristics.

Tests:
- Extend and adjust user, decklist, and tournament tests to validate the new permission model, role grants, and restricted access to previously public tournament information and user search.
- Update test roles and expectations (e.g., bulk-edit roles and head judge deck viewing) to align with the new permission semantics.