### PR TITLE
Add cube ownership and owner ballot access

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -578,6 +578,11 @@ def create_app():
                         db.session.execute(text(f'ALTER TABLE league ADD COLUMN {column} {definition}'))
                 db.session.commit()
             LeagueCube.__table__.create(bind=db.engine, checkfirst=True)
+            if 'league_cube' in table_names:
+                columns = [c['name'] for c in inspector.get_columns('league_cube')]
+                if 'owner_id' not in columns:
+                    db.session.execute(text('ALTER TABLE league_cube ADD COLUMN owner_id INTEGER'))
+                    db.session.commit()
             LeaguePlayDate.__table__.create(bind=db.engine, checkfirst=True)
             LeaguePlayDateCube.__table__.create(bind=db.engine, checkfirst=True)
             LeagueCubeVote.__table__.create(bind=db.engine, checkfirst=True)
@@ -3624,7 +3629,7 @@ def create_app():
                 } for i in registration_invites
             ],
             'league_cubes': [
-                {'id': c.id, 'league_id': c.league_id, 'cube_cobra_url': c.cube_cobra_url, 'title': c.title, 'image_url': c.image_url, 'created_at': iso_datetime(c.created_at)} for c in league_cubes
+                {'id': c.id, 'league_id': c.league_id, 'cube_cobra_url': c.cube_cobra_url, 'title': c.title, 'image_url': c.image_url, 'owner_id': c.owner_id, 'created_at': iso_datetime(c.created_at)} for c in league_cubes
             ],
             'league_play_dates': [
                 {'id': d.id, 'league_id': d.league_id, 'play_date': iso_date(d.play_date), 'is_active': bool(d.is_active), 'created_at': iso_datetime(d.created_at)} for d in league_play_dates
@@ -4056,11 +4061,13 @@ def create_app():
             cube = db.session.query(LeagueCube).filter_by(league_id=league.id, cube_cobra_url=url).first()
             is_new = cube is None
             if is_new:
-                cube = LeagueCube(league=league, cube_cobra_url=url, title=title)
+                owner = user_map.get(item.get('owner_id'))
+                cube = LeagueCube(league=league, cube_cobra_url=url, title=title, owner=owner)
                 db.session.add(cube)
             if overwrite or is_new:
                 cube.title = title
                 cube.image_url = item.get('image_url')
+                cube.owner = user_map.get(item.get('owner_id'))
                 cube.created_at = parse_iso_datetime(item.get('created_at')) or cube.created_at
                 counts['league_cubes'] += 1
             cube_map[item.get('id')] = cube
@@ -4991,7 +4998,9 @@ def create_app():
     def require_league_member_or_manager(league):
         if current_user.has_permission('tournaments.manage'):
             return True
-        return db.session.query(LeaguePlayer).filter_by(league_id=league.id, user_id=current_user.id).first() is not None
+        is_member = db.session.query(LeaguePlayer).filter_by(league_id=league.id, user_id=current_user.id).first() is not None
+        owns_cube = db.session.query(LeagueCube).filter_by(league_id=league.id, owner_id=current_user.id).first() is not None
+        return is_member or owns_cube
 
     @app.route('/admin/leagues', methods=['GET', 'POST'])
     def leagues():
@@ -5064,10 +5073,31 @@ def create_app():
                     except ValueError as exc:
                         flash(str(exc), 'error')
                     else:
-                        db.session.add(LeagueCube(league_id=league.id, cube_cobra_url=url, title=title, image_url=image_url))
+                        owner_id = request.form.get('owner_id', '')
+                        owner = db.session.get(User, int(owner_id)) if owner_id.isdigit() else None
+                        db.session.add(LeagueCube(
+                            league_id=league.id,
+                            cube_cobra_url=url,
+                            title=title,
+                            image_url=image_url,
+                            owner=owner,
+                        ))
                         db.session.commit()
                         log_site('league_cube_add', 'success', f'league_id={league.id}; url={url}')
                         flash('Cube added.', 'success')
+            elif action == 'update_cube_owner':
+                cube = db.session.get(LeagueCube, int(request.form.get('cube_id') or 0))
+                raw_owner_id = request.form.get('owner_id', '')
+                owner_id = int(raw_owner_id) if raw_owner_id.isdigit() else 0
+                owner = db.session.get(User, owner_id) if owner_id else None
+                if not cube or cube.league_id != league.id:
+                    flash('Cube not found.', 'error')
+                elif owner_id and not owner:
+                    flash('Cube owner not found.', 'error')
+                else:
+                    cube.owner = owner
+                    db.session.commit()
+                    flash('Cube owner updated.', 'success')
             elif action == 'add_play_date':
                 if not league.is_cube_league:
                     flash('Enable cube league mode before adding League Events.', 'error')
@@ -5222,6 +5252,23 @@ def create_app():
         if not require_league_member_or_manager(league):
             abort(403)
         if request.method == 'POST':
+            if request.form.get('action') == 'add_owned_cube':
+                cube_id = request.form.get('cube_id', '')
+                play_date_id = request.form.get('play_date_id', '')
+                cube = db.session.get(LeagueCube, int(cube_id)) if cube_id.isdigit() else None
+                play_date = db.session.get(LeaguePlayDate, int(play_date_id)) if play_date_id.isdigit() else None
+                if not cube or cube.league_id != league.id or cube.owner_id != current_user.id:
+                    abort(403)
+                if not play_date or play_date.league_id != league.id or not play_date.is_active:
+                    flash('Choose an open League Event.', 'error')
+                elif db.session.query(LeaguePlayDateCube).filter_by(play_date_id=play_date.id, cube_id=cube.id).first():
+                    flash('That cube is already on this ballot.', 'info')
+                else:
+                    db.session.add(LeaguePlayDateCube(play_date_id=play_date.id, cube_id=cube.id))
+                    db.session.commit()
+                    log_site('league_owned_cube_add', 'success', f'league_id={league.id}; play_date_id={play_date.id}; cube_id={cube.id}; owner_id={current_user.id}')
+                    flash('Your cube was added to the ballot.', 'success')
+                return redirect(url_for('league_cube_voting', league_id=league.id))
             for play_date in db.session.query(LeaguePlayDate).filter_by(league_id=league.id, is_active=True).all():
                 available_ids = {link.cube_id for link in play_date.available_cubes}
                 requested = {}
@@ -5251,6 +5298,7 @@ def create_app():
             flash('Cube votes saved.', 'success')
             return redirect(url_for('league_cube_voting', league_id=league.id))
         play_dates, cubes, cube_vote_totals, cube_user_votes, available_cube_ids = league_vote_context(league)
+        owned_cubes = [cube for cube in cubes if cube.owner_id == current_user.id]
         return render_template(
             'league_cubes.html',
             league=league,
@@ -5259,6 +5307,7 @@ def create_app():
             cube_vote_totals=cube_vote_totals,
             cube_user_votes=cube_user_votes,
             available_cube_ids=available_cube_ids,
+            owned_cubes=owned_cubes,
         )
 
     @app.route('/admin/schedule')

--- a/app/models.py
+++ b/app/models.py
@@ -941,9 +941,11 @@ class LeagueCube(db.Model):
     cube_cobra_url = db.Column(db.Text, nullable=False)
     title = db.Column(db.String(250), nullable=False)
     image_url = db.Column(db.Text, nullable=True)
+    owner_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
     created_at = db.Column(db.DateTime, default=utc_now)
 
     league = db.relationship('League', backref=db.backref('cubes', cascade='all, delete-orphan'))
+    owner = db.relationship('User')
 
 
 class LeaguePlayDate(db.Model):

--- a/app/static/style.css
+++ b/app/static/style.css
@@ -2432,6 +2432,35 @@ html[data-theme="dark"] .tournament-control-box .rounds-form {
   font-size: 0.88rem;
 }
 
+.cube-owner-form,
+.owner-ballot-form {
+  display: flex;
+  min-width: 0;
+  flex-wrap: wrap;
+  align-items: end;
+  gap: 0.65rem;
+}
+
+.cube-owner-form label,
+.owner-ballot-form label {
+  min-width: 0;
+  flex: 1 1 12rem;
+  overflow-wrap: anywhere;
+}
+
+.cube-owner-form select,
+.owner-ballot-form select {
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
+  text-overflow: ellipsis;
+}
+
+.cube-owner-form .btn,
+.owner-ballot-form .btn {
+  flex: 0 0 auto;
+}
+
 @media (max-width: 520px) {
   .cube-preview-card {
     grid-template-columns: 1fr;

--- a/app/templates/admin/league_detail.html
+++ b/app/templates/admin/league_detail.html
@@ -36,6 +36,12 @@
     <label class="wide-field">Cube Cobra URL
       <input type="url" name="cube_url" placeholder="https://cubecobra.com/cube/overview/..." required>
     </label>
+    <label>Cube owner
+      <select name="owner_id">
+        <option value="">No owner</option>
+        {% for user in users %}<option value="{{ user.id }}">{{ user.name }}{% if user.email %} — {{ user.email }}{% endif %}</option>{% endfor %}
+      </select>
+    </label>
     <div class="form-actions wide-field start-actions"><button class="btn" type="submit">Add Cube</button></div>
   </form>
   {% if cubes %}
@@ -46,6 +52,17 @@
       <div class="cube-preview-body">
         <h3><a href="{{ cube.cube_cobra_url }}" target="_blank" rel="noopener noreferrer">{{ cube.title|cube_cobra_title }}</a></h3>
         <p class="muted-text">Cube Cobra</p>
+        <form method="post" class="cube-owner-form">
+          <input type="hidden" name="action" value="update_cube_owner">
+          <input type="hidden" name="cube_id" value="{{ cube.id }}">
+          <label>Owner
+            <select name="owner_id">
+              <option value="">No owner</option>
+              {% for user in users %}<option value="{{ user.id }}" {% if cube.owner_id == user.id %}selected{% endif %}>{{ user.name }}</option>{% endfor %}
+            </select>
+          </label>
+          <button class="btn ghost" type="submit">Save owner</button>
+        </form>
       </div>
     </article>
     {% endfor %}

--- a/app/templates/league_cubes.html
+++ b/app/templates/league_cubes.html
@@ -8,6 +8,26 @@
   </div>
 </section>
 
+{% if owned_cubes and play_dates|selectattr('is_active')|list %}
+<section class="panel-card owned-cube-panel">
+  <div class="section-heading"><div><h3>Add one of your cubes</h3><p>As a cube owner, you can add your cube to any open, existing League Event ballot.</p></div></div>
+  <form method="post" class="modern-form owner-ballot-form">
+    <input type="hidden" name="action" value="add_owned_cube">
+    <label>Your cube
+      <select name="cube_id" required>
+        {% for cube in owned_cubes %}<option value="{{ cube.id }}">{{ cube.title|cube_cobra_title }}</option>{% endfor %}
+      </select>
+    </label>
+    <label>League Event
+      <select name="play_date_id" required>
+        {% for play_date in play_dates if play_date.is_active %}<option value="{{ play_date.id }}">{{ play_date.play_date }}</option>{% endfor %}
+      </select>
+    </label>
+    <button class="btn" type="submit">Add to ballot</button>
+  </form>
+</section>
+{% endif %}
+
 {% if play_dates %}
 <form method="post" class="cube-vote-form">
   {% for play_date in play_dates if play_date.is_active %}

--- a/tests/test_leagues.py
+++ b/tests/test_leagues.py
@@ -91,6 +91,47 @@ def test_cube_league_votes_are_limited_to_three_per_play_date(client, session):
     assert [vote.votes for vote in votes] == [2, 1]
 
 
+def test_cube_owner_can_add_owned_cube_to_existing_ballot(client, session):
+    owner = _user(session, 'cube-owner@example.com', 'Cube Owner')
+    other = _user(session, 'other-owner@example.com', 'Other Owner')
+    league = League(name='Owner League', is_cube_league=True)
+    session.add(league)
+    session.flush()
+    owned_cube = LeagueCube(
+        league_id=league.id,
+        owner_id=owner.id,
+        cube_cobra_url='https://cubecobra.com/cube/overview/owned',
+        title='Owned Cube With A Long But Neatly Wrapped Name',
+    )
+    other_cube = LeagueCube(
+        league_id=league.id,
+        owner_id=other.id,
+        cube_cobra_url='https://cubecobra.com/cube/overview/other',
+        title='Other Cube',
+    )
+    play_date = LeaguePlayDate(league_id=league.id, play_date=date(2026, 10, 1), is_active=True)
+    session.add_all([owned_cube, other_cube, play_date])
+    session.commit()
+
+    # Ownership grants ballot access even when the owner is not a league player.
+    assert client.post('/login', data={'email': owner.email, 'password': 'secret'}).status_code == 302
+    response = client.post(
+        f'/leagues/{league.id}/cubes',
+        data={'action': 'add_owned_cube', 'cube_id': owned_cube.id, 'play_date_id': play_date.id},
+        follow_redirects=True,
+    )
+
+    assert response.status_code == 200
+    assert b'Your cube was added to the ballot.' in response.data
+    assert session.query(LeaguePlayDateCube).filter_by(play_date_id=play_date.id, cube_id=owned_cube.id).count() == 1
+
+    response = client.post(
+        f'/leagues/{league.id}/cubes',
+        data={'action': 'add_owned_cube', 'cube_id': other_cube.id, 'play_date_id': play_date.id},
+    )
+    assert response.status_code == 403
+
+
 def test_admin_can_remove_league_event_ballot_and_votes(client, session):
     admin = _user(session, 'league-event-admin@example.com', 'League Event Admin', 'admin', True)
     player = _user(session, 'league-event-voter@example.com', 'League Event Voter')


### PR DESCRIPTION
### Motivation
- Allow a user to be assigned as the owner of a League cube so ownership can be tracked and surfaced in the UI.
- Let cube owners add any of their owned cubes to an existing open League Event ballot even if they are not a league member.
- Keep UI tidy and avoid title/owner text overflow when long names are present.

### Description
- Add `owner_id` and an `owner` relationship to `LeagueCube` and include `owner_id` in import/export and payload handling (`app/models.py`, `app/app.py`).
- Add a safe schema migration path to add the `owner_id` column when creating or upgrading the database (`create_app` checks in `app/app.py`).
- Extend the admin `league_detail` UI to let admins pick an owner when adding a cube and to update a cube's owner inline (`app/templates/admin/league_detail.html`, `app/app.py`).
- Grant owners implicit league access by updating `require_league_member_or_manager` to treat owning a cube in the league as membership, and add an `add_owned_cube` POST action in `league_cube_voting` to let owners add their cube to an open play date ballot with server-side validation (`app/app.py`).
- Add an owner-only ballot UI block to `league_cubes.html` and responsive form/CSS rules to prevent overflow and keep formatting neat (`app/templates/league_cubes.html`, `app/static/style.css`).
- Add a unit test exercising the owner workflow `test_cube_owner_can_add_owned_cube_to_existing_ballot` and update league tests to cover owner behavior (`tests/test_leagues.py`).

### Testing
- Ran `python -m py_compile app/app.py app/models.py` and it succeeded with no syntax errors.
- Ran the league-focused tests with `pytest tests/test_leagues.py -q -rs`, which reported `1 passed, 13 skipped` because MySQL-backed tests were skipped due to the local test database being unavailable (skips are environmental and not caused by these changes).
- Ran the full test suite with `pytest -q`, which showed many unrelated failures in the walter-bot async tests due to the environment lacking an async pytest plugin (e.g. `pytest-asyncio`); these failures are unrelated to the league/cube ownership changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8249c942a48320bdf7cf3bde42e374)

## Summary by Sourcery

Introduce cube ownership tracking for league cubes and allow cube owners to add their cubes to existing League Event ballots while keeping related admin and voting UI tidy.

New Features:
- Track an optional owner for each league cube and persist owner information through backup export and import.
- Allow cube owners to add their owned cubes to any open League Event ballot, even if they are not league members.

Enhancements:
- Extend league admin UI to assign or update cube owners and add responsive styling for owner-related forms to handle long names without overflow.
- Treat owning a cube in a league as implicit membership for ballot access checks.
- Add a safe migration path for adding the cube owner column when initializing or upgrading the database.

Tests:
- Add tests covering the cube owner workflow, including owner-based ballot access and restrictions for non-owners.