### PR TITLE
docs: add complete site, API, and Discord bot PDF guides

### DIFF
--- a/documentation/API_REFERENCE.md
+++ b/documentation/API_REFERENCE.md
@@ -1,0 +1,188 @@
+# Walter HTTP API Reference
+
+**Separate API documentation**  
+Version 1.0 · Generated 16 August 2026
+
+## 1. Overview
+
+Walter exposes a JSON API under `/api/v1`. It is intended for trusted administrative integrations, including the bundled Discord bot. Unless stated otherwise, requests and responses use `application/json`, integer path identifiers are database IDs, and timestamps are ISO 8601 strings or `null`.
+
+## 2. Authentication and authorization
+
+Create an API key from **Settings → API keys** using an account with `admin.api_keys`. The token is displayed once and normally starts with `wlt_`. Send it using either:
+
+```http
+Authorization: Bearer wlt_your_token
+```
+
+or:
+
+```http
+X-API-Key: wlt_your_token
+```
+
+Every documented API endpoint requires `tournaments.manage` or `users.manage`, as specified below. Missing/invalid/revoked credentials return **401**; an authenticated user without permission receives **403**. Revoke keys at `/settings/api-keys/<id>/revoke`. Use HTTPS outside localhost and never place keys in URLs.
+
+## 3. Conventions
+
+Success bodies are JSON objects. List endpoints wrap records (`{"users": [...]}`). Create operations return **201**; most reads/updates return **200**. Delete returns `{"deleted": true}`. Errors return a JSON error with a relevant **400**, **401**, **403**, **404**, **405**, or **409** status. There is no documented pagination or rate-limit header; list clients should tolerate large arrays. Unknown JSON fields are generally ignored.
+
+Common schemas:
+
+- **User:** `id`, `name`, `email`, `role`, `is_admin`.
+- **Tournament:** `id`, `name`, `format`, `structure`, `start_time`, `league_id`, `venue_id`.
+- **League:** `id`, `name`, `start_date`, `end_date`, `is_cube_league`, `scoring_system`, `scoring_percentage`, `glicko_enabled`.
+- **Round:** `id`, `number`, `matches`.
+- **Match:** `id`, `table_number`, `players`, `is_bye`, `completed`. Each player includes `tournament_player_id`, `user_id`, `name`, `dropped`, and sometimes Glicko fields.
+
+## 4. Users — permission `users.manage`
+
+### `GET /api/v1/users`
+Lists all users alphabetically.
+
+**200 response:** `{"users": [User, ...]}`.
+
+### `POST /api/v1/users`
+Creates a user.
+
+**JSON fields:** `name` (string, required), `email` (string, optional), `password` (string, optional). Email is trimmed/lowercased.  
+**201 response:** `User`.  
+**400:** missing `name`.
+
+### `GET /api/v1/users/<user_id>`
+Returns one `User`. **404** if absent.
+
+### `PATCH /api/v1/users/<user_id>`
+Updates provided `name`, `email`, and/or non-empty `password`. Returns the updated `User`.
+
+### `DELETE /api/v1/users/<user_id>`
+Deletes the user and returns `{"deleted": true}`. Referential constraints may make deletion inappropriate for users with event history.
+
+## 5. Tournaments — permission `tournaments.manage`
+
+### `GET /api/v1/tournaments`
+Lists tournaments newest first. **200:** `{"tournaments": [Tournament, ...]}`.
+
+### `POST /api/v1/tournaments`
+Creates a tournament. Fields: `name` (required), `format` (default `Commander`), and `structure` (default `swiss`). **201:** `Tournament`.
+
+```bash
+curl -sS https://walter.example/api/v1/tournaments \
+  -H 'Authorization: Bearer wlt_REDACTED' \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"Friday Draft","format":"Draft","structure":"swiss"}'
+```
+
+### `GET /api/v1/tournaments/<tournament_id>`
+Returns `Tournament`; **404** if absent.
+
+### `PATCH /api/v1/tournaments/<tournament_id>`
+Updates any non-empty `name`, `format`, and/or `structure`; returns `Tournament`.
+
+### `DELETE /api/v1/tournaments/<tournament_id>`
+Deletes the tournament and returns `{"deleted": true}`.
+
+### `GET /api/v1/tournaments/<tournament_id>/standings`
+Returns `tournament` and `standings`. Each standings row contains `rank`, `tournament_player_id`, `user_id`, `name`, `points`, `omw`, `gw`, `ogw`, and `dropped`.
+
+### `GET /api/v1/tournaments/<tournament_id>/rounds`
+Returns `tournament` and every `Round`, ordered by round number.
+
+### `GET /api/v1/tournaments/<tournament_id>/rounds/latest`
+Returns `tournament` and the newest `round`. **404** if the tournament or any round is absent. League-enabled responses may add `glicko_rating` and `glicko_deviation` to players.
+
+## 6. Leagues — permission `tournaments.manage`
+
+### `GET /api/v1/leagues`
+Lists leagues alphabetically: `{"leagues": [League, ...]}`.
+
+### `POST /api/v1/leagues`
+Fields: `name` (required) and `is_cube_league` (boolean, default false). **201:** `League`.
+
+### `GET /api/v1/leagues/<league_id>`
+Returns one `League`; **404** if absent.
+
+### `PATCH /api/v1/leagues/<league_id>`
+Updates a non-empty `name` and/or boolean `is_cube_league`; returns `League`.
+
+### `DELETE /api/v1/leagues/<league_id>`
+Deletes the league and returns `{"deleted": true}`.
+
+### `GET /api/v1/leagues/<league_id>/standings`
+Returns `league` and ranked `standings`. Rows include `rank`, `user_id`, `name`, `played`, `counted_count`, `league_points`, `raw_points`, `wins`, `draws`, `losses`, `colley_rating`, `glicko_rating`, and `glicko_deviation`. Some rating values may be null depending on configuration.
+
+## 7. Cube leagues and Discord poll transport
+
+All endpoints in this section require `tournaments.manage`.
+
+### `GET /api/v1/leagues/<league_id>/play-dates`
+Cube leagues only. Returns `league` and `play_dates`, each containing `id`, ISO `play_date`, `is_active`, and `available_cube_count`. **404** when the league is absent or not a cube league.
+
+### `GET /api/v1/leagues/<league_id>/cube-votes/<play_date_id>`
+Returns the current ballot: `league`, `play_date`, and `cubes`. Each cube has `id`, `title`, `cube_cobra_url`, `image_url`, and aggregate `votes`. **404** for a mismatched league/date.
+
+### `POST /api/v1/discord/cube-polls`
+Registers or updates the Discord message mirroring a cube ballot.
+
+Required fields: `league_id`, `play_date_id`, `channel_id`, `message_id`. Discord IDs should be sent as strings.  
+**200:** `registered: true`, a `poll` object, and `cube_vote` ballot.
+
+### `GET /api/v1/discord/cube-polls/<message_id>`
+Fetches registered poll metadata and the fresh ballot totals. **404** when unregistered.
+
+### `POST /api/v1/discord/cube-vote`
+Mirrors a Discord reaction into a Walter vote.
+
+Required fields: `discord_user_id`, `league_id`, `play_date_id`, `cube_id`; `selected` is boolean. The Discord identity must already be connected. The cube must appear on the ballot. A user may select at most three cubes for a play date.  
+**200:** refreshed ballot.  
+**403:** Discord account not connected.  
+**404:** ballot/cube mismatch.  
+**409:** selection would exceed three total votes.
+
+## 8. Discord identity and result reporting
+
+### `POST /api/v1/discord/authorize` (alias: `POST /connect`)
+Permission: `tournaments.manage`. Connects a Discord account to a Walter account using the one-time pass from Settings.
+
+Required: `discord_user_id`, `discord_username`, `one_time_pass`. Optional: `discord_display_name`, `discord_global_name`. JSON and form values are accepted. Leading `@` is normalized. The configured Walter Discord username must match case-insensitively.
+
+**200:** `{"authorized": true, "user": User}`.  
+**400:** required field missing.  
+**403:** invalid/expired pass, missing Walter username, or mismatch.  
+**409:** Discord account belongs to another Walter user.  
+The pass is consumed after success.
+
+### `POST /api/v1/discord/report-pairing`
+Permission: `tournaments.manage`. Reports the connected user's pairing in the latest round.
+
+Required: `discord_user_id`, `tournament_id`, `table_number`. Result fields: `player1_wins` (default 0), `player2_wins` (default 0), `draws` (default 0); all must be non-negative integers.
+
+**200:** `reported: true`, updated `match`, and `round`.  
+**400:** invalid score or Commander event (not supported here).  
+**403:** identity unconnected or caller not in the pairing.  
+**404:** tournament/latest round/table absent.  
+**409:** a later round already exists.
+
+## 9. Worked examples
+
+List standings:
+
+```bash
+curl -sS https://walter.example/api/v1/tournaments/42/standings \
+  -H 'X-API-Key: wlt_REDACTED'
+```
+
+Update a league:
+
+```bash
+curl -sS -X PATCH https://walter.example/api/v1/leagues/7 \
+  -H 'Authorization: Bearer wlt_REDACTED' \
+  -H 'Content-Type: application/json' \
+  -d '{"name":"2026 Cube League","is_cube_league":true}'
+```
+
+A robust client should set connect/read timeouts, inspect HTTP status before decoding expected fields, avoid automatic retries for non-idempotent POSTs, and log request IDs locally without logging credentials.
+
+## 10. Audit and security notes
+
+Walter stores API request metadata and response bodies in the API audit log; authorization headers are redacted. Treat request bodies as auditable operational data. Use a distinct key per integration, a least-privileged owning account, TLS, secret storage, and prompt revocation on suspected exposure. API keys do not replace end-user Discord connection: bot write actions validate the connected Discord identity separately.

--- a/documentation/DISCORD_BOT_COMMANDS.md
+++ b/documentation/DISCORD_BOT_COMMANDS.md
@@ -1,0 +1,126 @@
+# Walter Discord Bot Command Guide
+
+**Separate slash-command documentation**  
+Version 1.0 · Generated 16 August 2026
+
+## 1. Purpose and prerequisites
+
+The bundled Walter bot provides nine Discord slash commands for tournament discovery, standings, pairings, league/cube workflows, account connection, and result reporting. The bot must be online, its commands synchronized, and its API key configured with Walter's `tournaments.manage` permission.
+
+Commands may take time to appear after a global sync. Command output marked **ephemeral** is visible only to the invoking Discord user. Do not paste Walter one-time passes or API keys into public chat.
+
+## 2. Discovery commands
+
+### `/tournaments`
+Lists up to 25 Walter tournaments as `ID: name (format)`. The response is ephemeral. Use the numeric ID with `/standings`, `/pairings`, or `/report_pairing`.
+
+**Parameters:** none.  
+**Typical use:** `/tournaments`
+
+### `/leagues`
+Lists up to 25 leagues, identifying standard versus cube leagues. The response is ephemeral. Use the numeric ID with league commands.
+
+**Parameters:** none.  
+**Typical use:** `/leagues`
+
+### `/league_play_dates league_id:<number>`
+Lists a cube league's Walter play-date IDs for use with `/cube_poll`. The response is ephemeral.
+
+- `league_id` — required numeric cube league ID.
+
+**Typical use:** `/league_play_dates league_id:7`
+
+## 3. Standings and pairings
+
+### `/standings tournament_id:<number>`
+Posts tournament standings, including rank, player, points, and supported tiebreak information. The successful response is visible in the channel; API errors are ephemeral.
+
+- `tournament_id` — required numeric Walter tournament ID.
+
+**Typical use:** `/standings tournament_id:42`
+
+### `/league_standings league_id:<number>`
+Posts ranked league standings. Displayed fields reflect the league's configured scoring/rating system.
+
+- `league_id` — required numeric Walter league ID.
+
+**Typical use:** `/league_standings league_id:7`
+
+### `/pairings tournament_id:<number>`
+Posts table assignments for the latest paired round. Each pairing identifies table and players; byes are indicated by Walter's response formatting.
+
+- `tournament_id` — required numeric Walter tournament ID.
+
+**Typical use:** `/pairings tournament_id:42`
+
+If no round exists, the bot returns the API error ephemerally.
+
+## 4. Connect a Walter account
+
+### `/connect one_time_pass:<text>`
+Links the invoking Discord account to a Walter user. The entire interaction is ephemeral.
+
+1. In Walter, open **Settings**.
+2. Save your Discord username (without concern for a leading `@`; Walter normalizes it).
+3. Generate a new Discord connection pass.
+4. In Discord, run `/connect` and enter that pass.
+5. Confirm the connected Walter name in the private bot response.
+
+The username must match the invoking Discord username case-insensitively. The pass is single-use and consumed on success. Generating a new pass disconnects the previous Discord user ID until reconnection. A Discord identity cannot be attached to two Walter users.
+
+## 5. Report a pairing result
+
+### `/report_pairing tournament_id:<number> table_number:<number> player1_wins:<number> player2_wins:<number> [draws:<number>]`
+Reports a two-player result for the latest round. The command response is ephemeral.
+
+- `tournament_id` — required tournament ID.
+- `table_number` — required table number from `/pairings`.
+- `player1_wins` — required wins for the **first-listed** player.
+- `player2_wins` — required wins for the **second-listed** player.
+- `draws` — optional drawn games; defaults to 0.
+
+**Example:** `/report_pairing tournament_id:42 table_number:3 player1_wins:2 player2_wins:1 draws:0`
+
+Before submitting, verify which player is listed first. Scores must be whole non-negative numbers. The caller must have connected Discord and be a player at that table. Commander reporting is not supported by this command. Walter rejects changes after the next round has been paired; contact event staff for corrections.
+
+## 6. Cube poll command
+
+### `/cube_poll league_id:<number> play_date_id:<number>`
+Posts a Discord mirror of a Walter cube vote in the current channel, adds one reaction emoji per available cube, and attempts to pin the message. The command's confirmation is ephemeral; the poll itself is public.
+
+- `league_id` — required cube league ID.
+- `play_date_id` — required Walter league play-date ID (discover it with `/league_play_dates`).
+
+**Typical use:** `/cube_poll league_id:7 play_date_id:19`
+
+React to select a cube; remove the reaction to deselect it. The bot mirrors changes to Walter and refreshes totals. Only connected Discord accounts can vote, the cube must still be on that date's ballot, and Walter permits no more than three selected cubes per user/date. The bot recognizes at most the first set of cubes for which it has configured reaction emojis. It requires permission to send messages, add reactions, read reaction events/history, and pin/manage messages if pinning is desired. Failure to pin does not discard a successfully posted poll.
+
+## 7. Automatic pairing announcements
+
+When `bot_channel_id` and `bot_poll_tournament_id` are configured, the bot periodically checks for a newly paired round and posts pairings to the target channel. `bot_poll_interval_seconds` controls the interval. This feature is automatic and is not a slash command.
+
+## 8. Visibility summary
+
+- Ephemeral on success: `/tournaments`, `/leagues`, `/league_play_dates`, `/connect`, `/report_pairing`, and `/cube_poll` confirmation.
+- Channel-visible on success: `/standings`, `/league_standings`, `/pairings`, plus the poll created by `/cube_poll`.
+- Errors are generally returned ephemerally to avoid clutter and accidental disclosure.
+
+## 9. Troubleshooting
+
+**Command is missing:** Wait for global synchronization, restart with correct token/application configuration, or enable guild syncing temporarily for immediate development updates. Avoid keeping both stale guild copies and global commands, which can appear duplicated.
+
+**401 / invalid API key:** The bot key is missing, malformed, or revoked. Create a new administrator API key and update `bot_api_key` securely.
+
+**403:** The key owner lacks `tournaments.manage`, the Discord account is not connected, or the caller is not allowed to perform the requested write.
+
+**404:** Recheck tournament, league, play-date, table, or poll IDs; the latest round may not exist yet.
+
+**409:** The operation conflicts with current state, commonly a duplicate Discord connection, cube vote limit, or result report after the next round was paired.
+
+**Poll reactions do nothing:** Connect with `/connect`; verify reaction event intents/permissions, that the reaction is one created by the bot, and that the cube remains on the ballot.
+
+**Ready announcement absent:** It is disabled by default. Configure `bot_channel_id` and set `bot_announce_ready: true` only if wanted.
+
+## 10. Operator configuration checklist
+
+Set `bot_runtime_script: "discord_bot.py"`, `bot_token`, `bot_api_base_url`, and `bot_api_key`. Optional values include `bot_channel_id`, `bot_poll_tournament_id`, `bot_poll_interval_seconds`, `bot_announce_ready`, `bot_sync_guild_commands`, and `bot_clear_guild_commands`. Keep the bot token and API key outside source control, grant only required Discord permissions, and use HTTPS when the API is remote.

