### PR TITLE
Add multi-cube ballot controls and browser fingerprint bans

### DIFF
--- a/app/app.py
+++ b/app/app.py
@@ -433,6 +433,7 @@ def create_app():
             PendingRegistration,
             BadLoginAttempt,
             BlacklistedIP,
+            BlacklistedFingerprint,
             PasswordResetToken,
             SiteSetting,
             RegistrationInvite,
@@ -505,6 +506,7 @@ def create_app():
 
         if table_names:
             BlacklistedIP.__table__.create(bind=db.engine, checkfirst=True)
+            BlacklistedFingerprint.__table__.create(bind=db.engine, checkfirst=True)
             PasswordResetToken.__table__.create(bind=db.engine, checkfirst=True)
             SiteSetting.__table__.create(bind=db.engine, checkfirst=True)
             RegistrationInvite.__table__.create(bind=db.engine, checkfirst=True)
@@ -647,6 +649,7 @@ def create_app():
         LeagueCubeDiscordPoll,
         BadLoginAttempt,
         BlacklistedIP,
+        BlacklistedFingerprint,
         PasswordResetToken,
         SiteSetting,
         RegistrationInvite,
@@ -947,6 +950,28 @@ def create_app():
         raw = f'{user_agent}|{accept_language}'
         return hashlib.sha256(raw.encode()).hexdigest()[:16]
 
+    def _blacklist_client(ip_address, fingerprint, reason, created_by_id=None):
+        ip_entry = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address).first()
+        if not ip_entry:
+            ip_entry = BlacklistedIP(ip_address=ip_address, created_by_id=created_by_id)
+            db.session.add(ip_entry)
+        ip_entry.is_active = True
+        ip_entry.reason = reason
+        if created_by_id and not ip_entry.created_by_id:
+            ip_entry.created_by_id = created_by_id
+
+        if fingerprint:
+            fingerprint_entry = db.session.query(BlacklistedFingerprint).filter_by(fingerprint=fingerprint).first()
+            if not fingerprint_entry:
+                fingerprint_entry = BlacklistedFingerprint(fingerprint=fingerprint, created_by_id=created_by_id)
+                db.session.add(fingerprint_entry)
+            fingerprint_entry.source_ip = ip_address
+            fingerprint_entry.reason = reason
+            fingerprint_entry.is_active = True
+            if created_by_id and not fingerprint_entry.created_by_id:
+                fingerprint_entry.created_by_id = created_by_id
+        return ip_entry
+
     def _split_name(name):
         parts = (name or '').strip().split(None, 1)
         return (parts[0] if parts else '', parts[1] if len(parts) > 1 else '')
@@ -1156,17 +1181,15 @@ def create_app():
         if ip_attempts >= threshold or admin_lockout_reached:
             existing = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address).first()
             if not existing:
-                existing = BlacklistedIP(ip_address=ip_address)
-                db.session.add(existing)
                 app.logger.info('Creating IP blacklist entry after bad logins: ip=%s attempts=%s', ip_address, ip_attempts)
-            if not existing.is_active:
-                existing.is_active = True
+            elif not existing.is_active:
                 app.logger.info('Reactivating IP blacklist entry after bad logins: ip=%s attempts=%s', ip_address, ip_attempts)
-            existing.reason = (
+            reason = (
                 f'Admin account bad login threshold reached ({user.failed_login_count} attempts)'
                 if admin_lockout_reached
                 else f'{ip_attempts} bad login attempts'
             )
+            _blacklist_client(ip_address, _browser_fingerprint(), reason)
             db.session.commit()
             app.logger.warning('IP address %s blacklisted after %s bad login attempts', ip_address, ip_attempts)
             site_log_events.append(('ip_blacklist', 'success', f'ip={ip_address}; attempts={ip_attempts}'))
@@ -3045,10 +3068,12 @@ def create_app():
     @app.before_request
     def block_blacklisted_ip():
         ip_address = _client_ip()
-        blocked = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address, is_active=True).first()
-        if blocked:
-            app.logger.warning('Blocked blacklisted IP address %s from %s', ip_address, request.path)
-            log_site('blocked_blacklisted_ip', 'failure', f'ip={ip_address}; path={request.path}')
+        fingerprint = _browser_fingerprint()
+        blocked_ip = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address, is_active=True).first()
+        blocked_fingerprint = db.session.query(BlacklistedFingerprint).filter_by(fingerprint=fingerprint, is_active=True).first()
+        if blocked_ip or blocked_fingerprint:
+            app.logger.warning('Blocked blacklisted client ip=%s fingerprint=%s from %s', ip_address, fingerprint, request.path)
+            log_site('blocked_blacklisted_client', 'failure', f'ip={ip_address}; fingerprint={fingerprint}; path={request.path}')
             abort(403)
 
     def parse_datetime_local(value):