--- a/documentation/README.md
+++ b/documentation/README.md
@@ -1,0 +1,9 @@
+# Walter documentation
+
+The documentation set is published as three focused PDFs:
+
+- [`Walter_Site_Guide.pdf`](Walter_Site_Guide.pdf) — the complete site, organized by audience and workflow, with every visible page and supporting action route.
+- [`Walter_API_Reference.pdf`](Walter_API_Reference.pdf) — authentication, schemas, status conventions, and all `/api/v1` endpoints.
+- [`Walter_Discord_Bot_Commands.pdf`](Walter_Discord_Bot_Commands.pdf) — every Walter slash command, its parameters, visibility, prerequisites, examples, and troubleshooting.
+
+The corresponding Markdown files are retained beside the PDFs as searchable, reviewable source material.

--- a/documentation/SITE_GUIDE.md
+++ b/documentation/SITE_GUIDE.md
@@ -1,0 +1,283 @@
+# Walter Site Guide
+
+**Complete page-by-page documentation**  
+Version 1.0 · Generated 16 August 2026
+
+## About this guide
+
+Walter is a web application for running Magic: The Gathering tournaments and leagues. This guide documents the visible site by audience and workflow. Paths containing `<id>` use the numeric identifier shown by Walter. Features are permission-controlled: a page may be hidden or return **403 Forbidden** unless the signed-in account has the corresponding permission.
+
+## 1. Public and account pages
+
+### Landing page — `/`
+The public entry point. Signed-in users are directed into Walter; visitors can proceed to sign in or registration. It also establishes the site theme and primary navigation.
+
+### Home dashboard — `/home`
+The signed-in overview. It presents relevant active tournaments and shortcuts based on the user's role. Use this as the normal starting point after login.
+
+### Register — `/register`
+Creates a player account. Enter the requested identity, email, and password fields. Public registration may require a valid tournament invitation when invite-only mode is enabled. Submission sends a six-digit email verification PIN rather than immediately activating the account.
+
+### Verify registration — `/register/verify` and `/register/verify/<token>`
+Completes pending registration with the emailed PIN. The token form supports verification links. PINs expire according to the server configuration; restart registration if the token is invalid or expired.
+
+### Sign in and out — `/login`, `/logout`
+Sign in with the registered email and password. Failed attempts are security logged and may contribute to IP blocking. Sign out when using a shared device.
+
+### Password reset — `/password-reset`, `/password-reset/<token>`
+Request a reset email, then open its token page to set a replacement password. Tokens are time limited and single-purpose.
+
+## 2. Player dashboard and preferences
+
+### User settings — `/settings`
+Manage appearance (light or dark mode), Discord identity, Discord connection passes, and—when permitted—API keys. A generated Discord pass is shown once and is used with the bot's `/connect` command. API keys are also shown once; store them securely.
+
+### Revoke API key — `/settings/api-keys/<id>/revoke`
+A settings action that permanently revokes one of the current user's keys. Existing integrations using it will begin receiving HTTP 401 responses.
+
+### My tournaments — `/my-tournaments`
+Lists tournaments associated with the current player, including quick links to event details, rounds, standings, and deck submission.
+
+### My leagues — `/my-leagues`
+Lists the leagues in which the current user participates and links to league standings and cube voting where applicable.
+
+## 3. Tournament player pages
+
+### Tournament overview — `/t/<id>`
+The event hub. It shows format, structure, state, players, current round, join status, and organizer controls when authorized. Players can request to join; staff can add or replace players, manage rounds, and complete the event.
+
+### Join link and QR code — `/t/<id>/join-link`, `/t/<id>/join-qr.png`
+The shareable registration page displays an event pass/link and a scannable PNG QR code. Organizers can distribute either to players. The QR endpoint is an image resource rather than an HTML page.
+
+### Join action — `/t/<id>/join`
+Submits the current account's join request or passcode. Depending on tournament settings, entry may be immediate or remain pending for staff approval.
+
+### Round page — `/t/<id>/round/<round-id>`
+Displays pairings by table, match completion state, and round context. Players select their match to report a result. Staff can access repair/delete controls when authorized.
+
+### Match report — `/match/<match-id>`
+Reports or edits the selected table result. Two-player events record wins and draws; Commander/multiplayer events record placements and draw state. Walter prevents invalid or late changes based on tournament state and permissions.
+
+### Standings — `/t/<id>/standings`
+Ranks players using match points and tiebreakers (including opponent match-win, game-win, and opponent game-win percentages where applicable). Dropped players remain identifiable. Treat standings as provisional until all results are entered.
+
+### Elimination bracket — `/t/<id>/bracket`
+Shows the Top 8 or Top 4 playoff bracket once the event is cut. Pairing and winner progression are displayed according to the event state.
+
+### Draft seating — `/t/<id>/draft-seating`
+Shows randomized or assigned pod/seating information for Draft events. Use the displayed seat order before opening product.
+
+### Tournament logs — `/t/<id>/logs`
+An authorized audit trail of pairing, scoring, timer, player, and tournament-management actions.
+
+## 4. Decklists
+
+### Decklist gallery — `/t/<id>/decklists`
+Shows submitted decks according to visibility and event permissions. Staff can review player submissions; players see what the tournament policy allows.
+
+### Player deck — `/t/<id>/players/<player-id>/deck`
+Displays a single registered player's parsed deck, source information, and any uploaded deck image.
+
+### Deck search — `/t/<id>/deck/search`
+JSON-backed card lookup used by manual deck entry. Search by card name and choose the intended printing/result.
+
+### Manual submission — `/t/<id>/deck/manual`
+Accepts a manually assembled main deck and sideboard. Review counts and unresolved cards before submitting.
+
+### MTGO import — `/t/<id>/deck/mtgo`
+Imports a Magic Online text decklist. Walter parses quantities, card names, and sideboard lines; correct any unrecognized entries.
+
+### Deck image upload/delete — `/t/<id>/deck/image`, `/t/<id>/deck/image/delete`
+Uploads a deck photo under server size/type constraints, or removes the current image. Avoid including personal information in photographs.
+
+## 5. Leagues and cube leagues
+
+### League view — `/leagues/<id>`
+Shows league metadata, membership, linked tournaments, results, and ranked standings. Scoring may use total/percentage results or Colley ratings; optional Glicko ratings show rating and deviation.
+
+### League settings — `/leagues/<id>/settings`
+Authorized league configuration for name, dates, scoring system, percentage counted, Glicko, and league-specific options.
+
+### Cubes and voting — `/leagues/<id>/cubes`
+For cube leagues, manages Cube Cobra entries, play dates, ballot availability, and player votes. A player may allocate no more than three total cube selections per play date. Image previews may be proxied by `/cube-cobra-image`.
+
+## 6. Communication and support
+
+### Message center — `/messages`
+Role-aware entry point that directs users to the appropriate mailbox.
+
+### Player inbox — `/messages/player` or `/messages/inbox`
+Lists received messages with read/unread state. Open a message to mark and view it.
+
+### Sent messages — `/messages/sent`
+Lists messages sent by the current user.
+
+### Compose — `/messages/player/send` or `/messages/send`
+Sends a direct message to an allowed recipient. Recipient search is assisted by `/api/users/search` and the unread navigation badge by `/api/messages/unread`.
+
+### Message detail and reply — `/messages/view/<id>`, `/messages/<id>/reply`
+Shows a conversation item and supports a reply when the current user is a participant.
+
+### Judge messaging — `/messages/judge`
+Judge-facing inbox and compose workflow for tournament assistance.
+
+### Admin messaging — `/messages/admin`
+Administrator broadcast/direct-message workflow with broader recipient selection.
+
+### Reports — `/reports`
+Submit and review the current user's site or event issues. Include actionable detail without credentials or private API keys.
+
+### Lost and found — `/lost-and-found`
+Browse or submit lost-and-found items across available venues. Venue staff also reach a scoped view at `/admin/venues/<venue-id>/lost-and-found`.
+
+## 7. Tournament administration
+
+### Admin panel — `/admin/panel`
+Central operations dashboard and administrative navigation. Access depends on granular permissions, not merely whether a link is visible.
+
+### New tournament — `/admin/tournaments/new`
+Creates Commander, Draft, or supported 60-card constructed events. Configure name, format, Swiss/elimination structure, dates, round settings, league, venue, registration, and timers as applicable.
+
+### Edit tournament — `/admin/tournaments/<id>/edit`
+Updates tournament configuration. Be cautious changing structure or format after pairings/results exist.
+
+### Ended tournaments — `/admin/tournaments/ended`
+Archive of completed events with routes to inspect, reopen, or delete when authorized.
+
+### Bulk tournament actions — `/admin/tournaments/bulk`
+Applies supported operations to multiple selected events. Confirm the selection before submitting.
+
+### Complete, reopen, delete — `/admin/tournaments/<id>/complete`, `/reopen`, `/delete`
+Lifecycle actions. Complete freezes the ordinary event workflow; reopen restores an ended event; delete is destructive and should follow backup policy.
+
+### Player and join-request actions
+`/t/<id>/join-requests/<request-id>/approve` and `/reject` resolve pending entries. `/t/<id>/players/add` registers a player directly and `/t/<id>/players/<player-id>/replace` swaps an entry while preserving event continuity where supported.
+
+### Round controls
+`/t/<id>/set-rounds` sets the planned count; `/pair-next-round` creates pairings; `/round/<round-id>/repair` rebuilds/fixes a round; `/round/<round-id>/delete` rolls it back. Verify results and backups before destructive round actions.
+
+### Timer controls
+`/t/<id>/start-timer/<timer>`, `/pause-timer/<timer>`, `/stop-timer/<timer>`, and `/restart-timer/<timer>` control named tournament timers. The timer bar appears on event pages and is shared across clients.
+
+## 8. League administration
+
+### League list/create — `/admin/leagues`
+Lists all leagues and creates new standard or cube leagues.
+
+### League detail — `/admin/leagues/<id>`
+Manages members, linked tournaments, manual results, scoring, play dates, and cube-league administration.
+
+### Delete league — `/admin/leagues/<id>/delete`
+Permanently removes the league subject to database constraints. Export or back up first.
+
+## 9. Venue, vendor, artist, and schedule administration
+
+### Venues — `/admin/venues`
+Lists and creates event locations.
+
+### Venue detail/update — `/admin/venues/<id>`, `/admin/venues/<id>/update`
+Views location details, tournament calendar, lost-and-found items, and editable venue fields.
+
+### Bulk add venue tournaments — `/admin/venues/<id>/tournaments/bulk-add`
+Creates multiple scheduled events for a venue from one form.
+
+### Vendors — `/admin/venues/vendors`
+Creates/lists vendors; `/admin/venues/vendors/<id>/update` edits an existing vendor.
+
+### Artists — `/admin/venues/artists`
+Creates/lists event artists; `/admin/venues/artists/<id>/update` edits an existing artist.
+
+### Schedule — `/admin/schedule`
+Combined operational calendar for venues and tournaments. `/admin/schedule/export.csv` downloads it as CSV.
+
+### Lost-item update — `/admin/venues/<venue-id>/lost-and-found/<item-id>/update`
+Changes item status/details, such as marking an item claimed.
+
+## 10. People and access administration
+
+### Users — `/admin/users`
+Searchable user roster with bulk-selection tools.
+
+### User detail — `/admin/users/<id>`
+Shows account, roles/permissions, tournament associations, and administrative actions.
+
+### User actions
+`/admin/users/<id>/add` adds a user to an event; `/remove/<tournament-id>` removes that association; `/update` edits the account; `/delete` removes it. `/admin/users/bulk-delete` deletes a validated selection.
+
+### Register player — `/admin/register-player`
+Creates a single player account administratively.
+
+### Bulk register — `/admin/bulk-register`
+Imports multiple player records. Validate duplicates and malformed rows before confirming.
+
+### Staff — `/admin/staff`
+Lists and manages staff assignments.
+
+### Tournament judges — `/admin/tournaments/<id>/judges`
+Assigns judges to a specific event.
+
+### Judge break — `/admin/judges/<user-id>/break`
+Toggles/records a judge break state for staffing visibility.
+
+### Permissions — `/admin/permissions`
+Edits role permission assignments using the permission schema. Changes take effect across navigation and server-side authorization; preserve at least one viable administrator path.
+
+### Registration invites — `/admin/registration-invites`
+Creates and lists invite/passcodes for controlled account creation or event onboarding. `/admin/registration-invites/<id>/revoke` invalidates one.
+
+## 11. Operations, safety, and auditing
+
+### Site settings — `/admin/site-settings`
+Edits runtime-backed site options exposed by the application. Validate operational and email settings before relying on them in production.
+
+### Backups — `/admin/backup`
+Creates, lists, restores, or manages backups according to the selected form action. `/admin/backup/export` exports a backup artifact. Restores are high impact: schedule downtime and retain the pre-restore copy.
+
+### Site logs — `/admin/logs`
+Audit history for application actions and outcomes.
+
+### API logs — `/admin/api-logs`
+Request/response audit records for API traffic. Authorization values are redacted, but bodies may contain operational data; limit access appropriately.
+
+### Submitted reports — `/admin/reports`
+Administrative report queue. `/admin/reports/<id>/update` changes status/assignment, and `/admin/reports/export.csv` exports records.
+
+### Bad logins — `/admin/security/bad-logins`
+Shows failed authentication activity for security review.
+
+### IP blacklist — `/admin/security/ip-blacklist`
+Lists blocked addresses. `/toggle` enables/disables an entry and `/export` downloads the list. Verify shared/NAT addresses before blocking.
+
+### Current connections — `/admin/current-connections`
+Shows recently tracked clients/connections. `/admin/current-connections/blacklist` adds a selected address to the blacklist.
+
+## 12. Media and utility resources
+
+### Media — `/media/<filename>`
+Serves authorized uploaded media through a safe path. Direct availability depends on the referenced file and access rules.
+
+### Cube image proxy — `/cube-cobra-image`
+Fetches an allowed Cube Cobra/Scryfall preview with host and size safeguards; used by cube pages rather than normal navigation.
+
+## 13. Recommended workflows
+
+### Run a Swiss tournament
+1. Create the event under **Admin → New tournament**.
+2. Share its join link/QR or add players directly.
+3. Resolve pending join requests and confirm the roster.
+4. Set rounds and pair the next round.
+5. Players report matches; staff monitor incomplete tables.
+6. Review standings, then pair again only after results are correct.
+7. Optionally cut to an elimination bracket.
+8. Complete the event and verify logs/results.
+
+### Run a cube league vote
+1. Create a cube league and add Cube Cobra entries.
+2. Add play dates and select available cubes for each date.
+3. Members vote on the league cubes page (up to three selections).
+4. Optionally use `/league_play_dates` and `/cube_poll` in Discord.
+5. Review totals, select the cube, and retain the vote history.
+
+## 14. Access and troubleshooting
+
+A **401** usually means the session or API credential is absent/invalid. A **403** means the identity lacks permission. A **404** may mean the object does not exist or is deliberately hidden. A **409** generally indicates a state conflict (for example, a vote limit or attempting to alter a result after another round exists). Never share passwords, one-time Discord passes, reset links, API keys, bot tokens, or backup encryption material.