@@ -5252,22 +5277,38 @@ def create_app():
         if not require_league_member_or_manager(league):
             abort(403)
         if request.method == 'POST':
-            if request.form.get('action') == 'add_owned_cube':
-                cube_id = request.form.get('cube_id', '')
-                play_date_id = request.form.get('play_date_id', '')
-                cube = db.session.get(LeagueCube, int(cube_id)) if cube_id.isdigit() else None
-                play_date = db.session.get(LeaguePlayDate, int(play_date_id)) if play_date_id.isdigit() else None
-                if not cube or cube.league_id != league.id or cube.owner_id != current_user.id:
+            if request.form.get('action') in {'add_owned_cube', 'add_owned_cubes', 'remove_owned_cubes'}:
+                action = request.form.get('action')
+                is_add = action in {'add_owned_cube', 'add_owned_cubes'}
+                raw_cube_ids = request.form.getlist('cube_ids') or request.form.getlist('cube_id')
+                raw_play_date_ids = request.form.getlist('play_date_ids') or request.form.getlist('play_date_id')
+                cube_ids = {int(value) for value in raw_cube_ids if value.isdigit()}
+                play_date_ids = {int(value) for value in raw_play_date_ids if value.isdigit()}
+                cubes = db.session.query(LeagueCube).filter(LeagueCube.id.in_(cube_ids)).all() if cube_ids else []
+                play_dates = db.session.query(LeaguePlayDate).filter(LeaguePlayDate.id.in_(play_date_ids)).all() if play_date_ids else []
+                if not cube_ids or len(cubes) != len(cube_ids) or any(cube.league_id != league.id or cube.owner_id != current_user.id for cube in cubes):
                     abort(403)
-                if not play_date or play_date.league_id != league.id or not play_date.is_active:
-                    flash('Choose an open League Event.', 'error')
-                elif db.session.query(LeaguePlayDateCube).filter_by(play_date_id=play_date.id, cube_id=cube.id).first():
-                    flash('That cube is already on this ballot.', 'info')
-                else:
-                    db.session.add(LeaguePlayDateCube(play_date_id=play_date.id, cube_id=cube.id))
-                    db.session.commit()
-                    log_site('league_owned_cube_add', 'success', f'league_id={league.id}; play_date_id={play_date.id}; cube_id={cube.id}; owner_id={current_user.id}')
+                if not play_date_ids or len(play_dates) != len(play_date_ids) or any(play_date.league_id != league.id or not play_date.is_active for play_date in play_dates):
+                    flash('Choose one or more open League Events.', 'error')
+                    return redirect(url_for('league_cube_voting', league_id=league.id))
+                changed = 0
+                for play_date in play_dates:
+                    for cube in cubes:
+                        link = db.session.query(LeaguePlayDateCube).filter_by(play_date_id=play_date.id, cube_id=cube.id).first()
+                        if is_add and not link:
+                            db.session.add(LeaguePlayDateCube(play_date_id=play_date.id, cube_id=cube.id))
+                            changed += 1
+                        elif not is_add and link:
+                            db.session.query(LeagueCubeVote).filter_by(play_date_id=play_date.id, cube_id=cube.id).delete()
+                            db.session.delete(link)
+                            changed += 1
+                db.session.commit()
+                verb = 'added to' if is_add else 'removed from'
+                log_site(f'league_owned_cube_{"add" if is_add else "remove"}', 'success', f'league_id={league.id}; owner_id={current_user.id}; selections={changed}')
+                if action == 'add_owned_cube' and changed == 1:
                     flash('Your cube was added to the ballot.', 'success')
+                else:
+                    flash(f'{changed} cube ballot selection{"s" if changed != 1 else ""} {verb} the selected ballots.', 'success')
                 return redirect(url_for('league_cube_voting', league_id=league.id))
             for play_date in db.session.query(LeaguePlayDate).filter_by(league_id=league.id, is_active=True).all():
                 available_ids = {link.cube_id for link in play_date.available_cubes}
@@ -5652,7 +5693,8 @@ def create_app():
         require_permission('admin.ip_blacklist')
         log_site('view_ip_blacklist', 'success')
         ips = db.session.query(BlacklistedIP).order_by(BlacklistedIP.created_at.desc()).all()
-        return render_template('admin/ip_blacklist.html', ips=ips)
+        fingerprints = db.session.query(BlacklistedFingerprint).order_by(BlacklistedFingerprint.created_at.desc()).all()
+        return render_template('admin/ip_blacklist.html', ips=ips, fingerprints=fingerprints)
 
     @app.route('/admin/security/ip-blacklist/<int:ip_id>/toggle', methods=['POST'])
     def admin_toggle_ip_blacklist(ip_id):
@@ -5661,6 +5703,7 @@ def create_app():
         if not item:
             abort(404)
         item.is_active = not item.is_active
+        db.session.query(BlacklistedFingerprint).filter_by(source_ip=item.ip_address).update({'is_active': item.is_active})
         db.session.commit()
         log_site('ip_blacklist_toggle', 'success', f'ip={item.ip_address}; active={item.is_active}')
         flash('IP blacklist entry updated.', 'success')
@@ -5695,17 +5738,12 @@ def create_app():
     def admin_blacklist_connection():
         require_permission('admin.ip_blacklist')
         ip_address = (request.form.get('ip_address') or '').strip()
+        fingerprint = (request.form.get('fingerprint') or '').strip()
         if not ip_address:
             flash('Missing IP address.', 'error')
             return redirect(url_for('admin_current_connections'))
-        item = db.session.query(BlacklistedIP).filter_by(ip_address=ip_address).first()
-        if not item:
-            item = BlacklistedIP(ip_address=ip_address, created_by_id=current_user.id)
-            db.session.add(item)
-        item.is_active = True
-        item.reason = request.form.get('reason') or 'Blacklisted from current connections'
-        if not item.created_by_id:
-            item.created_by_id = current_user.id
+        reason = request.form.get('reason') or 'Blacklisted from current connections'
+        _blacklist_client(ip_address, fingerprint, reason, current_user.id)
         db.session.commit()
         log_site('ip_blacklist_connection', 'success', f'ip={ip_address}')
         flash(f'{ip_address} has been blacklisted.', 'success')

--- a/app/models.py
+++ b/app/models.py
@@ -532,6 +532,18 @@ class BlacklistedIP(db.Model):
     created_by = db.relationship('User')
 
 
+class BlacklistedFingerprint(db.Model):
+    id = db.Column(db.Integer, primary_key=True)
+    fingerprint = db.Column(db.String(64), unique=True, nullable=False)
+    source_ip = db.Column(db.String(64), nullable=True)
+    reason = db.Column(db.Text, nullable=True)
+    created_at = db.Column(db.DateTime, default=utc_now)
+    created_by_id = db.Column(db.Integer, db.ForeignKey('user.id'), nullable=True)
+    is_active = db.Column(db.Boolean, nullable=False, default=True)
+
+    created_by = db.relationship('User')
+
+
 class SiteSetting(db.Model):
     key = db.Column(db.String(100), primary_key=True)
     value = db.Column(db.Text, nullable=False, default='')

--- a/app/templates/admin/current_connections.html
+++ b/app/templates/admin/current_connections.html
@@ -22,6 +22,7 @@
         <td>
           <form method="post" action="{{ url_for('admin_blacklist_connection') }}" onsubmit="return confirm('Blacklist {{ connection.ip_address }}?');">
             <input type="hidden" name="ip_address" value="{{ connection.ip_address }}">
+            <input type="hidden" name="fingerprint" value="{{ connection.fingerprint }}">
             <button class="btn danger" type="submit">Blacklist</button>
           </form>
         </td>