--- a/documentation/Walter_API_Reference.pdf
+++ b/documentation/Walter_API_Reference.pdf
@@ -1,0 +1,181 @@
+%PDF-1.4
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 6 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 612 792 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+7 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 612 792 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 612 792 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 612 792 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 612 792 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 612 792 ] /Parent 14 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/PageMode /UseNone /Pages 14 0 R /Type /Catalog
+>>
+endobj
+13 0 obj
+<<
+/Author (Walter Project) /CreationDate (D:20260816234813+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260816234813+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Walter documentation) /Title (Walter HTTP API Reference) /Trapped /False
+>>
+endobj
+14 0 obj
+<<
+/Count 6 /Kids [ 4 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R ] /Type /Pages
+>>
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 431
+>>
+stream
+Gatn!btc/1&;9LtME(_NY(*a;I4TsO&eY?l3(Lfa=u@b)l&CI2PGTY&Wl+p@b0&D.n[E9a87&=njs=u3@PgqY)JK3eM\t[\DUR`)&rrc3&2'++3-sH'(sfZg"d3,(]W`eM<cRIa9>![+@3VXmoY$eL2GU'%Lo'WFF54@XZW<`FW6SG-n4Zd?ln)F"TuQaThisgLZ=^hNcB0`@?F6:kTh0nnRKhbc2@E?6ngEj>?Z5`_CLZ7I#fdhRI[f:F82$6@E+KYV"JH9=+9)D/T_?a[7)R*SDaSC%'FS@Zs*<LGF-ib&N2QDp%Rm<`Q%pC?jflB"4pIcm&,)oXm_S[U9m=RZ"]L6oMYmtOYpec14Bpg??7eM#TKZgH<1KU;rmX3@qB'TJ_E#6gILYt=hZT1*pu3R=S(VE05YGsDa:C*j3MLHc[]D4~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2319
+>>
+stream
+Gb!Sms%hB='`X`=ii1A%F99M?S^;(K>:=!VK0m.D)H1a_O)W)3\T`4!<pbCo]<buK3)2fB[Ak_,,dH7?0;%ua?Yk:Ms"++uQiOc;62uoJQ49T>Y[#)"d0UeQG!>=2"4%qs^_d3O2o+_j5FF-o+75l^R<YJ_1jhj0o.@W?%l%>U<!!0>;\FkN35b:B_">H^9kS.oGV,bLWHu@[PgX#XcPWB7$1rZoED?ZWn?>GsRZj93oJqjo_!$+kF88*L0F!R)/NnJNVA/BngY\]!p&.&q'\L-.UD*-D;h':()&!u7:nmf)C`"(NG*&Kcl!;Yp#a/,2H$0VD$ME75S7i*GSnL8HnM_pCM?h<YiR7E%32.j%.R[\?n?SDs1'cR@rH8AB^g&9qQp]=@@RMapYWWL*g[XX(qa`#Wi<!enoW_&;/-AX[<6Q2m?#ub-/5Ei*efL-SQM)mJ]PpObIen9.-'^aRkDRer[EFIb_B8EdrAW$]8]1,D@,Rb*G2RZ^(f#USZa?eta]O%)<KAsVB#&Br9EIk.MUE`ZiW=.ODT0@^Pd$Co*$*=:<8TJH3o4ln5D=(hZ#g?K22)A%(=QsUPhlG)+Vt_aG](=o1o=0&b]Vi'hCic7Uq7c5a+DGRND(Sp+>]7@-5Vh_AL5I(R"\_KrWcT"Z-h@_dKoJS7e1>&&H\>*0gllj6#5j4P*62</WL@g;PdXD&lb)@RD'8n02>s6Rhj^'cik'WG&^*33,T$p41;eQh[Q#k"&fK#JNbKqVbJK4'c65/%2.Felpd4DIYmVYdm1M9*2KId2TWWK<7)%E29^"&*3KE?(*9Sl#RMp*[C`JHg]qq@Bm]isLT6s^P3#'?pCM3L`HX?K6XHQKgbQgf<WH*U@UQ?uRnd)2[LqXoc>RBrOtL3!Mof5c6lIQHlhiK&_g3aJ$&R]QarGt8ZF+#JEB\9hjoTTF=C-9'16n:)CI7Ggi;;q9cmtr#N_+YRFeOrP/Yp#_\N<n6bE/)P,VPL8[L]PiAsNFno:-V+XPMB,a?7Xm@Th[UXE968Y,qP2&!=?q$_?a)@@FePYr4!PLKL22F`g/i.H"^+1QKt_)4)MqD?ZdTF\[c+-]NeTfO:ice[A/->VFZ$72!W:OjR!f2-(G1o@o][HZ,<O!:I187Ud/+"eD?>,7"J'"A`K`L?E6g@nLac8(Fm=6Bf5+1SQ:oVTqD4jH*6$W$@EY"Uup37bK'>GpM$mF01lX+s?]uJk`;VXS>SVofXUrY9igi-nh[_O5>rZV=Htm!PHGkpX<etFoc9C`,Z,<%nV/nZ)pp3+Jgko.q92m3jTOWT:a1^(!=55bg3=dNWH>/3`C%6etDt<a7C3j`jOF\bXE+uW^E3DLs`NFl_]S950sj,%k$!5eObE^/4cX)Nua76bMG.%s7Au0rn0L5Bc+iss/qC-j`<8m/;u]d<St1sa*&,VlO6?a5Z(Q-qaH7q%;cbh2W4:Z`Y9.:+52`<5!=hr_\(U]SL&,-fmlF5\>Y[nH=*\d/?9l/T40i+87`5JpK7%CKaUj1inLUTW62]3!-U:okJl93c#3+kDS)[hjZA6Y3u6@<(K,Gj#Z^4:;SLBM)4@e;D!4]k)OL/,Q=-8u7KcQX!b)>r0P63i5pE5Gf\uC':KA#?0s+[=Z4S6HOL\>Mr(Y=PdkWDo`,Sa'b>_8KW`*>)Cg(MZL*%CJdh24\jaPI<"O3+g2,/m3;oKb-BOCs]=h6*2=*b<pZCH5A&89Jca))eVX%2n8SFc9uW+HeA0q+50X$5QMn@$H0MU>MT`2t?rXP[=*6J&Q0nRXdj!cchW/1/EK(#NE+WWUl^*IBd@P0b)s*S34VTX(?\8fH"57>UW21\LCM2-(rO<t]"8V?Iua(Cb2;f#ZS_l+Z&2oYh7='WBXTs!Ci4dD#E'EF&]<oimtaD]3aJ%iI/S-?NJoZno>!1WDFd/E\dd8_6kF)%P3V\TM;-K`2DkRDpejiFA=>a^Un<PT?=^IaQa,S/5o3oqYQL9W7/I)HI@7rn=esRkgVd1beoibkG.@o$p,W=,7rB)_8VY'J6TDR]Rq.c<)RW8YuaAeq''=f2.o5^%-F=nn_QgC$u+pb$/V]cs_FOAJL.,ca#G^Q`jL::T/`e!_8]3Wr[8Nd98h7UL*>OloOm`XjZKG'FriC)^Zh8U']!n^=q(/`\u#aeS9GTD^8BkHoMddM[d#SPcpLW5S(h(LEibSo_#U!CX.+)-ViQ6%>GOG*:&$OqCB0)'<7@o3;ft<Ph!FqG4)Qs)L0[gc2-hcB@>niqFsD*(Y1.rf%;fu]8P\%l,?\3oUl!RUKf:K2p:KNLDIbPIqTo5$N~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1637
+>>
+stream
+Gb!#]gMYb8&:N/3$j78F$@B`R7AVEj=E9#1BO"b-+6k%PM^sVjDqSE!<J13rLSQQ09p$VeUkW7j>*3H1cCCG`Uk41O2>o`K!8^DBJ#S%"_.3bM5n',c_0FE(dNJ]kE<\Z4[UKa9lJObCJ=F$=&537Ge/`!a!2cUP21=N&D.`ra'/Mpr2K2'n$sTue(lI`p)I>4!5#34r2b'XJRRnL+-@jsFe<c-3.%2aj(.p'i.!u2^:GDT)_9>-BgLQsmB("Vn3bP,KDZ9feg>-]+7^cn@%8"A.*0^LcYnI7?:MfK,C>]XdnO6#VHk*jIDVtI(1QV@7(oBA?*cLK3_.H-nXq9,]m"#1*dqlp$J`o"TTr(@(%G4U4rB>2P'9[_$r"M-fZLg+tmp;R9g40@Vo8hTKMA(H<?[%9m$F,Ju>B:GZj2<eD"Q3oY^tcXGXVd[._-HOZDU0Q*fF9('.;1OOE>/cRSY>p'(dIA.Ka61:d*Mk^;$m^B4<]gE(:@6*J>F6)^e>cQ1C&#D--HF&QFn5Jd\*ksIo-#8UfI'9c$R39QXo?UQO0bfCP?&KH47%^%c8tNjIq)PA8UU>MmWp=7aQB$5]6l!?=9)"iZ7i2NVDc1ai1m#Qo?%\+nHdbQV&SIk0\hE1:K[e\!ejDJVJ&,iXeT<)%0oaDE1Q,fSWKX(bAThlETkb8]e=L'uU=1)NCr?PAtBtdYl)@>*\@k0qTcW8h%_2P9=<DaEXl*mFSM16FknqQE2D0<Z]="j*7(WlGF=:NTARsV1=*!naA8d'FS\"GTi&Dq(_Utg+Ym>V-Im5kcHtX!;:qFYjd=)ppqZ.L/V=tNJ&]s='8KMF]`Vte\T7!eSWPfd;e!l*$b-n,VY(:-CT$`!q)-`L`'!(%2ut@DM(nTS_V,EJ;2^F<OcEs>8Ide(5aq%cV1R(W_:X!$4G'ForUi)<u<2^>E64TXdG4&0QJ<El@Du<dH`5;[iML?YC5%uJIqBrR8b\]d'WKjEW,mF5q$iQ3#"lQr<pp!b!L1>+E3`kmd2pt9cJ1:n,\fNcn:g8V(ZW#?:4f81q0P),aKdfYRW5HZ/lZuB/pc&$l1?e.qQ^9SfIFVa[pSrjHf[AdeJ(N`hkBeFNmr(8h:P*Pgdnn,;348:PY782R1ZTG/MkkFA/%VLGNoX$RoR?m.XTGr(G[,1l-Q\E,OV%DHA.bcJHCZq,/ghmerX#b!UEk.*%4So&[o]n`]m[1*2uKJ*8'`-,Q3IehJ*F<[6LkV?$Qj+psr+i53UfDIPkTfY-@;MZmt9ktH7r],:XZ^0TC5"kV0&GJB]5NT@\)@L$ormlt\Vp)b:/MJ*7;lgYWXSRZYu7UNVe@qbc)g\-TRAfM^jkj?#K_f`jt^<N@HWW;C_NgB;/lUFTf$TV/?[hPs*)/\Y33AbI%R5jp;rfF[cga1K/?V5Y3on>e#]Pq3)rM`8+(lmhZRcI[uKYACI9mKeN9T3IB?,5l'i6a"l*$pW)ofV.hr7k=jb(VMBl$>Rt[t("ks,5jE_Y>49EZBAZ\YKD9-s3k\2/`pQ.Yk%)EL018bf[ZTW]92,$d)1+>)$o`@WIM*p#noD-2,-!]jBhJn[2$s&]ZVh\T#<<PSXUl_*-'i<PNLcZuGa;V!F4?b_FDmZqLR4~>endstream
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1872
+>>
+stream
+Gb!#]>Ar7S'RnB339ZPf,dOS=h$sOu-><hjB\.L]__N(97,)H*dNtjq7^<!-6V3</`&92I.>ArWlpr5Em5m7Pi8Tf!r_7E`hoF*YoYC',49I6Y65X(G`VANKM)1+Gd1DgVlpa@TNpr5O_WQ+j*$Q2;$qAMBEejo@?HWifY"rfJfSL$rW.oAF5o@39E'cK#q*&+8<&llJGdU?oX<0GIPU;1B?\E,CiERWs::V]4'Ds/8^VKU\K=Uqg&3IeFO1$,/7-53#XkWk@SaPqgi'FUa3'J5]^YaX[hglF[#VRmK)eDK6@$GZS+$#,5B;u?]'pS4db@#aRisjdg(kUfFE>WuZ">T3/Q-X,pNtA'WrR;<^+?Th@TYTe4<OrdV'Eq;,6T]';J,R,gk_>/emm/i^"kZ?R6D@R4..JHZ5c+n'G2S7@GsTb)-W<K5OAme8=&c;=hTO"J8=DHb@a;:?X-cG"2P41^eH.\+\(N*gG!g$G91Dr].d'+m4:.ZH4P1N:Tnsi*NZK:T;(8"sEkN&?^^FU9MGVA:njd,6jBugu"ZIhk/?-iLV,5BqN]"sV!N)BWE/]:)pu-0DrdNLTRK\GrGpQ6_1#.\HT"T=aaEt5:qR9e'<Ou:-pI@<)(Kee'Ppri.4p2-q0$':B/0TtS?8W(Imk8F?(U)ccaoeR"36jbg*oN/L/_B=6W1Q7[2md<VoNPMl18?C#c0T);m/W8dHBN_-1.fraQ]2<@WC]u]l(h5Si$hSJn1K.s.@lTQBp]L0kfq9k.F34O=&3mD'=k7snlXlrMS_Ld.YFC7r,sJ.P%=m_qW77\?`QimjWpnl6LQjkCdHQ+Gh2OaE8%9G?QWX^lDeCBd#GZDrhh^8\*pr9IlJFV[/ZcAP\?6hJI?oro;,c98S$n"+1m&lB?rp)f@W;En#:btN8_S>/f`.iXtI^1S]4%\[>]l^b,C.%e&bU&QMJ"LM8-er9<]+GUm;1$?Q-gFrUs#\ID*ACBF&E+/Tilem%tsb/^H-j=GpGK4i4t^Aju?c[X7.gcf.\c`Y2CKc*FejBKu!#,HO4/\TV!YE/,*11TYU6kY/8ba!bKIUq@`K?,pTQ#b!;5L@'IlZ:]/h1#cKY42XZf]["<[;!ZN:'.5S*=4Sh/)<d3XnYo(q%AW+]l.CQ&O]/33J6Tn7$t]_B.0X$3L-><pQ8o2>5tD-NAb/6STU,-["ImMIn#X03d,'`6e]?R)*I*Joa(@ZVgj,Kj7*$(.kSPj\KWCr2g*2WfY</tRJ2_]Y)PNl8VH0e9R0#ej@g8leU6`ut#IAiJ1@4HM&V"7-2ECH3lrbpW7_=(f`/a7O$jb-Z=QuEX1cI!6PE"jS3(uoL0_Ea<j+^6eHL?F)lGN;8G4KgAa)E:HaFr<#JB`-P\Kr+LX2o&6Ygh97f:dBrb.$-hqu*EqMfPM2j@V=]Attst5G4S[pZtrEa1't'q:P5U)n"hjRY\tf8Kjq8kEIYIFL).8NL\644_piPV7SJV_=mc#A@dVk"_j9k\ndXTVHIPDXQ_[/A5YtL?&P36=S=;-V0g:20'OASfLY@l&jMsAB'+4BjI+/I:)5gm<AE2dEFh]PhS=W<h/QW+58Eoe%qI-$??e]7Y:Zub#MRV=@QQ>lSgdC11AS2Rf2@@clOGJD8srb%Gp]ALVR4kk[,SjF7/jpnWBK?BX([m.=EHc$V-Tse%Pa.NiLI1`&Sk_o7!.i[qr&NAgk@.YC5.;F7Ue\_g,RdZ.a<$q>!;aYchC`>#<2Lb%U#6$)m4hXV4![4Ba6[h1&Z\K6+`:81$Rs'p/,X`45>R/[j+\tc,3TB;-[8]9=.u_?W*)>'l6!;%=gIh"Na1%?an?,<K#RCTS4^d2/3[1^,b2Xc/I_JT`bp>~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1905
+>>
+stream
+Gb!#]?#SIU'Re<2\0s&\).HaC,g/eeehu8r[q:JTm_OE>9=1fq?R;\Il*13%91lLT7$/\2",['oX@W(,?65\Z8R#T^T;=c)"Q9/;9Ra4]+u!AVjVSKOhne(Caeoe^k*l8XN1"=i1VESZc#hn/a-.3B'-FT0@gWOP;[]f*9+9E"<C"lL<CFS/B@p/'1T+V?VX5%Kf.ni5W#)NBPR^>k_acNiN'>Zl1(G+':a@TW<(:#:$M2#?riM(2I*qYHR8)JVbEm=g^hl45#EENmr"KfiKGXiMTZ1_@9lK0E6&=^6()XK8Gc_5?9X*'G&fdPRQ<fNto$e4@Qg_+ti&$KA2qB757$-qX&eliS^<%Y4#NINMe#n7hqYoN^?CB@Ghlq6(>A*mdi]Q6&-sVucJMS4C3^K"Q%.@7T<$7-;'N93VUUZY\pgs.SAHP;Z'h29k;\=!b_E).G.*b+k;H9_<ICd-HWf"28"QRZRXBobcE],=^bikp37gtd*oPPOEH-DY5+J%It%14IbbQ>mIi^"htQ"='fe:@@\e\%l\0fBKi6mbT9ILDo!`+9b,4%K]%J]:6`n.&J-Jh0W=VD<rG7eKHH1Wfao-h71n`c3=7GR\D.+ea*V63Jb]amaSdjfEi:^cLLH=B4K%NN#dRReLe<jen*Mp3l4h`s!W`H2b$Q,@!ZQcGUJ9>n*JT4Y[I@O)im9^0]#?#dPY>OCkdqnfB?ZFYFT/"\W!K8NFbP8>ls*4V6Bd3>dA*!hn\6'"-JqLdPRB",9`QE^s`)``h7f+"YIgl+Q>NQB-3"fcG-=>YMS!I-6X]3i20UY^?V.Pc?f$Fu-L0+Z*3Q.uIHg--s)[dS15lbBosUg1*`^Bf\u?b&=[0>0(R#UG&\u.G9J#PmuK.DrSa,3O\%6$F(Gq320+ZIm/C?UdO])::n^1bhUc)=jp\]\mucu/!)a.*(a`G:T8(hKTXUq)i:HreUTU?R%#F-YM5oVfCoW'bg>XBV/.]XKL&?:WZTQM\e:cR-5D+.)!s<M\hh.-^C%/^L/ipl<a;`q;H7t@.bln:mrKd.1d7uZGh(&)&+k0##=dUh)/=+dE!(R"IfI#\+gfW"DJ3:JV,GSQnQ;rrqAn;!,2\J:Ib3CKUmMSPileJ<aO54<.9%s&GOP8FN);aYA\Xo*"9L(*3(a?I73nWI(>ncsT,_Tdm=%9q,6,=.l"^"Q*$d2i)8&e`_J^Ocno)Q*oaK#+gc4'CQtB\8=q&kS%g[Mo+17Mn;C#`d:>"`7@o7%3XN"/EUh7R`?k`=Z2?UFQ7r:%'WqVCi)/?BVEU:KL#d])j&)=nP(q?JBb=F\r/h^I)!r'EbBs$r`!nXaAEs6pJ=Sttlg9SU6k;;23D%?*j\!?Yg@c(75/4)GhY/f*Lr),d;6KGBMIuHH$'J5@;k\J)XFF%WTnl8ia^6lqL8lm`OVF@e"]R+O<6[d%TJhglVXlV.g8r&*P7Nku7Q,Hpt%X$tj#8rh;fVEP6qs;\5E/,L$[YfF>1eYk<gJI"0l7e$2)"1B5i]OUpq>Y<>e.flJjeuHY.robV&.XT#rM1sBlC8'p<>oh\d1c(%;1,h"<uq`A!gp:?2d(a\(SYQH)dL!G'Qo-QMS(JqTUE((Bcft=cr62W3e;U`>bl_C7Bcg`(6L)"Q-`RCgOmiC%mP5O46kI6h5%%B'.m9N=4j/=SHN*PiMS>G4UKZ1_b2,a'0,\G'!cF1>IJUCissssNu@teWIl"Uj=q<2M60.+Zes`G5Y*0'gAIOdVjUOgp!"dqC<o6ndclp8g7$R/%oVSu_5m-q3c@ja(rkPR[Sl8IHnr7_I@a;q[r-[6NQ&gZP9!J%/9]beJFQG)o$?jlbFchiZFb1fNTK`rmD\BMo=#Mh]7,dm2[fehp-J#<U5D/*ITSKfq%#RSE\%~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1052
+>>
+stream
+Gas1]gMRrh&:N/3$j6]V$]BA\Y-dJX@QS^_!*/%gdY@f,[2_h5\`B4?8l:KFHY9mPj2@pj$UJfFGikM`-4nWR$3,,Mn@F589`dlneNG0V2MLE:>Z[\U&Y%s'3<qI7`VH%DP%O4uhZ#dfON/'&Q)oK?nfjb^9GH9BNWj&Hmjj^EE\&`<Za]unNO(B7BcO/,9qRLe6%uUYc:UFP_"gL'4Bf6MFk<;[ge4DlJa,$j^\0OW->#%lcdM__nqq>sMC7A4;GWAD"W^R,,tj)JdArPOHXe#_4c0u`Hk_@Gn%g;)A1=#@`M5@024+QiikE>%]!D_jmM7.!_.m+YhS@_>eh*V0+.?U4Kf?-NLpo.n-':O.l-MjTq"3g(nJkqW")#g&DiL#h6b<_NNSG-QHfa_Q?XGB<X6Zgmk=M"0H_P1O*El\JDd+OR:a#W$N;bOt^tCq^bo7WU`bCqYE7q?*h??U5Mm7AJ2(dSm+NFk.48ej>74O4CT^q'>eBtHZ0pb.NA1e86/]!luk<.6d;?u-gVGdO9dYcEjCEH^?!k`?rFP^;Re?5WZ\>cJC33l!9@,23H+L!ajl4)[<4p2&E92pM+ps)D2]^pkgQLuIA(;6!sJC6_&4cof8f(<4alAs]"cdW#\fmq$H;U!&5.nB3".s6BU,cs,bmr/&4CQ!dB-!-+Ta4GCPdeS_S(70#=dbRI"=dnNhdO\2;kq`gI"+_mHA^=^En<_'%QCX+$!-Lh-Pl<q]G]YT+aG]l;U.s,:'CC$#SL;i+/6?a3fkJfS_*&<BBX9SM+fn6M$BuJ,(.11pOGUI(H;VBo*k!=P=pO,7aqq]lO[2DWn4uFk%Qg!<DCEQW$Gj)_6RAn.#K#C$!T5)ro2:chrl,%:%"[rY)+$o*+L=-oBs$/^Kc>&mg$;sB?Iu('rdt!\]m)q14Hjgf!VFYG->BSr>#1f8B"31Q?e;i`'?QEWFV\-DT27KYVUpY[>/b7[e7-k:rl()(2HH>#5^3Obk$.k4P*gP&3t?F=8a6ul\&T1Dmo2[Z8!5/<[e."R</2R/$)@M#c(iC\~>endstream
+endobj
+xref
+0 21
+0000000000 65535 f 
+0000000061 00000 n 
+0000000122 00000 n 
+0000000229 00000 n 
+0000000341 00000 n 
+0000000536 00000 n 
+0000000641 00000 n 
+0000000718 00000 n 
+0000000913 00000 n 
+0000001108 00000 n 
+0000001303 00000 n 
+0000001499 00000 n 
+0000001695 00000 n 
+0000001765 00000 n 
+0000002064 00000 n 
+0000002156 00000 n 
+0000002678 00000 n 
+0000005089 00000 n 
+0000006818 00000 n 
+0000008782 00000 n 
+0000010779 00000 n 
+trailer
+<<
+/ID 
+[<0e96d3d2559dca2c6719ab72fe369d0b><0e96d3d2559dca2c6719ab72fe369d0b>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 13 0 R
+/Root 12 0 R
+/Size 21
+>>
+startxref
+11923
+%%EOF

--- a/documentation/Walter_Discord_Bot_Commands.pdf
+++ b/documentation/Walter_Discord_Bot_Commands.pdf
@@ -1,0 +1,156 @@
+%PDF-1.4
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 13 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 14 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 15 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 16 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 17 0 R /MediaBox [ 0 0 612 792 ] /Parent 12 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/PageMode /UseNone /Pages 12 0 R /Type /Catalog
+>>
+endobj
+11 0 obj
+<<
+/Author (Walter Project) /CreationDate (D:20260816234813+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260816234813+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Walter documentation) /Title (Walter Discord Bot Command Guide) /Trapped /False
+>>
+endobj
+12 0 obj
+<<
+/Count 5 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 9 0 R ] /Type /Pages
+>>
+endobj
+13 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 455
+>>
+stream
+Gatn!8Pd5X&;BTK(%2E!R.2*l8D,UdC_<24e?+=k"Ocq^O(XWQ$WNBN+A3bYDs$kbYpG3m*;6*.-5eFR-)<jcK/CFf]>mX3HmZ^7$6I'^A3IuK-Sfq\957Sg6lgqJ"m[GSiNU*j1)d%,p5WRg'AAk=*/#IUPiB2rD<H=u*2*R@AOU!q$7BcfU5LV+RpoC:]$%^kWDAYi,<P3SpBu*n]N03ZpbAC2aM%3nmV/0Zp`cVqn2u@k`O\q*.8V-)(gQ?*=UUq1<PeS7-Q),e]sq(he2OOIh`52/B/Q1H\g`t7dnVW33a=OBQ.OIoUeF@A*7O@WjYUk>F%,F0f$_pg+gY'Nk!'<E@+WKtqKdC7h]p<$#\eo30cjr5Z7,;J52,-^(*2*gMf#PR*S\nt,BS$Df#G?%iHA7Hml&t)Z!HpEJJ<bj(3-mRYEg1C.CUQ%;)=@[q$'\VZXa~>endstream
+endobj
+14 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1695
+>>
+stream
+Gb!Sl>Ar7S'RnB33,`knKGH"0ZFXI0\#`#L5,>6g]`\USM7,E;U.S$,]O/E@8sYa\[d:@gL*8fm$fnjIhmo,+LO[hP:NCuXB/"d-JMNTEJ54/gAfos_fu<+^1(Cm@$=k'#_%`LrIe+oUgUi@F!Y5h<0aT"Y+JedS?S_Cud0bh'?mWgp39#^Wa:!Pm4?mEdT8cg`ZkmCkPS;4A&u.<EN;hm@,rAl-Us;D+nOfh@(!QZ/g%SNZs.UTtWR$1QjVtoJ^j=$cU/0V@&/@Vb,Rf<UmlgFETeRV`,dO/aD]-L3G6.9:5GM#KjI0-O9ZG?B.T(K:M\OSAL47pQgP\hV9crX!6YM,3JJ&K2=W"t:;$^r2$8dDpos-Ij0TUq.%1"1sCB3m6O2dP+l:3B2J1s2qn`5NuPAN!eD!bYj4d<`VX\34.fGKiVB^rX!7TRA7R)&X%#nQ[4\FI7P\/0^5UgQ#`$(0=5R\A=b9'3-?jm$0L_E]7P!S>aF8uGCHTM:T#L!ies=r5uV$;u69?KfW[QjOAF@VIHgjANTc>8Kbsi6,;_PBnk>Mpgo[VS:tSSg:=*0o7@eOk@TZ\i=A3lE%imWH<iW#WS=$aP8*JKr?1_.ka1hAnRXe'ZitJ6N/RbSSft)*d_u"*nFe1PqD(&f'*&K=fpBhHtU7N(r,aQ&L0.)U?MeZb+_HmJbTiJOLc:s@UKHk8%Q(:pV\"CTlXp!nAt-q"u4r'<#Q5nop9M,Ek[*^Y6@l\a+"G@=UM<_05R@C/2K0HR>Vf2p(jU<.Vjtqf4tdflUj\&OXO9T8"O7PSK*2;E0#77B.bPNX0>ca0)2`^=)6#fLSri39s?*5@3NZ#eq"ThWXr7WApeA*L5<2pAHl[rEm&d#aTRbAYD2$R9YLs#)/0Mg&FXQrTR0`W%g2$8\I'8B5%_;RrA8Qka$#q5=$)6dc\9XLBojBYBlf&8TM7pP1[t"Wnc&ABfW/sQ_Kq@9lLrb:Fu7uD`g<^@15L2?cplr;I"QBi!aC;sgqUUISDAqZ7!lpZD)uLQj]NXb[jCI05QpRZ17N<.f8;a)YlQ+<_-SD^%tVNf$GO?jS-r$)H2Wuk"nH_*EtCN6o5%@J"KN/9LHVZ`MW3lZ@FK-ce>C+mW:],$TkV^$Vj#:KP.'Y[!N,([>\n59FYMu\A?fC-)B5Gg\*_;@Tip-a])jql"$_ZL#_7@XI<bgaL'6Bq@&ZLqK;q,\:/H4;ApeZdi\YH)XP_.,nRhE'o=tLTKl0*S1ghK_5E#:ap(Q;<+&5mS>Hp(m=W7r`brCP'D[*JQU25P@Pq%,9P+:*+Nr.+2[`A-8^K47XOd"HHlr;ii-uu%(DHODQZraFZVA$/1>l[Z@[nGnH.J">DJQj5_BY1*]0*rKccL9&;!s+5OD\k&lV#@6P"qp-Thdul\$%1G:&'^!_Du>C`H\VsUF6MG>0>4(GCT't&B=FQRA\$XO!./LR/<[*CT0`'XIHd[_1d2Y7n#"e)9O6?q#6A""1"V#\nQI^og@`NAf$m88N*4Y58)E&cZ!0.tiHc9B"1UI*5Ib8jBWX*<8rJnD:4muNl34`t+NJ-drQ4\\#4&8g+)%:%^cl0/H)1I,8)5'SoaQ&QgRn;:<Ppi?.Elj;audMrK'J_h_Es,2`KObnM551Ykh9tD<tDp!j41EsQ(&[N\:j#I/;a?b%C%5#E(bkBIfNftRK`~>endstream
+endobj
+15 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1931
+>>
+stream
+Gb!Sl>Ar7S'RnB33,`kn=I#hSeI9@Lon!0la;P/-=GD?gBUc+lW?Pooqt3#r-/!0`MrtSf&0QuN?G?$%gIHSJif@`$VZjl*0t_o&JOa*1!AABn(k73_j,:)Wc7!du&NHQ<%7g2]i&<TF:EM1lKJ$$l'.8A5_T9Vjo-K1HMg!"j$2'<M]:ItP60q)!"Kn@.JtI5<HE%d+/L[qW$(V4H'JT<Qk).^Y[S30B#t5R^`=!N4L@L=Nch3!@m#6<)Xt@A];[36To\\#mIXZqT`?]I0P(;S.>IiZRZ/3=g2>3C*#pbP7D/mfr4b^^s=n.a=cq*lQS=hHOB+:LSn[fCRMqiOkJ3ujIKH<+%N+@0FVjBE=dtZ[O77G58<'i[^ZWHZ$pa>R+A@)GfB]-oH^5n"N?gPa/;-oa`<S>lRC;)P0"(C\_r=D]n^hWc@cNh6S4guGKRjbtkZFn2I-%'Z18qet_6dC3SaeqIXOYA5":br;9<D4mhJ6<)!fndk'G;PjVCBO&7([q`DrAGjP.]5p?b:@g>i]+%XE+D)Mbq^:(XD)24#738O<@K3Bk8%#Ggt4VpEtE808D(nF8Mes89!k:mE4YXMlg)fgp7cHhcpJ?'d]<u%UOm:!Q/BUGl?KhV[:o$\`\<9VAi3AXc+_^TE;d4XTEhiV$F20?s2ELA&^g\?i'oZY+1hHSaM"0q-uD?RHfQ$`QR6/`8qlme"<l%af/M<sl5J]N<ATAGdl^tY#d,j.*@f*(>VEoslM3.@6T!X18J4/%)-E++]L7At(1c@=YGDd]<BrVfdkjM?l2ZDY3+KWn>7@?9pPKdR^;=.4/2rGLWhYGGLfOI3O+$*KMtIAmoC@el*cJS_b<"rK_;JJdKL&a&0ZN@g^mGad__fo'$+O6No8kcaD4TjG9&VdWl\+a%_.K7jP4$qr2<PUpMMWs`qHP#q1/mT$PP"1C)QjS(DI>.ZYnW?W(jJ^:%$m:P]e?eNF9-p(_1J^jfdOZ296&=#'rmb+m_7#I0>HkVW)m9?#i.R_rYK_tY3oUYK>;/)!Bl$"^F*u).]f"bOp`d.K+CX`&1d+:+P<E$Yt\@AlT/1@@8)cQAk[08E,Q2qKXqcACE]h%H[;TU(/1)b3MYlM`;&b7`.Vdm13S3TY7";->!'"dGCcg$Ka[LuWoe@C%CV7!<HPm5rocUe-HWFUX:&m;\j_7G%ttkc]WLk<T9rNuL)_oTaVCF(CosRFCY.bo/TFe9L,e'M%o&ChGVWCW/I&LP;hg<c2A>^C2AaRaR6K%1-<l)SS<o5j^k-;-Y^c-^3Ep'T"0_T)<i2lC+r6p>]C4YYJLQ;)(-uC';2]J.s2Y;U`=GH$&IP36T3,+E=snF7)Vs<3#BYRdqHJ(DEDI2S[D?h>+ZT1A@[6u,*BW7!1U-TUms]h]ZYs24NuX\a7on*X^)?Y)ci%C;;/i8:Z+e,FNXh_U7G[h/gT+;#LDlXK:_Yr@qV0=P<"4]$s24fuU^I\>:/l>mc1\R75MgL'>IKGt;O>@:(TuTW*DIpWO'SU6X2E>,lH+IW4d"FMI&.bDGYM^EJof;)RA9Ru:R$dpQS3AS^8,YAfpN-;7OLgVmmWW.(5J8,/$0t.%XPR6.97mC"W<e+XQoYQ"5KXX#e+Btl<S;R'@"-Z>#b;^I\,6IfE8G4^jXl!cXa?kH[Q^>:"S4YW'$-2.S8MON)'Y`Gpp25-""NZeU4ZU`Jj+18D@d^CYC`OPN<;0U>j'`TFnH-mhW6-(YVaq"e/Dl;VS3%gGVas*4IZOB6^!7m99nirga,&[8r7Bd<GsP2\AELId8]th=Q0@[s9'\GdKd^.Qq7t5B.-m[b]j*oOc?3CQZ4iI7D1T^Re3eKa1J]a&YDI:5M6'BO>AT['E.9X+8H;09qDi-76>:G&>e!+Y=XgkE3%^o$ALN<LN$@Ol)Z;(OlO.lY<'~>endstream
+endobj
+16 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2517
+>>
+stream
+Gau`TgQ(#J&q05PW42:J3jLB(AL2s0AoehHYeXj+NQk+H"te4\-^:QkP^C&M^Jtso]@1M%H@%=Od_:Q,eu>[e;\_TSs!%3HVuZgB$e#Uu6o!K"+IWHi\G[5V^V0Je'eIce?U1j:_K:@43IV<JnEJQ*)U]0=9_)R$'r:F,?ekqn^L)8==cefcgm\\7q()p:&Br!:O(3S)XQhYpM#<s:ff0F]4A?!CcV.NFiLMIPMV".sU$<`Yp(+\3#MD4EQt4#WM:7*r+5*+#m,7Ekd&5ju3Gt)#E=a?#q#,cC&/%$M"]7a%T70<R8igU:BHCcD)$FrLc-clL,X\aZF93f<U0[?%7S*oLZZXI[7/>R(55D1)WS;10FnblJBI)?gQ->hEm_S]@GqdR^hLj1'rt%s'57]O?Kd)ZbM2Q@?DG<;E@gt,:-VU4U$'ik@Bi$>XcJqY@_,a\KU'A6gpk@99#:ML3Y.;1L<gEqhbs?DO:iq4hl43n)Y%Clb,[3n/m,53mffLuuf(,iWrN1[k)m?b+(pX-ZBdZn\\DRUEn*61bQ&@d2"2*=VMJFQr\5a#X@1APRqR(%(;A?qRe?Wa5mO?/(^a][3<&$\h,7B\g;3j5k&!JZ8pIej^QmfJOoI*Z/GhA)=cB'a*pd)"T>Jh7^LG43nL#uq_RVj"u]Gpbh[XZ0aF=cDN7`Q$ti,%;!G'`W!`%*To35CkP8a3n,T7quG@5m,hSopR&&&`E<oCS`jr-1-b8b*#/39Y\(il?E$mM\qV$*E0i^H]j$1=*tm.=4TP;1?/odWp51Csqr)ZM?o\5fJb+b4-Kn$2b!;>%+X?+V,!5:R0^"-Yu9X94^7P)+Ql+m\n$9!YPYh?YOC9mX*-Q$/j^Kg^Sph/5i6/batEp=Ac$*7LCVIm7?[!;]HQReJ\h8$:G7dd?uo:!o\fcZt*&alhIPG!7G/,*!E[$8nmjOd2L8TIt1U/&2'+ciOO_8kFA_bj2_iXXJ`GAhI"M8[B@JunHn!`6Fq=F6o(RUED'9e)-A&#hetofTqpR"c^F*bMWH!9RiuE3GENp"Q^-g*0ZJm`E-0E)Z>i8sR)4pZp<`FI0*O/f#\0.VFiY]+:Q`KX%dpHL=:Of9T5.<-M6\kg<7V(t_#'iPoX[,X<1FLggbE8s+pOnr$8f2+V;*6c)o@\Wq?5]R-jk@]#%8QB3QdF3al5.r>"R.%T05g.=dR/`6oh)`gnf!+^b;fiF;Yh?0VQSl]F$BU$;LrI*'_Lq>Dt='S9l"\K.*0Wo9b-Yo>1e-I,=AhU@Q?P](;9^EMfSZ?##`NE+`1OCIT/2fKf%\o^$=QZ5p8IW05dC6X+AOn[6PU"uX/nBJW8DLY8^?pTht#-Y@`o*&Wg`bOh56C*e+rA"psMh_KIiYTE-$aGiH6=fnK>S+l6ITJ=VkS68I%@J1mY80r:BFNKP7/t(Db!pE$acXtSJAG.3trs0j8641?B3lB58m_msj2C^$`-0M+>U0me":5n-0^/op)d%2.^?ZmsfZh?ppYFhR5?J=7=RcHfYr_e+uH^ZlcA(bs8Gg,M?0/,fj@O6*.&r3@C6jY/BqY-lWgQ%k3D5mL[Iss-lMm*io]l`PQ]]#H]Nu;bEC\B>dJSKh?qrR7L9Uo%lJq*ghrb5%fmi/5rg3K;XPP:UJVCQc5CLTK?(cB?\V+,!M`YcJ/$]o4j5_UXkgIl'V]V;2VMKG"R.YAPc\P5a1jY(](jEMj-`Jp:'2G2Yo.%\@>cGkVr]k0=R5/$@O:qBi$ZE;_'?.<MAU7%7c=t5d1@!6[td0bT:@h7#!R/blaPLqp0mTQ$^]UlF+OXOA&#jt-@?\J]0:",0^\mMp5QHhUl7[efTc*Y9"dI*a/GU]SN/Q#89e^1,qD;uHTAZ(IK=3_agN8eB#r<Yj"kc>Q"&_&2$Z^i$?NK:sW21*pu:q)(tk"J.qG,ON$<(8tX7mkYPglW/l_?d$;Khr'6q1&3bK0JWkU<kh^q!15UY+];;dA]Yc,"S/@&U/%+hE!RY`$+h$Q)Lt^5j7_U^PB_$K<KLe!p.H@EJI#Dgb>Z2Z$PL!'Qi<Di]dg^j9_L#4`t,\%"sa<^4^eC'Mm*KB?*!!kkD]D\JM858*qM\>%aWP)SC;<Md>m:dZRW-VN5L"VJl4DTh$@s^Xp?n'/2n6r0\do=Z@?dnIp*u#40aIp2cA^rBL\FVZM&@\NB$;S`tlhP)9lVB@hW4D!)f#Ipro)Nn[LHUgq"3b`p2@8-t"&mWf)])V^sGYl)QXfn)=13`%\S%bm?M&7HYYa'\_sY8!8+^ALYTBjs=_Dr8R9k^js[CAqiVauqPpANPT84=7hg6K9<0A/Ip(W@/1EEL)+/\b:uEi(9(/#.E0rY'/^I6X0^aA!-^p`E[V>U^,p4i<JLm^)hAkh\p_1P[U6nN91ig[HU.ZglJ7++J"Qh+jU/b'5-Fp_41V[dbr:Sco6t-:g[&`3&aID@[K%S`Lq#Ds16S]NQ!M-hYVFc6S3dH;'`5\O)Q>R.M=8UoQoR&Krb4SR:'V,~>endstream
+endobj
+17 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 702
+>>
+stream
+Gau0@?#S1G'RfGR\CskIP@lssddRGZ!sB6j7H-&m*3V5@m*9c>rV'Q0h6[WikVQhlQK<J>3VU]*-n[FFC&iM-_T<Yt`hC'K<g"*L:[kf`?-gSYct3;h;,aa8Zb[S4iTn+D"$t>=BLi:/Ll1.O>qDMlG(;F^)6ql2OeO=@=og'dd;Y-/%;K!V#IY:'_/_g[<&;>fS$Y`l3;%#+ZqE.lmp89V*SQhto=e^3P=<=,4m/YHBb:$_^L0`Zp(\4jX<JXJOCP*rAIZdl7EpMd_@+2LnrZ$AAVNB/j1q*'*A;GXF%-I`hWQ)G&"pSI1oi?)C-eu0]!<Z[#=<m';MdIa&,A2a1F8NHEaB\_A7dm)Y_)\]:,%6kS/&N:KN5BcPSaV.9>Q,m25[!?p(oo8@<BU"\r/&*9mQt5]nsme^;EIHfcKPMrkN])0N[gHg-$gVgmILr7bs'?m_b<mIhMI?hYnNR(HN@5g=q5)In2Zd#f\;TpA//h[?f*PgR8%$PI0l2@d;"lA0.<AJSlG;-O/HsNBQ1>4Tr7)3i!D6q9^YI"YKU7"Z]h8gcEuf7Uu<jq-fB^V*Cr=PgqPe1C&Jl>&POc24ua!"-[Hf3pcP1"(52^+&b#K@M.q+FT,uPnFd]"6+R3Ufe!>T4dr$j35(_n^i*p@0k/>GRom\/iI0H5cf+%*Gqs0T2\CHCT/:ic;o.f:E>t-8~>endstream
+endobj
+xref
+0 18
+0000000000 65535 f 
+0000000061 00000 n 
+0000000112 00000 n 
+0000000219 00000 n 
+0000000331 00000 n 
+0000000526 00000 n 
+0000000631 00000 n 
+0000000826 00000 n 
+0000001021 00000 n 
+0000001216 00000 n 
+0000001411 00000 n 
+0000001481 00000 n 
+0000001787 00000 n 
+0000001871 00000 n 
+0000002417 00000 n 
+0000004204 00000 n 
+0000006227 00000 n 
+0000008836 00000 n 
+trailer
+<<
+/ID 
+[<53468c47c74d1ac0eecfc41074dd879e><53468c47c74d1ac0eecfc41074dd879e>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 11 0 R
+/Root 10 0 R
+/Size 18
+>>
+startxref
+9629
+%%EOF

--- a/documentation/Walter_Site_Guide.pdf
+++ b/documentation/Walter_Site_Guide.pdf
@@ -1,0 +1,238 @@
+%PDF-1.4
+% ReportLab Generated PDF document (opensource)
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 5 0 R /F4 13 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/Contents 18 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+5 0 obj
+<<
+/BaseFont /Courier /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+6 0 obj
+<<
+/Contents 19 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+7 0 obj
+<<
+/Contents 20 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+8 0 obj
+<<
+/Contents 21 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+9 0 obj
+<<
+/Contents 22 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+10 0 obj
+<<
+/Contents 23 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+11 0 obj
+<<
+/Contents 24 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+12 0 obj
+<<
+/Contents 25 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+13 0 obj
+<<
+/BaseFont /Symbol /Name /F4 /Subtype /Type1 /Type /Font
+>>
+endobj
+14 0 obj
+<<
+/Contents 26 0 R /MediaBox [ 0 0 612 792 ] /Parent 17 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+15 0 obj
+<<
+/PageMode /UseNone /Pages 17 0 R /Type /Catalog
+>>
+endobj
+16 0 obj
+<<
+/Author (Walter Project) /CreationDate (D:20260816234813+00'00') /Creator (\(unspecified\)) /Keywords () /ModDate (D:20260816234813+00'00') /Producer (ReportLab PDF Library - \(opensource\)) 
+  /Subject (Walter documentation) /Title (Walter Site Guide) /Trapped /False
+>>
+endobj
+17 0 obj
+<<
+/Count 9 /Kids [ 4 0 R 6 0 R 7 0 R 8 0 R 9 0 R 10 0 R 11 0 R 12 0 R 14 0 R ] /Type /Pages
+>>
+endobj
+18 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 427
+>>
+stream
+Gatn!b>,r/&4Q?hMRs!:>ee:`QQTs#83@g,3_J3X<?I="4$K6-RYF(-M$:3GOYq3`c]"tKH)Ys?f"c-Wd9&\KA90.L/@#N9B?<Xf4NZM)Hn*6Z%"+3R09]oKP$D[PE*.a_in,;QQmSA4.]@=qSXhI[VU@b4BnFnU&$FHW&Z?2>[FHN(e#[QZQETRUiGMldf5XaPFh-=5,$Q8'C-78<P6u4b%E)'<,!la]T=Ll6hXO%[=Q+N2V\oj#OPqY0+B;fgAPu5*Tag6oIt:6hF6RA>@:[irTr)hK30oc]XD_]See+*o3K$D7lTnO/H&=t'O7T80p,MuSVL;S(ihSjg$IfYNcKAb9jt")GgLVpN<,it[\1%Vq587bo9K4t#Xo=+1Omq3J\R/jSj.?;t,X+5FS,Hg2X.cA5hrI!Y*BB99NYe[:~>endstream
+endobj
+19 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 2050
+>>
+stream
+Gau0DgN)%,&:O:Sls$$@7Iq_gP&rbF-?8==,i^k!qVi<IKIG=q^]L/KrI&kjP*-G^8o/W*'96`+HZo/Mf``T+nR(AVcROH0AoN2:5nq4Q!RWS<_X'FuSXo\*&kp_m3e:Zo%at_JVt_b^_Tf\+$#,2'PA)_&$IVe):\UW;cR8+2iuk03VsSIi1)c1j&Hp!*RDpsFrMdB$%8dMU*?1om'[]m!qDToVfC27@9uWr?<[dbFB)f[5=#tDL@knN@8Xs[8^1IP(G\d+&oVl1^6:9dX'Z:gkHloro]3mrrJh\9gIMp$[86gZXo&oYQWp5aO%Q,.BbgurC6N.89:Cig&a$45uqSr.DXplE_;%UT]4;u+!0"GS[k7EX2U+%!j+V*P[IK6-_fDu8pBc'Q!2,Q,hdhIBn8`T()4%R7A(=AB9`#d7D>W!;`;A^f#On/ZeUYbA*fs1;'41XHq(S.-+BSXDeT*).[;IhE2YYZ6[,GgJ*HshZL?G^O#i>o6tY3Dc_NL#NdKA0rI-"fZa9n:DJi-kG1HGa/;N0osF4/YPU]'!j:9eNs"\3&hZl+9B`mK9sg;[,"2fbY-QgN\18FH-LO-lc$;(u9F!9Hsh+0ig^'>l2bt4r(VXrnd'k+:-=2mbgZiW^R*t>["BD(`BYZpQ?Zq8-NtSR;FcNO7gMRRd3Q_U<nG;C/pQ^Iu,n&'X$(,jrB[2a)cg+b4,bjH.1B].@)\n.Qqt`^Vu*bA]]oBU_/=Aq*7JY=f**O@EI;3H:XIPLpC&:Vnd-L#5brqNg&L"35Y;FF!QsmBnql2@1FCsV@Tsm+mhWPO$/oY>iO9fLg0OFL=6\Ul"$/L6^QL#XEC/`E/Q!p0W<mBLI1//O@I?@]no4>#n@\JmDFQUdqbnIO>_X8I9r&"g5ueaTm9+*KI^$F_cO"*XMQ8$P>H%[EEn'E-YD:/:U<A)X'IRfE+OTc7eHoC`\I[)QFruWF]D96.]g%V(]on;,mo.?rb)]fa3350$;om./E_oTr$e%<iX#kZVU*EAV?5;*l]pE&0#TU_SWc.[9>4k+H'VU<inoS=$B)>qK>6Qm@-UR-.1;C6?Z<J(GlW=S>p=:FX_k%Z`CdoKC?t(Xj8l\3.5+[E%]1^>?E.l_ajBMjP,-jGqp?aSE.=VAl!oQrX\l2lX._0!)F:em'YmpEQmq$`s,0UpeX)JJ]06='0i=P<3afs88'1ke6(+3Ke[CCZ.6O/RQ&<"NXDGKY-#8]h/Ba=JK+-Ng\b*Z45fn$UQ,7EqWTFhoP344sc+K<X5XskrKFqPr\L<.(!!.q3?)hbnf2j%[]AAKaZ$oY5'ii4oJRLegNf2,$L0X2AE?P6pHo/9Z+iN^&i&u]Pk:Qi%^6/Bp!ghDL=n>pmRkLkSCO:1c@QY^Pp]-?s(S#A"2V?*!8)&mY]s(.r:e(n(13+OW_jWq_P?\9gWG@_<Zcee8a?(U=eOQFlf@gfR=eTn$i,)RiP(u)Rm(s'A+c=:oIYC=_%dbGQ$\ucl7ogk`W@4\qGq8[kd`'\qOm[;F&h3E/=$M7T:/uduAnO>H!21EhalphLl9`iRV;jCq`G<T(f&;kZH,QfG<Gh[S@X-I;PXfIC"oT$WORTf;=3MU%*u%sc_n8t%*V-+(Yr>IPGI#g;+rADTP*,^5Y=-A@nKBn6+0I[sVdB<I3cook\.ej;?L1jAWq=6gPF6LPgEWT=8#pKdQ4g03Wc#E&\N4q52N=Bb0?9ZRES'tD`1#(GcR15^a=B\*X=)KJX\]cZ+4Q:QPrV6kBQU$X98k@aLP3q1km(Y2^cK<dl%+acPT4VA_T>SP*2ur-V_GL4]-$V9i=?1L5dfdm_$;;9gT7P<du:Ht\#6&NQBid[BDTm_1q,-`i/KG?:U[.$mL9MY`1%5/$R,j8DW2jQSP6OT.ghAbF)cU3GC46cRW8Ets,j0?OcH,Yj)==bqkAUZ)OdpXop[Ii6h\iR9fR(-meMa%WN&:#!H_EabN[<[L$.!@j`l.D(G;nm31h4aqWN/:Gf*TbL`Oq,&F>q;@R/f<C=DT`(Rh&=i&CYOaa^kXZFp~>endstream
+endobj
+20 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1994
+>>
+stream
+Gau0D=`<%a&:XAWR("Q!:%?_a'F!2O=-9kMXeIIo=cmK6@p\"t>&f%?^KH^\'#Y1m"boa>g_nD]pW]ObI/F-8Dd!_N^7b#>J:`ju[hQbe9T-CP@W?R@k04Ng4sOu(oog8rF8Y4AFT(L+Ur:<iB^STnTO\\nlMeoik,_K@ob,h8n'lX1,bFiGnmXhPLEWh&<kVsnTJO`i%23XiCC2!Y.rm-t>ukZ<aO1ErWq%#Z518G'f"!FN9ta[D-@<U2@O3JW48p9bD9l#IU1k0a+bG7A^:Sl.%"9S\P]a5qF"_PGMV+U1ht*`Z]Pb!Jd;NQk[AmIL&h0;@FtG8q;AZ'\g%ck,q,#m=6WGS7]#A_^BqmO,;IcO%aj?T+1`j@*U^V#_<Ecr]c=)>MmZs]/b&^b/Pq&I^Q0JDEHO"t3bNm.,MIJfcF&PG,)XedM?c6>-9DTJF\/mAP"U.hJGPj4Lj"6p1fDui.F!$`Z(.UZLd*_(5,MB*EV-pM9I0d_>\[RW,7Q^ERi_O2AoRt[Q$(to<ActlF\9P[=dkG0TE\)O3[tq=MYZ2N=V+OjX+inhTJ5Dep8#agc8X_RU6ZM"^oT!rlhQ[iZ%t#pl<iFfDPHL?0_pqjdno9&q#<YfNHB1Om=Vf-s^cR3FGZ&p0.9;Ej(7S'F^g_fa1bR/U/-pZB-A]B=X*";/`_\7o<N2u!R;q3AU=%-OU@4\Nbu2tWj`5.CQ<KHMlWg8qREGU6P0(B2a7JJC0Ll]_U1ou?Lf9OkoCr\(j46GF12$?uf"K/"`KkNbX5M$5.%j-OS;[Mr##l+25:F'&L'r1kcB!Eg0.Lb@^CE6_c]??'"n6HZCu$X*H=P'uX,Wh-$:WNdY3@:@NKu3a/1tdeOaB6.>[!`J`sSX%1JO4&Q!T;Fr<Fn%WjK@[%5VPLB1AW#lUp2&k0[20PZ#=4p`:-W9KC]"S<_sf\jmrS[5\13;RnRerICA8?Q^=CX.mn9Q&ahK_Z;g<ZdZ2<:Q>T+N\feq26=p\an[V/F*oV84e:/B1@G&FfPn%-HIjpe'&`Ps=DHDR9.h`FIt`L*2K>)HPUXLTi0)Tp\OPTsD\3Ok5bHIr?iBYt8&V1;H]GPab?1rO2HF]u.abXh@?@a()i>*+JHf7h212m/gj<&[-n#NS!OrI-SD9QI>LMiV]=6):+Voe[AmmVYr>=rcm7T8t)Xn\`j'C!rl\nA5jL<*%k=SHU-7\DuDXkB([<15]GZrnQjF31Q#AR:(U0p)mh?.ADb]l1"Q7_*"('=>Z7AtlF"[ZkNeUtpJ+H.YFKCG<[>0HHb,O!;3i=U;"iZ$WI'HW8&AY637:tc?l9?ao9T3TSl#*Z3=1O$IN_hmaHF8\LUZFdPRA1gg(Cf.d-8&Cup<#WF.Uhk&k^L7tg34jp.VU?;F#s6.pF<0D7?-uuJ)@2+J3o&UQ+$'XeR42;<&6a;D>G2KR7mhXjN&I2maK7(M>C`p\fWKh8J1NV/75qE\ZHYq9Q0)AGD!/u8MiE!WIoHStHm\NrJ=nrbfh5QtlXkceqrflD'_83WHY_HN9pJ7^j^sC?X$DPWNNnV3_SFaK8dMJ:)L2@#GDr4A0Ke<IH*a'R:L=F:1]>ej?poL5'ds>p@tihmU2-IYinYr]l_,n0<llY6r#HmT0\WX_<K3950k`QUEh(ScW3i2PXP'60Df82JYYtIXK44_+62C!Y*CE1pAm<`qlE;rKWE\KX(g=^)]>+0W'sn%]*"Y-(/#f%,Sp/,m!PLEXTNLHpl4H^%-_nhB>SX8TkG+jhl('r:L^]BBdlcPh1dIHVAcT;rE:m=429e*Pq*XMAWmHfRf;^U^)tS=p9,haYD/4.h!$b+&psf]_0l.7q5;rXm*\MQCpU/<Q%:lBCXWIYJqPQ^M;N"bN>(g+]:QJf$qCao.:V/L_:&m02?PV?\)*pr2C/o;g<S=nV:R1=Yaft9EeU$-(BTN-I/\4$J=:WL#%PYge!95#q[=.NEFG@L%F2[;/J$GX&*<~>endstream
+endobj
+21 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1817
+>>
+stream
+Gau0D>Ar7S'RnB33,eBm>Lm'q2@R[\V<H8Y?/o?HH_DnBjs#Y^83-?lrQZR_fNH\%0Pgjt/X\`1mlM=H!$D4Bqk$pi^FWfB'0m,GEXb>$`NX^p^Fl]R?$V@HcPPLk1-\q"RcBSR_oF];2'bA'N,gS*$Bd6]eNT4:GL[)F]S%Qm]f7Z;j31<8Mu>%76X623G!cLdhC'm49Y;@IWF595.ue6$[GkI<C;Z!0p%P]g#F7T9bi==Qjt3;]3BI(hD$7dIg]'O2*quS2-jrBq`$""8,>gWmA9nDF7^gW]63nduN#23-7rdtWOt>T@LsZHp/61<QN3%\1D)D/2L)F+To:+qd+@uHI&Yl!QMj",EAJg`K8sl*Yh*:_W/[B?]cYf/7fI,O'l&QnqrqQ3ce)6C!)*(1UjBc?tO3#A`FUbE.>LglG7=cNgBu%)LQCugU0\OTp1Bl$gqd<q\g*nj)gXF=1!mIG>Z\m9MH5d42#r:n]Cj2>FKAE,kqa$6!$)/tE&e%a(KR*KL-aE7FTukE9d('a8n65>Y;JJ!#W\dnL%Ji@:CfjhtG(0PZMf871:L>G6OFE/iG?aa56$KA%)M9"PN>h=Sa:#p+nV*O`E[=@mp(hYQ,D7#`<`3^k1>EbU?3=gtZskE%6dH;kent8gIttUg(qc8!C`*k'.un9GN@H5E<Fq#QNA)d&c3NM;B/9_L!_E%A5MbC,cCRCO`:"s91#lV69j/-<d"lTh&@)a#9XG)>ZfaE0WSd!4%%.$M%2U/Q[;%3rMd>VSH4O:[.TZ1G5uq(f`ZU1kZXt?NM7%_XU#_\)kp%eaiJD7GG'Ei\CrQ047Zasb^`K6<]*:<Rrb;sG;EIpji*pT2Hd"A1/q.LF:srH&pf8gqCbj,dLmgSCY\Y7HH/8naQ"C/eGS-PWRJ5"r6NO\24t]/HNhsjsrK20K(ePRAVo60B[A[+P7^lj4G0j(`[4K6g+XA+VF@D:lY,8Q#AQL)XWnd8$CKLm:-8F"UKP1c5S9)u1c19+2VJ;l0F"pY<7ZBCgO'qP/Q8S9I^lLf#!$5P=f(qZ<]k8;+iO1@MNG0M!)]6/a#Q6o%bF4/]*Q,6<;X!?gM=gEhN'MEfD.+Z*"ZNU<+cKZCC7:FmpO$`\,q$hS5qu"1B2K*9;i@9M\:#+3d$MV*94;R8ojY\X_!)Dho:+.>3YLh!EU$NqV[Y&Zb3!oS<B(5+=As4:&abSojM9R;)hA-k29j@4lVgV3p<uY$OC_CJH&(IsRDq*R\DAZ;@!UmGB87uWU9pp2j_Jnd@r\!e]4kES*Fi-;#Nlu$'+`q+[crGq>eF8I.,Bdn$e"6T(!9YZ[YgZlk2+s]aRjU6%cbZFUU3r0Pq]:IL/%2:[6gCmZC+TbTiQZ1G*+P_2tuF3ATi\apj`dHg"K`GYhSMY/9mtJ;21?WA.YXXnjX%.Lk;fE?:ac<N&h?t0\$`0YTLWrdJ@/Y?[tV(qZj18^rBs-2o[cUlr\%3S5#?dHSQZW]^/d_SIGPki?I*!!%YrjDS"E\1M4(41fHYG:qPtqeY)XrITKH-_U=GSU6tY)3GpgU1Yi<hf9/?R_4`qk+bKK:R(^A:i9J3T=n5f)1b(_"L]u,^-O-5_>k%^9-iY66W/e)$5_dAi_K/uLVVlpLcp6Gs9!)8$I@GFFJIFN@kc0LB_N)a$\Vm`qXM4pKN,UP&lf"6eR>u5K%e\kPj9CHu`^7#NX0gQgJhG'1k0>Z?4jX)06<#t4i5&VZ"Z5Z<Xf[0i4fcoWh'3u7l.pe#),`BQjR;HFk<BWd&^"\TH$WBR@JHn'X!MthA-]NFTulbQ(;SIMDae[K~>endstream
+endobj
+22 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1779
+>>
+stream
+GauHLgQ(#H'R\fA3,`pI>Ba3_:__!Y8<L@FY1p\_KpHDA=ku\BG4tAd,^nF,@jbHT=MS+^jPb(?SDfTYo'kh3cb(HJ3@":#:OYR8"o48odHj$0RGIdfj.rrHV<"G/(T4cT\FUoUrV<=ffYbKYF/Do64S<\O2^R;9C]c"ZX<V?3E)&BP&oUB;jFp_Ji+f%0V4QU`6(+rClsr@[dHGLLG$NJ]-LWHkGH;HPrB8Chdd.2Zo6=`33,'5J8!?0A-)^NOp`J/;If'lf,sgGl+9BfL6?s8[kS<oM`pUPMa:IZMS6u^gN%tp13/p6h_B*C_.p#=rQie]Yrt>MARC1k[iF0Gboo_-uS03Yt+)qptigTpcAL"-DLd/rHKfdMMH2a0r%6i1t[02m2)Grl8O3qfCnd4&)aU&gG"1=,e46fkJUI%MCGD^^cV4t-/;bjE2A^a8f3_gD'jh1EMS-LuIii<[fTk"ZV;UehB3HVj7$+-9$<D-78LG!2s?6BQH_\@JO'JtD>>c`3:]1$EY\eQ9m_X2,e+b`hQ%fP8TRb2MJQF12mSlf:F>4;uXmZO/-H8RkSOE:`KcOj,"dKSE4p+2*q0_J=#Ik]uGpJU9\>pC/1Mc9Xj]Y/'[[Scr0-(p)Frhhg00D/n:U?j-qrmY[m"Z]IoVkcn\66WV9CE;Rs6b\muZU&`l/("\0k0WM`?g,UB^*8-]8jR3NK=^qCDHAm27FhgtfVE;8D'ts+BaRRINigGE*M](*`R:8f1hQuB%tUrtqC),1'UM_JMb_D+GgA>P$f9jT0`.3L/K^RL]\9Aj1O&Jd]a27+d8/Y_bi9]Shi?X=iZm&kn3"`g)@s3M]2c2bR@ZA1)C]<_7Wc9ugoA)*)qjHVQKHF!LB#c(9X[mCA1(1XXM/6A;4Ln9]RK*fITn!b]mNj%I+5DR5S)=p6lVe_"j8bqgN.%_o<%h+)L9)JYL!?:fJU@DR;PR)0#HnD?R"%pY"%]7U([-a87aj5H0A]!%j][*"[A/mTPZ;#<ocqsY4_2(cF<Q/RQe_"6e9C)dk3?pR=BeJE#N&Bj'-COCB1il:;)08MM@6SnJj3Mi^ILgJN`Ys8p":02(dY5ir9KO%/`GajF"'O$Di'O*-t]LARD+P2pARQ\T_nm6IU.C93u"\@&;<#nKP3gDZVRU]VBiQT_;i>)Tik>kteL[aSSH[SM$?PT*'`q&Rg7s',0?;5!aMk=T"'EjJ@NB)oe/.kOH.'^>[/DC_SL;:i=p@3_#LOoMp,)MZnDEe`b!o/INeg2_Ep1m]8K6c+^2jd'`)k733Oak1Sh[Z$(`#+mh]0m10lNb</"Y!bRf&E=A4C*+[H0R31+p7oElDWPEgOim@&5G7W!ipa:Vk&H(":k&BY*+j.tO)/)Gme'DOte)\/)m.0Xeds\'"mTE+P(<_`4JuR;5@BqT[F3NI/e"I_'kXD)\P@4Trl*/QN/1%@oP+hfaXPb*[hO*RtGMSE()P7UF%sX.'SsH+bf0./X."T=NO<B""4`u5&#'`\%_#bWd.(A?.$QBA+981g^n<So4]F)f#3MtDk/\82E&(B=-ihtWYfA`J1KPGq<T,BG?>J+_9Kin%HlWE\^mS><e!-]B<jml;W5EBPiA4'bE(jU\_a!?Wr.Gf42-?*=4[d<Ol0a<$MQhsAogNOQ5l(<g"dQ\>/,%m6RcE=)9Rf]1-D4/_Yp`(fUhd5RWCm"^5N<mT%ag[FNC[rb]FOoLP?;\FG[;#I1,3hk,RM-;=p"(rB[>\cd<*uAPiLce";g%<d5<rq^D?~>endstream
+endobj
+23 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1729
+>>
+stream
+GauHL95iiK&AI=/bgA!^=\m5X('V:]8M;NSDN4A<$SBa\'2$c;<4q'p^I(n>Pf0in`#Ai`Ck`qTbkK@T!VlF+f[%25pc+&NAH5"%o-FOE(W6.X0'6eRcb*E?B/B$hWLqE(RGfe`L+e%J<KR!c1!7-XP`SQ@I+fY^r]+`tVI!^WB!"$GR`;<k"Y]SE/.D(5UrjWt+D@%G@`-.-:n&(ert2E5K[1i\8m5r'RAbRcq(9g?2)>%6UXYc%@F@5b9l;@QHe\QiS$r3lGYoB6?AM@loq!QR,,9Gj6#(M6>_WeXc583NQ&jqKa%%nCUEE#F@!#6\ZiDZr=V7F0K)`_B"ag4/13sKD9`9&KUSol+P5n%Jka90.R#n%QeYFR'6B0Vf2E\IcO#ee=]DgHZ`gkPG@mJ/KaMJo7b=7!&I)YM&LaD,VX?"gE!kl(sYF/^J'TJssXTDP&Rc\o)P)>]/@h97[C/2Qj74TL??4"`fe&'kCm5.O4k4=WC^[&EM88\]R,0qo=pjaggq+A]Z2.u,Te^V!g`p;hf8Y#M<mBY]>+Wd<'`VBTc*deUNP0"@/Wr"08JH]<dM$qS&A6Q>)AdF&4fEjn.^B0*b/Ti,Ed1YIb0\GulhqWjp:`00!*g;Vlm3N":476?pYYrcJU[C+iD!/&$QmHITT5DF:-+[Be--\A/nu7T[_^">)=@u3#Ri"X^$!FKiaGj[KXG+;kEj>Vj!fIScO_5"l"ZA*GN?:3sRDNl7b6DmqhjQ>F<<6h\)IC3WE"iQcP2A,Se:P#S1VhNdflHaSO7,agIB4E^8(X8IYau\cD?[)d-2lPj_OXm8'_/*5K-kYgGKr+6\)-!M\_b[!^3WS,TNs^1HA'eU'_blaCcTk)"\.)2/MRc5;USdn0RG&h)$IteK'Ybfg`S,S`5Lg2A*a?TW%DlodmLBAR2`$-?U0'l3roMKBE6p0Du,#'4kes4T)g/crZg;*N*;FVN@HM=gV?sq(rgBO:8[U=]%=r5/h5*8%FZ7pHYqVXbK)ps`Tc`"U%Cc1kYe15'RV$Di[B,faAGp/9;A$2kA[G,b!T^>MAei#PK8cY855I6YNWIh^-1*0OqQ57R1kCO3q=IFr^d_V9=pRG2nZ)F-'b9aL@IT)QL()4j^:OU/<+t@m=h4PMP,K6>8'-oQV+^AR(S#&OKr<\MM:>aS6go##J]"Sdh]Cn1A],7Jmckr9JVA,5rA8l0aKUuqHP!4*cJDYrOk9i)'9e'NM>lb)tkEI>:q-2PW?Ad^<rVp8&2L>r@noNH#1RaR#LBUj?%N5F\N/X1@4C6cED5TFl@jFQ<Fklqn/7^.EHM)0JgQG%E!$8pAE,F1*"Dg-k2@C9okGkHd;Y9bPo^f'tU8_k.qcY2[q[1VJ4)n/"b,M40B+#duAkEoc10,\.&92Ob6k@"!JY]Y9!D@:e-2"F(d54:j-EDU2*#G<<\M=)6EFA6+`*YE/*oLeG_"t-B,^mQ2;3DbN=H[6dCT2rej`66qUW80VHEVMsBa#)jrFFUhU2(Wll5Y/keDLgNF/9"3/t:K*\"=?1]2T_r!U[^BTbFDQ7I%pmH@H2Lu(=n<Mp:;i.YI%(IbR,u,nlqeAi(c,.[Bk04-?5ScabP;&!>R=4C@n]g^8-8\CP!'!"lR8eJ4M]bbiPNjpPQW+D7"6ST08E>TVa9]g$Q*4lKnDj(I&>U]6M:Lu&DnYT+q>L/%ZaXM[?FFnYNJj=nCtIV3#QO/0[K~>endstream
+endobj
+24 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1539
+>>
+stream
+Gau0D>Ar7S'RnB3302o-lRkiIL&l)!$j6(Ieo(2e(Ik-9[Zp!4P10F-*a\3SNap&6L&`QrOG=pmn(]<54T+gDDdELX>C_(`K-.m<$%Cr'YdfHQ(H;BM3,._j.6)&$`@6fb5'[`fqWk#1fY`PSk00KOGin%b+#qJ_XMMi3Q,Ut9F2D(EGVa:_0?f"J7q8r5W<L!>V9K4LP9HA--N=Y6cl2lpH!A^s+Uo+8:U'TqMk?9Zm_UYtdP-J=Ma*:<KqpO',G&U6Itemc![g5Gn9r?A#D&eWQf'4u]R(HF+.CY<JOLYMR>4/"7\Lp_+^jk+X-Q(<)oB,>D@4fgpbrHkcj8F=nC`U^o9(ps@mLaH4rR(U)dcfh8Pue9h'up_eOq:)RXl2cr66.-'<9gCq*tZDZ%kFap]\XCFLIsse*dh?p)nGi7CD]RbR(ZfL5PZG"/AX)\B))CQ<8D?NG.X8.!L33E*=!P^;XflR?FS;/k&tZ^`$D9<."_R?k%DB'_I5iaXAg<dfVZ%a7G45/cQ0R-nKm]pen`Es/8_+/,'WQ9G'_>_1Q-g>466a^*'+cH,DO2\'3I2BK8Kb[ed4$;$5LN:l>rS7FfSe7uTEc:5TVnMpXl@o'3a?)EU*tPLJ4(EbL9p0Y(\@:Su='7,mQF^H;V,$SKHrk&<M@8r&SJTE=s!J[&s$U%J^/-)1eAHei@1Xqd$84$CB3F;+au!.`nr)B#Z6d:G.Xqdf?3d:Ad%j=jiZ?$\Ml3D*'pni%sFb"#K@p(A<JlO$&T^>A'YAi.mmVNY\a+nG%2j3hib;)_6&[qG=``)FVY.3t3>+;3PW+*s`@_V'2,ls>r\<FDNLjG[3[oXj@m=!&4QUBj+=0,D3s3JmZEBXq?2C.4t:1dGM[g.HSHTu]-!.q)%JJ(<LXR<^e?XJA:G=CJe%1WR[$5Js)G&!J,rOi]9eZKMJ9aFH\S15.G:(k'_]%ofK:XIPO93L/g3MKk*RqRDqW"XOXJ$i/,3?;l)Q[Cc`](_0Md:._"[FdK'#JJt'gLF:ZS5rVQ%Egl;PZk7oa[?'8sf8?9/g"uHqo$16p=-!t&DVsVmJaGN[*QDl9Mj/5jFNgR-P7i^7CugG;,%oUSD;3oidk*VbB"sE%+Pmq$="-9]8QQ<FO!3@tgTt[73kP5E_p-\P]G.Q\GUn3rQ^g^k6a(lP@WA8Si."T2j4fR?V-gVU(UbMF/]F"sics$nH@.k="iQdid&b??kSGH-BlTA:Sg&Mj>+K8"GE-q,7Kpg1fj8E;+P$rNr'jh[@X>L='9nM]_O2U@J:1bh#n0%FXcpF\,CQ::VUOR[POCI>c:YK%1c:#6:69!fhFn5H/B4(:/T0kd8"#*]n"VXeXed$4BjaHKE$D^im*,*p%u4K\s"7;eg:?-G)Jbe"]"l&S_0RCAm=qt&E/p@!,[B0rd9CBd&KWAb;9226A698?<?L,TGh;t@6^GnGmMp!;H*h9JOPY>4;`&l%7(&>,2jGZAW\RY6^<[7`n[*PDb[9'jJJl[7pD_W8$>)1W3[3AW!$(F+3<~>endstream
+endobj
+25 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1797
+>>
+stream
+Gatm<gMYb8&:O:SbbJ?D]S`H9'Et!`.1uccCCBN&?^BbFg6gqV];/?tl[*eH8T`sZM'N30/RIR[k005:IIcmR\,U(edE<iHDg_*X>->r=3AXjQVq9+mO&sUNnra/:MqEq'3%"F^c04T)X,8)32hm/FVimdbO/)YNd/?s_0QnXM1$QqCiHuDfF)kl!QimGMSQ3'U&,:QLenbmX$)/k_ni&';Y38rT[3`!ped,FW5g'\Fr6a.:4rD;b+q13^_maI,Bed-r:ZQW-Ih"tg0R!SKJFf?qs#:jV674[g9KJ"D>(Ar'cf@Q2Z*#p3B_++5e4=&ECS$BJaG=aHX7OF&(TurC@dj.LO-/tra2X,9-@iuD7jmM?$YP<O6aW57rX9CfjIHU/;T7;kr=];g=kE)2nG'4PpYs.#7Y5k#q(NGV)SUXRAU,^S\')^tO%t/l%^"l..e<#J0AXIPIR]KYP7qqAb4W>2(lDs(jVk(H(aQ#q!)>&Db[7E9W7J<j>,7l(c#*sZaM/SM[p51"%$4l4aahu5,9r?J,A?rFYJL#q(QBaf$Vj39`%61.6YU;C6*]**\j9sJ?8@:BD-1B6boSk7eV[uKYtR`kWFB):[f&auapCJhJh($cI%SW9[EV/jnXmM\"kALb]8/=DE2FS;'hA4)MWcT:68scZW,BkKbt'jijDs@pj6P!ua[T66dI8sWWWq%O]sWu-U?'F$p3#b[3N2A;"uLUZ^+ds')AI.kqtStc7F#G(9;YuM=Z'SQ_/n*ZPASiHAtCgcj0BCNPTuGejl"#WH]rdEo>Jip$d.X9UA.bQn/g[=dPKR\6KC$pct/.M6*LUBnIj/D0Q-eB%\a5;LJa/W^?D+jf/V\[@U'.DhtXoQJ"Rs$.f,Sj>Oc<LD..$.RL10#+3H.&?&YEM!"p='(p@Q`;o?h$De:9kH#TYAJ7>86e!+DS+J!LHZF4EZs0n:4-e"X:*ELdGa=PaLrRFsg2tuOB_P.N''#bH9P_7PW'JFW!^Q)O7"=?dg#'(s[2R?FSEXa['WL$/bXj<qCC(6+)lih%E`HA'nf>(0LDp8Te5fkKfe3<8`0M5d8^oTJl;OSDh!2pmA06+NQfceUY(Q-LjCP\XPB=bji!KeA%gHA,%2.D7>*4kGl^aW"tZ/1QjCL$\W%^E[cCrtcd91I)L`>]#)fR]sqZj-R4=cY-G@=7$o0'#%KCn;[S3/UJeDN2R89nU^9%Ziu?p4_sINbk1YQ<]JZ(W7--mcO61RF&3B9ZQ*"OqIK'Y(:fp@gcaS]]g>*nSVscI]52TROg-BZ,C5ah$c4g_Sg5:67\W`drF!([LK&g(V!;ISK6pK`rh_loEb)Q]g.@>_JF!*a0p`n.9S0PjtF`!*m?9=X8=eD'LjhlmooOG[E9C)M*6emQ,]<R"tI'oO-`\`QCjsmID!np5Ab7lh(oD*oc(Ddo4bUZgt_9LEpB+E7FnH=PNhHn88uo21%':Qj3C;`Rm%YO]OPZI[0lAWQoOoK1\Q1traKlAB&7Ie-aYe?'XM>FTi%VZ@U^;EUi[[l+PdD(B`q;oGVMVDhGRNbJ=>GH!DGpF4d[0[,'`roa#CBeHi$^)(=MW5/C1#h)Y<+g>-bE*'qV1GAR7a3RgX*55^20lKB[$GgirQ4h.k.t;FlO.@($W!*qipC`+heg"4b`Rhf"h$\*/7_qjl>J0mlRi$Kg4,M"@WHb.Jm,l;YEgr[7:bl\nOC`^[[lS4oNW-Qudb=7"/D[4KH-@D70"K*Y58pa7h:+*YZP"@,Q'Q`\.dh3Ssop@'ZrfW1WGR]cVp:Pc2D~>endstream
+endobj
+26 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 1880
+>>
+stream
+Gau`TgMYb8&:O:SbbJ(S'X+6e'Eqa>/daFP@LMCXJRCp,Ul@sK]"=3/IXPjpeA[S\7>cW2J14?cbF(A3=U*g5?f:qH'u7!tkhcLSKJ8i[&:6-jre0/u(]Rfd_o0lUi!iUL):CC;Dgi,(^L,KPq".sYGlsuf)$G&(?V7i?kS0n#_A]aUSJMape/s2Wqb\,`FD\GN.169L;bh1sGStd*615mm>1E%Jj\:H:'iq@2%?/$:kU4rl/Jt>@0FF!qiK%H*ODR/[M(l'(+-<0Q(jI2-J[,'>+(XG=&>`fuJ/:[HR)M/Tq%0mtr_3Ya`ot9qiUqfLK+D'T!MV3>Z*KU;#o\e<FH5LO%sqUkL;T8mcV-bI^^>[X9fS>6)cA?U65[\0:R>T/7fg4/^"/&;0MK;#mGC;NZ!cLf_jJB[1en)b:FRT@PNu:$fQT*aTA.OWQ<9%PgMahH!0O?Ml+?i)JYQ&>D<q>F]Z?5;%Gi,j"W@r3SLH/j6OMba<2-#rc7?+TXd\J_";ijZQjZ"Ii4[X->7_/c9/1;d?Jlgh_LSXX"tBNbe6(n0Lp=JFLn+%@:.S/>,oZ4P[.&J=\SfCmZ=7Fk[<c#JP,b$o>ioe&`MM&U](\d>Eaiq5jtk:V%AGE(,K8(+J'GG!GI_$TkWT$`Ku?K+P]d6eAZQ9HThN%F9cKc6o*u[+o&D%#qinuI.Fs_T.W7Bn$anEJ.+a<T`Bm=*]cY<jP%84*iQ-XUbZ.*&L:R&WoYZ>Y+/n$A$J+pcQM22@Zd"l'6bV6/+q8aWdMT4<3k5$$Hb_i<Spbc/A7_=^^iq\'[^"fliGA\o]T!,JQ!d!.kgl]rfW[f*NK.e6_P/P=>`c#5;!@P/cf%KhG?%VJ?JUWcBQbIEK3a?%-hrUE[1eBK7s\rg>]/>F3D=E.SJJ)A*N#1GB+qJ^o%A9;]:0+$AT&$*;&"d`edq^T\"GR6U4@M<QDb6,Y+q9*,=&*qBqV1VJ@_TA<\C>8WE`ssD4t\A[m=M`CB:uG-W4#_0;cI6q?Ub+EZ2=[*;Moo%Q?LB(rolPm6K1reGX=hOD&SOOQ6g85'GH(3*4g#-!Wfe#KDYC"=dDE9-f`ZFhN'W>fgHf4V/.!$e!MN%F2gU2g5OdA"\+j8ZLNeM5_UYWk)GeR.(SWb?.[u0rYe,V7G*i*G1PLZiYUWbk);ts.8g!Ue/b9do&9gJW-G$QKeZ"cns#in/+-!FrHn0);nc'\[J(J>\"5lEjC?r9hiCGeId=pEt;]gV3EC*%DkHb"%uZ/IJ4<PNe"Q*ppn^gf.FEI2P<TVGt`3J_%3'(=5@D?K#"dBfO27to$]qOJ.52NKqZS#m`BB;8"8Iu)kJ.U)KTD#C9<LH?05<e]HG+?YF0IFdfB`ZK22Yhmb\ub1]?`-HMW*#e[fGmhjec!#@BXV[,Lf(*;Jk[Ye0jNbW'bcV4<29H*5<\'r<`OhFg5BieV:j-9lJ'GOs02.nU_7?+DYs)"(TE-&n2q,N!UuRn5st^_&Y@(nBp)'mjo]:?0VS97%EB*]'WD%J/3KD32Ce^rTF+7d1X[?L=@[@R&L,=V+pZa4gqiD-X^^\]Wrug<J0g59SQ[:eR(J"A'0EL;*:k]b%"k#h_j_U4"g:p!RQ\1]hB[;Zf9j8S@NCb2Q]<mbD'(en(aWNP@.L$:PE#<Yk1]ZH`B4_Zalge:OX'#inYpAGn$5Z@/pS=Hb.g8(-[f[iLnR0oKr80.!%"n%$aA,^A/ZqpoD,7m,X8S1h`_XQH$o\(\>.I\L&u]%p)BoDG>uXkkW:mX]I@UoaZV4'g*b0m$qZM"n!i9.MMtQ*:&oc.gKI+#L@`o.c2qk$1+.P!4j?Dc[HOZORFSaoh<DXE2'sI>mo5g/:>LqapoBrWcJ.<#b~>endstream
+endobj
+xref
+0 27
+0000000000 65535 f 
+0000000061 00000 n 
+0000000123 00000 n 
+0000000230 00000 n 
+0000000342 00000 n 
+0000000537 00000 n 
+0000000642 00000 n 
+0000000837 00000 n 
+0000001032 00000 n 
+0000001227 00000 n 
+0000001422 00000 n 
+0000001618 00000 n 
+0000001814 00000 n 
+0000002010 00000 n 
+0000002088 00000 n 
+0000002284 00000 n 
+0000002354 00000 n 
+0000002645 00000 n 
+0000002757 00000 n 
+0000003275 00000 n 
+0000005417 00000 n 
+0000007503 00000 n 
+0000009412 00000 n 
+0000011283 00000 n 
+0000013104 00000 n 
+0000014735 00000 n 
+0000016624 00000 n 
+trailer
+<<
+/ID 
+[<3cd02fadc6e66e7713d89d0ae3aafcab><3cd02fadc6e66e7713d89d0ae3aafcab>]
+% ReportLab generated PDF document -- digest (opensource)
+
+/Info 16 0 R
+/Root 15 0 R
+/Size 27
+>>
+startxref
+18596
+%%EOF


### PR DESCRIPTION
### Motivation

- Provide a complete, page-by-page site guide plus separate API and Discord bot command references as downloadable PDFs and retained Markdown sources so the project has an authoritative, searchable documentation bundle.

### Description

- Added Markdown sources `documentation/SITE_GUIDE.md`, `documentation/API_REFERENCE.md`, and `documentation/DISCORD_BOT_COMMANDS.md` and a documentation index at `documentation/README.md`.
- Generated and added the rendered PDFs `documentation/Walter_Site_Guide.pdf`, `documentation/Walter_API_Reference.pdf`, and `documentation/Walter_Discord_Bot_Commands.pdf` alongside their sources.
- The docs cover every visible site page and admin routes, all `/api/v1` endpoints (authentication, schemas, examples), and all nine Discord slash commands with parameters and troubleshooting.
- Changes were committed on the current branch with message `docs: add complete Walter PDF guides`.

### Testing

- Generated PDFs with `python /tmp/render_pdfs.py` and verified they were produced successfully and readable with `pypdf` (file pages, metadata, and extractable text checks passed).
- Ran an AST-based coverage check script that confirmed documented `/api/v1` routes and all bot commands are present in the Markdown sources (`no missing API routes or bot commands`).
- Ran the test suite scoped to the app tests with `pytest -q tests`, which completed with `22 passed, 111 skipped`.
- Note: a prior full `pytest -q` run reported failures (42 failed) originating from vendored `walter-bot` async tests that require an async pytest plugin (e.g. `pytest-asyncio`) in this environment; those failures are unrelated to the documentation files added.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a824b5fc9c083209e3d110203f6e8d1)

## Summary by Sourcery

Add a comprehensive documentation bundle covering the Walter web app, HTTP API, and Discord bot commands, with an index for the new docs.

Documentation:
- Introduce a complete site guide documenting all visible pages, workflows, and admin routes.
- Add a detailed HTTP API reference for authentication, schemas, and all `/api/v1` endpoints.
- Document all Discord bot slash commands, parameters, workflows, and troubleshooting.
- Provide a documentation index page that links to the site, API, and Discord bot guides and notes their PDF counterparts.