--- a/app/templates/admin/ip_blacklist.html
+++ b/app/templates/admin/ip_blacklist.html
@@ -27,4 +27,22 @@
   <tr><td colspan="6">No blacklisted IP addresses.</td></tr>
   {% endfor %}
 </table>
+<section class="panel-card">
+  <div class="section-heading"><div><h3>Banned browser fingerprints</h3><p>Fingerprints are banned with their associated IP so the same browser remains blocked if its address changes.</p></div></div>
+  <table>
+    <tr><th>Fingerprint</th><th>Associated IP</th><th>Status</th><th>Reason</th><th>Created</th><th>Created By</th></tr>
+    {% for item in fingerprints %}
+    <tr>
+      <td><code>{{ item.fingerprint }}</code></td>
+      <td>{{ item.source_ip or '' }}</td>
+      <td>{{ 'Active' if item.is_active else 'Inactive' }}</td>
+      <td>{{ item.reason or '' }}</td>
+      <td>{{ item.created_at }}</td>
+      <td>{{ item.created_by.name if item.created_by else '' }}</td>
+    </tr>
+    {% else %}
+    <tr><td colspan="6">No banned browser fingerprints.</td></tr>
+    {% endfor %}
+  </table>
+</section>
 {% endblock %}

--- a/app/templates/admin/league_detail.html
+++ b/app/templates/admin/league_detail.html
@@ -37,7 +37,8 @@
       <input type="url" name="cube_url" placeholder="https://cubecobra.com/cube/overview/..." required>
     </label>
     <label>Cube owner
-      <select name="owner_id">
+      <input type="search" class="select-filter" data-filter-select="new-cube-owner" placeholder="Search owners by name or email...">
+      <select name="owner_id" id="new-cube-owner" size="6">
         <option value="">No owner</option>
         {% for user in users %}<option value="{{ user.id }}">{{ user.name }}{% if user.email %} — {{ user.email }}{% endif %}</option>{% endfor %}
       </select>
@@ -56,9 +57,10 @@
           <input type="hidden" name="action" value="update_cube_owner">
           <input type="hidden" name="cube_id" value="{{ cube.id }}">
           <label>Owner
-            <select name="owner_id">
+            <input type="search" class="select-filter" data-filter-select="cube-owner-{{ cube.id }}" placeholder="Search owners...">
+            <select name="owner_id" id="cube-owner-{{ cube.id }}" size="6">
               <option value="">No owner</option>
-              {% for user in users %}<option value="{{ user.id }}" {% if cube.owner_id == user.id %}selected{% endif %}>{{ user.name }}</option>{% endfor %}
+              {% for user in users %}<option value="{{ user.id }}" {% if cube.owner_id == user.id %}selected{% endif %}>{{ user.name }}{% if user.email %} — {{ user.email }}{% endif %}</option>{% endfor %}
             </select>
           </label>
           <button class="btn ghost" type="submit">Save owner</button>
@@ -223,5 +225,15 @@ if (leaguePlayerSearch && leaguePlayerSelect) {
     });
   });
 }
+document.querySelectorAll('[data-filter-select]').forEach(function(input){
+  const select = document.getElementById(input.dataset.filterSelect);
+  if (!select) return;
+  input.addEventListener('input', function(){
+    const query = input.value.trim().toLowerCase();
+    Array.prototype.forEach.call(select.options, function(option){
+      option.hidden = Boolean(query) && !option.text.toLowerCase().includes(query);
+    });
+  });
+});
 </script>
 {% endblock %}

--- a/app/templates/league_cubes.html
+++ b/app/templates/league_cubes.html
@@ -10,20 +10,22 @@
 
 {% if owned_cubes and play_dates|selectattr('is_active')|list %}
 <section class="panel-card owned-cube-panel">
-  <div class="section-heading"><div><h3>Add one of your cubes</h3><p>As a cube owner, you can add your cube to any open, existing League Event ballot.</p></div></div>
+  <div class="section-heading"><div><h3>Manage your ballot cubes</h3><p>Add or remove multiple owned cubes across multiple open League Event ballots.</p></div></div>
   <form method="post" class="modern-form owner-ballot-form">
-    <input type="hidden" name="action" value="add_owned_cube">
-    <label>Your cube
-      <select name="cube_id" required>
+    <label>Your cubes
+      <select name="cube_ids" multiple size="6" required>
         {% for cube in owned_cubes %}<option value="{{ cube.id }}">{{ cube.title|cube_cobra_title }}</option>{% endfor %}
       </select>
     </label>
-    <label>League Event
-      <select name="play_date_id" required>
+    <label>League Events
+      <select name="play_date_ids" multiple size="6" required>
         {% for play_date in play_dates if play_date.is_active %}<option value="{{ play_date.id }}">{{ play_date.play_date }}</option>{% endfor %}
       </select>
     </label>
-    <button class="btn" type="submit">Add to ballot</button>
+    <div class="form-actions">
+      <button class="btn" type="submit" name="action" value="add_owned_cubes">Add selected</button>
+      <button class="btn danger" type="submit" name="action" value="remove_owned_cubes" onclick="return confirm('Remove the selected cubes from these ballots? Existing votes for those cubes will also be removed.');">Remove selected</button>
+    </div>
   </form>
 </section>
 {% endif %}

--- a/tests/test_leagues.py
+++ b/tests/test_leagues.py
@@ -132,6 +132,44 @@ def test_cube_owner_can_add_owned_cube_to_existing_ballot(client, session):
     assert response.status_code == 403
 
 
+def test_cube_owner_can_multi_add_and_remove_owned_cubes(client, session):
+    owner = _user(session, 'multi-cube-owner@example.com', 'Multi Cube Owner')
+    voter = _user(session, 'multi-cube-voter@example.com', 'Multi Cube Voter')
+    league = League(name='Multi Owner League', is_cube_league=True)
+    session.add(league)
+    session.flush()
+    cubes = [
+        LeagueCube(league_id=league.id, owner_id=owner.id, cube_cobra_url=f'https://cubecobra.com/cube/overview/owned-{number}', title=f'Owned Cube {number}')
+        for number in range(2)
+    ]
+    dates = [
+        LeaguePlayDate(league_id=league.id, play_date=date(2026, 11, number + 1), is_active=True)
+        for number in range(2)
+    ]
+    session.add_all(cubes + dates)
+    session.commit()
+
+    assert client.post('/login', data={'email': owner.email, 'password': 'secret'}).status_code == 302
+    response = client.post(f'/leagues/{league.id}/cubes', data={
+        'action': 'add_owned_cubes',
+        'cube_ids': [str(cube.id) for cube in cubes],
+        'play_date_ids': [str(play_date.id) for play_date in dates],
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    assert session.query(LeaguePlayDateCube).count() == 4
+
+    session.add(LeagueCubeVote(league_id=league.id, play_date_id=dates[0].id, cube_id=cubes[0].id, user_id=voter.id, votes=2))
+    session.commit()
+    response = client.post(f'/leagues/{league.id}/cubes', data={
+        'action': 'remove_owned_cubes',
+        'cube_ids': [str(cube.id) for cube in cubes],
+        'play_date_ids': [str(play_date.id) for play_date in dates],
+    }, follow_redirects=True)
+    assert response.status_code == 200
+    assert session.query(LeaguePlayDateCube).count() == 0
+    assert session.query(LeagueCubeVote).count() == 0
+
+
 def test_admin_can_remove_league_event_ballot_and_votes(client, session):
     admin = _user(session, 'league-event-admin@example.com', 'League Event Admin', 'admin', True)
     player = _user(session, 'league-event-voter@example.com', 'League Event Voter')

--- a/tests/test_users.py
+++ b/tests/test_users.py
@@ -435,6 +435,21 @@ def test_ip_blacklisted_after_ten_bad_logins(client, session, app):
     assert response.status_code == 403
 
 
+def test_ip_ban_also_blocks_browser_fingerprint(client, session, app):
+    from app.models import BlacklistedFingerprint
+
+    app.config['IP_BLACKLIST_ATTEMPTS'] = 1
+    headers = {'User-Agent': 'Fingerprint Test Browser', 'Accept-Language': 'en-Test'}
+    response = client.post('/login', data={'email': 'missing@example.com', 'password': 'wrong'}, headers=headers)
+    assert response.status_code == 200
+    fingerprint = session.query(BlacklistedFingerprint).one()
+    assert fingerprint.is_active
+    assert fingerprint.source_ip == '127.0.0.1'
+
+    response = client.get('/', headers={**headers, 'X-Forwarded-For': '203.0.113.77'})
+    assert response.status_code == 403
+
+
 def test_admin_can_view_bad_login_audit_and_export_blacklist(client, session):
     from app.models import BadLoginAttempt, BlacklistedIP
     admin_role = session.query(Role).filter_by(name='admin').one()


### PR DESCRIPTION
### Motivation

- Provide cube owners a convenient way to add or remove multiple owned cubes across multiple open League Event ballots in one action.
- Allow admin UX improvements for selecting cube owners via searchable inputs instead of long scroll-only selects.
- Strengthen IP-based bans by also persisting and enforcing browser fingerprints so a banned browser remains blocked if its IP changes.

### Description

- Add a new `BlacklistedFingerprint` model to persist banned browser fingerprints and associate them with an originating IP and admin metadata. 【F:app/models.py†L535-L544】
- Introduce `_blacklist_client(ip, fingerprint, reason, created_by_id)` to create/update both IP and fingerprint blacklist entries and call it from the bad-login flow so admin-triggered or threshold-driven IP bans also persist the fingerprint. 【F:app/app.py†L953-L973】【F:app/app.py†L1187-L1193】
- Update request blocking to deny access when either the client IP or browser fingerprint is active in the blacklist. 【F:app/app.py†L3068-L3076】
- Add multi-add and multi-remove owner-controlled ballot endpoints accepting multiple `cube_ids` and `play_date_ids`, which remove associated votes when cubes are removed. 【F:app/app.py†L5279-L5312】【F:app/app.py†L5294-L5306】
- Replace single-select owner inputs with searchable, filterable inputs in the admin UI for both adding new cubes and editing existing cube owners, and add a multi-select UI in `league_cubes.html` for owners to add/remove multiple cubes across multiple events. 【F:app/templates/admin/league_detail.html†L39-L45】【F:app/templates/admin/league_detail.html†L56-L67】【F:app/templates/league_cubes.html†L11-L30】
- Surface banned fingerprints on the IP Blacklist admin page and synchronize fingerprint `is_active` when toggling IP entries. 【F:app/app.py†L5691-L5697】【F:app/templates/admin/ip_blacklist.html†L30-L47】
- Add regression tests for multi-add/multi-remove ballot behavior and for fingerprint banning/blocking. 【F:tests/test_leagues.py†L135-L170】【F:tests/test_users.py†L438-L450】

### Testing

- `python -m pytest -q` (full repo) initially ran and exposed unrelated async test failures in the vendored `walter-bot` tests that require a pytest-asyncio plugin, producing 42 failing async tests; these are external to the web app changes. 
- `python -m pytest tests -q` (project unit tests only) passed with `22 passed, 113 skipped` and one warning, confirming the new league and blacklist tests exercise the changes successfully. 
- `python -m compileall -q app tests` and `git diff --check` were run and completed without issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a8269374c60832092d61f58b55db0b3)

## Summary by Sourcery

Add browser fingerprint-based banning alongside existing IP blacklisting and introduce multi-cube ballot management for league cube owners and related admin UX improvements.

New Features:
- Persist and enforce banned browser fingerprints so clients remain blocked even if their IP address changes.
- Allow cube owners to add or remove multiple owned cubes across multiple league event ballots in a single action via new multi-select controls.
- Provide admin UI search/filter inputs for selecting cube owners and surface banned browser fingerprints on the IP blacklist admin page.

Enhancements:
- Centralize client blacklisting logic to update both IP and fingerprint records from admin actions and bad-login lockouts.
- Synchronize fingerprint blacklist status when toggling IP blacklist entries to keep bans aligned.
- Ensure removing cubes from ballots also removes associated votes to maintain ballot consistency.

Tests:
- Add regression tests covering multi-add/multi-remove league cube ballot behavior and vote cleanup.
- Add tests verifying that IP-based bans also create and enforce browser fingerprint blacklist entries across changing IPs.